### PR TITLE
feat(editor): Add hierarchical file tree viewer

### DIFF
--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -434,6 +434,7 @@ def edit(
     host: str = "127.0.0.1",
     open_browser: bool = True,
     hot_reload: bool = False,
+    working_dir=None,
 ):
     """Launch interactive GUI editor for figure styling.
 
@@ -452,6 +453,8 @@ def edit(
         Whether to open browser automatically (default: True).
     hot_reload : bool, optional
         Enable hot reload (default: False).
+    working_dir : str or Path, optional
+        Working directory for file browser (default: directory containing source).
 
     Returns
     -------
@@ -467,4 +470,5 @@ def edit(
         host=host,
         open_browser=open_browser,
         hot_reload=hot_reload,
+        working_dir=working_dir,
     )

--- a/src/figrecipe/_editor/_templates/_styles/_file_browser.py
+++ b/src/figrecipe/_editor/_templates/_styles/_file_browser.py
@@ -256,6 +256,16 @@ STYLES_FILE_BROWSER = """
 /* Folder items */
 .file-tree-folder > .file-tree-entry {
     font-weight: 500;
+    cursor: pointer;
+}
+
+.file-tree-folder > .file-tree-entry:hover {
+    background: var(--bg-tertiary);
+}
+
+/* Folder chevron indicator */
+.file-tree-folder > .file-tree-entry .file-tree-icon {
+    position: relative;
 }
 
 .file-tree-folder > .file-tree-entry .file-tree-icon::before {
@@ -263,26 +273,57 @@ STYLES_FILE_BROWSER = """
     display: inline-block;
     width: 0;
     height: 0;
-    border-left: 4px solid var(--text-secondary);
-    border-top: 3px solid transparent;
-    border-bottom: 3px solid transparent;
-    margin-right: 2px;
-    transition: transform 0.15s;
+    border-left: 5px solid var(--text-secondary);
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    position: absolute;
+    left: -10px;
+    top: 50%;
+    transform: translateY(-50%);
+    transition: transform 0.15s ease;
 }
 
 .file-tree-folder.expanded > .file-tree-entry .file-tree-icon::before {
-    transform: rotate(90deg);
+    transform: translateY(-50%) rotate(90deg);
 }
 
+/* Folder badge (item count) */
+.file-tree-badge.folder-badge {
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font-size: 9px;
+    min-width: 16px;
+    text-align: center;
+}
+
+/* File tree children container */
 .file-tree-children {
     list-style: none;
     margin: 0;
-    padding: 0 0 0 16px;
+    padding: 0;
     display: none;
+    overflow: hidden;
+    transition: max-height 0.2s ease-out;
 }
 
 .file-tree-folder.expanded > .file-tree-children {
     display: block;
+}
+
+/* Tree indentation guide lines */
+.file-tree-folder > .file-tree-children {
+    position: relative;
+}
+
+.file-tree-folder > .file-tree-children::before {
+    content: "";
+    position: absolute;
+    left: 18px;
+    top: 0;
+    bottom: 8px;
+    width: 1px;
+    background: var(--border-color);
+    opacity: 0.5;
 }
 
 /* Empty state */

--- a/tests/test_editor_file_browser.py
+++ b/tests/test_editor_file_browser.py
@@ -229,9 +229,108 @@ class TestFileBrowserIntegration:
 
         assert file_browser_pos > 0, "File browser panel not found"
         assert preview_panel_pos > 0, "Preview panel not found"
-        assert (
-            file_browser_pos < preview_panel_pos
-        ), "File browser should be before preview"
+        assert file_browser_pos < preview_panel_pos, (
+            "File browser should be before preview"
+        )
+
+
+class TestFileBrowserTreeStructure:
+    """Test file browser tree structure functionality."""
+
+    def test_tree_rendering_function_exists(self):
+        """Test that renderTreeItem function is defined."""
+        from figrecipe._editor._templates._scripts._files import SCRIPTS_FILES
+
+        assert "function renderTreeItem(item, level" in SCRIPTS_FILES
+
+    def test_tree_folder_support(self):
+        """Test that tree supports folder structure."""
+        from figrecipe._editor._templates._scripts._files import SCRIPTS_FILES
+
+        assert "file-tree-folder" in SCRIPTS_FILES
+        assert "file-tree-children" in SCRIPTS_FILES
+        assert "type === 'directory'" in SCRIPTS_FILES
+
+    def test_tree_expand_collapse(self):
+        """Test that tree has expand/collapse functionality."""
+        from figrecipe._editor._templates._scripts._files import SCRIPTS_FILES
+
+        assert "expandedFolders" in SCRIPTS_FILES
+        assert "toggleFolder" in SCRIPTS_FILES
+        assert "expanded" in SCRIPTS_FILES
+
+    def test_tree_state_persistence(self):
+        """Test that tree state is persisted to localStorage."""
+        from figrecipe._editor._templates._scripts._files import SCRIPTS_FILES
+
+        assert "localStorage" in SCRIPTS_FILES
+        assert "figrecipe-expanded-folders" in SCRIPTS_FILES
+        assert "loadExpandedState" in SCRIPTS_FILES
+        assert "saveExpandedState" in SCRIPTS_FILES
+
+    def test_tree_css_indentation(self):
+        """Test that tree CSS has proper indentation styles."""
+        from figrecipe._editor._templates._styles import STYLES_FILE_BROWSER
+
+        assert ".file-tree-children" in STYLES_FILE_BROWSER
+        assert ".file-tree-folder.expanded" in STYLES_FILE_BROWSER
+
+
+class TestFileBrowserTreeAPI:
+    """Test file browser tree API."""
+
+    def test_api_returns_tree_structure(self):
+        """Test that /api/files returns tree structure."""
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import MagicMock
+
+        from flask import Flask
+
+        from figrecipe._editor._routes_core import register_core_routes
+
+        with TemporaryDirectory() as tmpdir:
+            # Create test directory structure
+            tmpdir_path = Path(tmpdir)
+            subdir = tmpdir_path / "subdir"
+            subdir.mkdir()
+
+            # Create test files
+            (tmpdir_path / "test1.yaml").write_text("# test")
+            (subdir / "test2.yaml").write_text("# test")
+
+            # Create Flask app and mock editor
+            app = Flask(__name__)
+            mock_editor = MagicMock()
+            mock_editor.working_dir = tmpdir_path
+            mock_editor.recipe_path = None
+            mock_editor._color_map = {}
+            mock_editor.dark_mode = False
+            mock_editor._hitmap_generated = False
+            mock_editor.fig = MagicMock()
+
+            register_core_routes(app, mock_editor)
+
+            with app.test_client() as client:
+                response = client.get("/api/files")
+                data = response.get_json()
+
+                # Check response has tree structure
+                assert "tree" in data
+                assert "files" in data  # Backwards compatibility
+
+                # Check tree contains items
+                tree = data["tree"]
+                assert isinstance(tree, list)
+
+                # Find the directory in the tree
+                folder_items = [
+                    item for item in tree if item.get("type") == "directory"
+                ]
+                file_items = [item for item in tree if item.get("type") == "file"]
+
+                # Should have at least one folder and one file at root
+                assert len(folder_items) >= 1 or len(file_items) >= 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add hierarchical file tree viewer to the editor's file browser panel
- Files are now displayed in a tree structure with expandable folders
- Expand/collapse state persists across sessions via localStorage

## Changes
- **Backend**: Updated `/api/files` to return nested tree structure with directories
- **Frontend**: Added `renderTreeItem()` for recursive tree rendering
- **CSS**: Added folder chevron indicators and indentation guide lines
- **API**: Added `working_dir` parameter to `edit()` function
- **Tests**: Added 6 new tests for tree structure functionality

## Test plan
- [x] All 21 file browser tests pass
- [x] Full test suite passes (762 passed)
- [x] Verified with Playwright:
  - Tree renders folders with item counts
  - Folders expand/collapse correctly
  - Nested files display inside folders
  - File switching works for nested paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)