### PR TITLE
feat(editor): Add hover feedback for draggable panels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,15 @@ pre-commit:
 gui:
 	$(PYTHON) examples/demo_editor.py
 
+gui-browser:
+	@echo "Starting editor and opening in Windows Chrome..."
+	@$(PYTHON) examples/demo_editor.py & \
+	sleep 3 && \
+	(cmd.exe /c start chrome http://127.0.0.1:5050 2>/dev/null || \
+	 "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe" http://127.0.0.1:5050 2>/dev/null || \
+	 wslview http://127.0.0.1:5050 2>/dev/null || \
+	 echo "Could not open browser. Please open http://127.0.0.1:5050 manually") && \
+	wait
+
 gui-periodic:
 	./scripts/gui_periodic.sh 60


### PR DESCRIPTION
## Summary
- Show blue border highlight when hovering over movable panel areas
- Change cursor to 'move' to indicate draggable panels  
- Use expanded bounds detection (title, axis labels, tick areas)
- Add `make gui-browser` target to open Windows Chrome from WSL

## Test plan
- [x] Hover over panel areas - blue border appears
- [x] Cursor changes to 'move' pointer
- [x] Feedback hides when mouse leaves panel area
- [x] Drag still works correctly after hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)