### PR TITLE
fix(editor): Fix theme switching dropdown

### DIFF
--- a/src/figrecipe/_editor/_routes_style.py
+++ b/src/figrecipe/_editor/_routes_style.py
@@ -96,7 +96,7 @@ def register_style_routes(app, editor):
             # Extract color_palette from nested colors.palette
             if "colors" in new_style and isinstance(new_style["colors"], dict):
                 colors_dict = new_style["colors"]
-                if "palette" in colors_dict:
+                if "palette" in colors_dict and colors_dict["palette"] is not None:
                     flat_style["color_palette"] = list(colors_dict["palette"])
 
             editor.style_overrides.base_style = flat_style

--- a/src/figrecipe/styles/_style_applier.py
+++ b/src/figrecipe/styles/_style_applier.py
@@ -85,7 +85,11 @@ def apply_style_mm(ax: Axes, style: Dict[str, Any]) -> float:
     import matplotlib as mpl
 
     # Apply theme colors (dark/light mode)
-    theme = style.get("theme", "light")
+    theme_section = style.get("theme", {})
+    if isinstance(theme_section, dict):
+        theme = theme_section.get("mode", "light")
+    else:
+        theme = str(theme_section) if theme_section else "light"
     theme_colors = style.get("theme_colors", None)
     apply_theme_colors(ax, theme, theme_colors)
 
@@ -171,7 +175,11 @@ def apply_style_mm(ax: Axes, style: Dict[str, Any]) -> float:
     mpl.rcParams["legend.title_fontsize"] = legend_fs
 
     # Set legend colors from theme
-    theme = style.get("theme", "light")
+    theme_section = style.get("theme", {})
+    if isinstance(theme_section, dict):
+        theme = theme_section.get("mode", "light")
+    else:
+        theme = str(theme_section) if theme_section else "light"
     theme_colors = style.get("theme_colors", None)
     if theme_colors:
         legend_bg = theme_colors.get("legend_bg", theme_colors.get("axes_bg", "white"))


### PR DESCRIPTION
## Summary
- Fix theme switching dropdown not working in the GUI editor
- Add null check for color palette in switch_theme route to handle themes like MATPLOTLIB that have `palette: null`
- Extract theme mode from nested theme section dict in apply_style_mm to fix unhashable CommentedMap type error

## Changes
- `src/figrecipe/_editor/_routes_style.py`: Added null check before converting palette to list
- `src/figrecipe/styles/_style_applier.py`: Fixed theme extraction from dict (2 locations)

## Test plan
- [x] Verified theme switching SCITEX → MATPLOTLIB works
- [x] Verified theme switching MATPLOTLIB → SCITEX works
- [x] Core tests (24 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)