### PR TITLE
feat(editor): Panel drag-to-move with mm coordinates and restore

### DIFF
--- a/src/figrecipe/_editor/_routes_style.py
+++ b/src/figrecipe/_editor/_routes_style.py
@@ -167,10 +167,14 @@ def register_style_routes(app, editor):
 
     @app.route("/restore", methods=["POST"])
     def restore():
-        """Restore to original style (clear manual overrides)."""
+        """Restore to original style (clear manual overrides and axes positions)."""
         from ._bbox import extract_bboxes
 
+        # Clear all manual overrides (including position overrides)
         editor.style_overrides.clear_manual_overrides()
+
+        # Restore original axes positions
+        editor.restore_axes_positions()
 
         if editor._initial_base64 and not editor.dark_mode:
             base64_img = editor._initial_base64

--- a/src/figrecipe/_editor/_templates/__init__.py
+++ b/src/figrecipe/_editor/_templates/__init__.py
@@ -10,12 +10,16 @@ now match the HTML input IDs directly.
 
 import base64
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
 from ._html import HTML_TEMPLATE
 from ._scripts import SCRIPTS
 from ._styles import STYLES
+
+# Server start time for debugging template reloads
+_SERVER_START_TIME = datetime.now().strftime("%H:%M:%S")
 
 # Load SciTeX icon as base64
 _SCITEX_ICON_PATH = (
@@ -138,6 +142,9 @@ def build_html_template(
     # Dark mode preference - set initial state
     html = html.replace("DARK_MODE_THEME_PLACEHOLDER", "dark" if dark_mode else "light")
     html = html.replace("DARK_MODE_CHECKED_PLACEHOLDER", "checked" if dark_mode else "")
+
+    # Server start time for debugging
+    html = html.replace("SERVER_START_TIME_PLACEHOLDER", _SERVER_START_TIME)
 
     return html
 

--- a/src/figrecipe/_editor/_templates/_html.py
+++ b/src/figrecipe/_editor/_templates/_html.py
@@ -25,6 +25,7 @@ HTML_TEMPLATE = """
                     <img src="data:image/png;base64,SCITEX_ICON_PLACEHOLDER" alt="SciTeX" class="scitex-icon">
                     <span class="figrecipe-title">FigRecipe Editor</span>
                 </a>
+                <span id="server-start-time" style="font-size: 10px; color: #888; margin-left: 8px;">Started: SERVER_START_TIME_PLACEHOLDER</span>
                 <div class="file-switcher">
                     <select id="file-selector" class="file-selector" title="Switch between recipe files">
                         <option value="">Loading files...</option>
@@ -233,20 +234,20 @@ HTML_TEMPLATE = """
                             </div>
                             <div class="position-grid">
                                 <div class="form-row">
-                                    <label>Left</label>
-                                    <input type="number" id="panel_left" step="0.01" min="0" max="1" placeholder="0.125">
+                                    <label>Left (mm)</label>
+                                    <input type="number" id="panel_left" step="1" min="0" placeholder="20">
                                 </div>
                                 <div class="form-row">
-                                    <label>Bottom</label>
-                                    <input type="number" id="panel_bottom" step="0.01" min="0" max="1" placeholder="0.11">
+                                    <label>Top (mm)</label>
+                                    <input type="number" id="panel_top" step="1" min="0" placeholder="15">
                                 </div>
                                 <div class="form-row">
-                                    <label>Width</label>
-                                    <input type="number" id="panel_width" step="0.01" min="0" max="1" placeholder="0.775">
+                                    <label>Width (mm)</label>
+                                    <input type="number" id="panel_width" step="1" min="0" placeholder="120">
                                 </div>
                                 <div class="form-row">
-                                    <label>Height</label>
-                                    <input type="number" id="panel_height" step="0.01" min="0" max="1" placeholder="0.77">
+                                    <label>Height (mm)</label>
+                                    <input type="number" id="panel_height" step="1" min="0" placeholder="90">
                                 </div>
                             </div>
                             <div class="form-row" style="margin-top: 8px;">

--- a/src/figrecipe/_editor/_templates/_scripts/_core.py
+++ b/src/figrecipe/_editor/_templates/_scripts/_core.py
@@ -191,9 +191,12 @@ function initializeEventListeners() {
     });
 
     // Form inputs - auto update on change
+    // Exclude panel position inputs - they have their own Apply button
+    const panelPositionInputIds = ['panel_left', 'panel_top', 'panel_width', 'panel_height', 'panel_selector'];
     const inputs = document.querySelectorAll('input, select');
     inputs.forEach(input => {
         if (input.id === 'dark-mode-toggle') return;
+        if (panelPositionInputIds.includes(input.id)) return;  // Skip panel position inputs
 
         // Update modified state and trigger preview update
         input.addEventListener('change', function() {


### PR DESCRIPTION
## Summary
- Panel drag-to-move works without shift key (direct click+drag)
- All panel positions use mm units with upper-left origin
- Server start timestamp visible in header for debugging
- Restore button now restores original panel coordinates

## Technical Details
- Fixed container ID from preview-container to zoom-container
- Added null checks for panelDragOverlay
- Store original axes positions on editor init
- Store position overrides in manual_overrides for tracking
- Updated tests for new mm-based API

## Test Plan
- [x] Panel drag-to-move tested via Playwright
- [x] Restore functionality verified manually
- [x] All pytest tests passing (7/7 panel position tests)
- [x] CI/CD passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)