### PR TITLE
refactor: Delegate Makefile targets to maintenance scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,86 +1,69 @@
-.PHONY: help install install-dev test notebook pdf clean clean-outputs lint lint-fix format pre-commit gui gui-periodic
-
-PYTHON := python3
-PIP := pip3
-PORT ?= 5050
+.PHONY: help install install-dev install-arial test notebook pdf clean clean-outputs lint lint-fix format pre-commit demo-gui demo-gui-browser demo-gui-periodic
 
 help:
 	@echo "figrecipe - Record and reproduce matplotlib figures"
 	@echo ""
 	@echo "Usage:"
-	@echo "  make install       Install package"
-	@echo "  make install-dev   Install package with dev dependencies"
-	@echo "  make test          Run tests"
-	@echo "  make notebook      Execute demo notebook"
-	@echo "  make pdf           Generate PDF from notebook"
-	@echo "  make clean         Clean build artifacts and outputs"
-	@echo "  make clean-outputs Clean only outputs directory"
-	@echo "  make lint          Run linter"
-	@echo "  make lint-fix      Run linter with auto-fix"
-	@echo "  make format        Format code"
-	@echo "  make pre-commit    Install pre-commit hooks"
-	@echo "  make gui           Launch GUI editor demo (PORT=5050 by default)"
-	@echo "  make gui PORT=5051 Launch GUI editor on custom port"
-	@echo "  make gui-periodic  Launch GUI editor with 60s auto-restart (supports PORT=)"
+	@echo "  make install            Install package"
+	@echo "  make install-dev        Install package with dev dependencies"
+	@echo "  make install-arial      Install Arial font for matplotlib"
+	@echo "  make test               Run tests"
+	@echo "  make notebook           Execute demo notebook"
+	@echo "  make pdf                Generate PDF from notebook"
+	@echo "  make clean              Clean build artifacts and outputs"
+	@echo "  make clean-outputs      Clean only outputs directory"
+	@echo "  make lint               Run linter"
+	@echo "  make lint-fix           Run linter with auto-fix"
+	@echo "  make format             Format code"
+	@echo "  make pre-commit         Install pre-commit hooks"
+	@echo "  make demo-gui           Launch GUI editor demo (PORT=5050 by default)"
+	@echo "  make demo-gui PORT=5051 Launch GUI editor on custom port"
+	@echo "  make demo-gui-browser   Launch GUI editor and open in browser"
+	@echo "  make demo-gui-periodic  Launch GUI editor with 60s auto-restart (supports PORT=)"
+
+PORT ?= 5050
 
 install:
-	$(PIP) install -e .
+	@./scripts/maintenance/install.sh
 
 install-dev:
-	$(PIP) install -e ".[dev]"
+	@./scripts/maintenance/install-dev.sh
+
+install-arial:
+	@./scripts/maintenance/install_arial.sh
 
 test:
-	$(PYTHON) -m pytest tests/ -v
+	@./scripts/maintenance/test.sh
 
 notebook:
-	@echo "Executing demo notebook..."
-	$(PYTHON) -m jupyter nbconvert --to notebook --execute --inplace examples/figrecipe_demo.ipynb --ExecutePreprocessor.timeout=120
+	@./scripts/maintenance/notebook.sh
 
-pdf: notebook
-	@echo "Generating PDF from notebook..."
-	jupyter nbconvert --to pdf examples/figrecipe_demo.ipynb --output-dir=examples
-	@rm -rf plotspec_demo_files notebook.* 2>/dev/null || true
-	@echo "PDF generated: examples/figrecipe_demo.pdf"
+pdf:
+	@./scripts/maintenance/pdf.sh
 
-clean: clean-outputs
-	rm -rf build/
-	rm -rf dist/
-	rm -rf *.egg-info/
-	rm -rf src/*.egg-info/
-	rm -rf .pytest_cache/
-	rm -rf .coverage
-	rm -rf htmlcov/
-	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-	find . -type f -name "*.pyc" -delete 2>/dev/null || true
+clean:
+	@./scripts/maintenance/clean.sh
 
 clean-outputs:
-	rm -rf outputs/
+	@./scripts/maintenance/clean-outputs.sh
 
 lint:
-	$(PYTHON) -m ruff check src/ tests/
+	@./scripts/maintenance/lint.sh
 
 lint-fix:
-	$(PYTHON) -m ruff check --fix src/ tests/
+	@./scripts/maintenance/lint-fix.sh
 
 format:
-	$(PYTHON) -m ruff format src/ tests/
+	@./scripts/maintenance/format.sh
 
 pre-commit:
-	pip install pre-commit
-	pre-commit install
+	@./scripts/maintenance/pre-commit.sh
 
-gui:
-	$(PYTHON) examples/demo_editor.py $(PORT)
+demo-gui:
+	@./scripts/maintenance/demo-gui.sh $(PORT)
 
-gui-browser:
-	@echo "Starting editor and opening in Windows Chrome on port $(PORT)..."
-	@$(PYTHON) examples/demo_editor.py $(PORT) & \
-	sleep 3 && \
-	(cmd.exe /c start chrome http://127.0.0.1:$(PORT) 2>/dev/null || \
-	 "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe" http://127.0.0.1:$(PORT) 2>/dev/null || \
-	 wslview http://127.0.0.1:$(PORT) 2>/dev/null || \
-	 echo "Could not open browser. Please open http://127.0.0.1:$(PORT) manually") && \
-	wait
+demo-gui-browser:
+	@./scripts/maintenance/demo-gui-browser.sh $(PORT)
 
-gui-periodic:
-	./scripts/gui_periodic.sh 60 $(PORT)
+demo-gui-periodic:
+	@./scripts/maintenance/demo-gui-periodic.sh 60 $(PORT)

--- a/scripts/maintenance/clean-outputs.sh
+++ b/scripts/maintenance/clean-outputs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/clean-outputs.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Cleaning outputs directory"
+cd "$GIT_ROOT"
+rm -rf outputs/
+echo_success "Outputs directory cleaned"
+
+# EOF

--- a/scripts/maintenance/clean.sh
+++ b/scripts/maintenance/clean.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/clean.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Cleaning build artifacts and outputs"
+cd "$GIT_ROOT"
+
+# Clean outputs first
+"$THIS_DIR/clean-outputs.sh"
+
+# Clean build artifacts
+echo_info "Removing build directories..."
+rm -rf build/
+rm -rf dist/
+rm -rf *.egg-info/
+rm -rf src/*.egg-info/
+rm -rf .pytest_cache/
+rm -rf .coverage
+rm -rf htmlcov/
+
+echo_info "Removing Python cache files..."
+find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+find . -type f -name "*.pyc" -delete 2>/dev/null || true
+
+echo_success "Build artifacts cleaned"
+
+# EOF

--- a/scripts/maintenance/demo-gui-browser.sh
+++ b/scripts/maintenance/demo-gui-browser.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/demo-gui-browser.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+PORT=${1:-5050}
+
+echo_header "Starting editor and opening in browser on port $PORT"
+cd "$GIT_ROOT"
+python3 examples/demo_editor.py "$PORT" &
+sleep 3
+
+# Try various methods to open browser
+cmd.exe /c start chrome "http://127.0.0.1:${PORT}" 2>/dev/null || \
+"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe" "http://127.0.0.1:${PORT}" 2>/dev/null || \
+wslview "http://127.0.0.1:${PORT}" 2>/dev/null || \
+echo_warning "Could not open browser. Please open http://127.0.0.1:${PORT} manually"
+
+wait
+
+# EOF

--- a/scripts/maintenance/demo-gui-periodic.sh
+++ b/scripts/maintenance/demo-gui-periodic.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/demo-gui-periodic.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Launching GUI editor with periodic restart"
+cd "$GIT_ROOT"
+./scripts/gui_periodic.sh "${1:-60}" "${2:-5050}"
+
+# EOF

--- a/scripts/maintenance/demo-gui.sh
+++ b/scripts/maintenance/demo-gui.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/demo-gui.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+PORT=${1:-5050}
+
+echo_header "Launching GUI editor on port $PORT"
+cd "$GIT_ROOT"
+python3 examples/demo_editor.py "$PORT" 2>&1 | tee -a "$LOG_PATH"
+
+# EOF

--- a/scripts/maintenance/format.sh
+++ b/scripts/maintenance/format.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/format.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Formatting code"
+cd "$GIT_ROOT"
+python3 -m ruff format src/ tests/ 2>&1 | tee -a "$LOG_PATH"
+echo_success "Code formatted"
+
+# EOF

--- a/scripts/maintenance/install-dev.sh
+++ b/scripts/maintenance/install-dev.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/install-dev.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Installing package with dev dependencies"
+cd "$GIT_ROOT"
+pip3 install -e ".[dev]" | tee -a "$LOG_PATH"
+echo_success "Package installed with dev dependencies"
+
+# EOF

--- a/scripts/maintenance/install.sh
+++ b/scripts/maintenance/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/install.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Installing package"
+cd "$GIT_ROOT"
+pip3 install -e . | tee -a "$LOG_PATH"
+echo_success "Package installed"
+
+# EOF

--- a/scripts/maintenance/install_arial.sh
+++ b/scripts/maintenance/install_arial.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/install_arial.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Installing Arial font"
+
+# Detect package manager and install Microsoft core fonts
+if command -v apt-get &>/dev/null; then
+    echo_info "Detected Debian/Ubuntu system"
+    echo_info "Installing ttf-mscorefonts-installer..."
+    sudo apt-get update 2>&1 | tee -a "$LOG_PATH"
+    echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+    sudo apt-get install -y ttf-mscorefonts-installer 2>&1 | tee -a "$LOG_PATH"
+elif command -v dnf &>/dev/null; then
+    echo_info "Detected Fedora/RHEL system"
+    sudo dnf install -y curl cabextract xorg-x11-font-utils fontconfig 2>&1 | tee -a "$LOG_PATH"
+    sudo rpm -i https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm 2>&1 | tee -a "$LOG_PATH" || true
+elif command -v pacman &>/dev/null; then
+    echo_info "Detected Arch Linux system"
+    echo_info "Installing ttf-ms-fonts from AUR..."
+    if command -v yay &>/dev/null; then
+        yay -S --noconfirm ttf-ms-fonts 2>&1 | tee -a "$LOG_PATH"
+    elif command -v paru &>/dev/null; then
+        paru -S --noconfirm ttf-ms-fonts 2>&1 | tee -a "$LOG_PATH"
+    else
+        echo_error "Please install ttf-ms-fonts from AUR manually"
+        exit 1
+    fi
+else
+    echo_error "Unsupported package manager. Please install Microsoft core fonts manually."
+    exit 1
+fi
+
+# Rebuild font cache
+echo_info "Rebuilding font cache..."
+fc-cache -fv 2>&1 | tee -a "$LOG_PATH"
+
+# Clear matplotlib font cache
+echo_info "Clearing matplotlib font cache..."
+python3 -c "
+import matplotlib
+import shutil
+import os
+cache_dir = matplotlib.get_cachedir()
+font_cache = os.path.join(cache_dir, 'fontlist-v*.json')
+import glob
+for f in glob.glob(font_cache):
+    os.remove(f)
+    print(f'Removed: {f}')
+print('Matplotlib font cache cleared')
+" 2>/dev/null || echo_warning "Could not clear matplotlib cache (matplotlib may not be installed)"
+
+# Verify installation
+echo_info "Verifying Arial installation..."
+if fc-list | grep -i "arial" &>/dev/null; then
+    echo_success "Arial font installed successfully!"
+    fc-list | grep -i "arial" | head -3
+else
+    echo_error "Arial font not found in font cache"
+    exit 1
+fi
+
+echo_success "Done! Arial font is now available for matplotlib."
+
+# EOF

--- a/scripts/maintenance/lint-fix.sh
+++ b/scripts/maintenance/lint-fix.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/lint-fix.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Running linter with auto-fix"
+cd "$GIT_ROOT"
+python3 -m ruff check --fix src/ tests/ 2>&1 | tee -a "$LOG_PATH"
+echo_success "Linting with auto-fix completed"
+
+# EOF

--- a/scripts/maintenance/lint.sh
+++ b/scripts/maintenance/lint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/lint.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Running linter"
+cd "$GIT_ROOT"
+python3 -m ruff check src/ tests/ 2>&1 | tee -a "$LOG_PATH"
+if [ ${PIPESTATUS[0]} -eq 0 ]; then
+    echo_success "Linting passed"
+else
+    echo_error "Linting issues found"
+    exit 1
+fi
+
+# EOF

--- a/scripts/maintenance/notebook.sh
+++ b/scripts/maintenance/notebook.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/notebook.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Executing demo notebook"
+cd "$GIT_ROOT"
+python3 -m jupyter nbconvert --to notebook --execute --inplace examples/figrecipe_demo.ipynb --ExecutePreprocessor.timeout=120 2>&1 | tee -a "$LOG_PATH"
+if [ ${PIPESTATUS[0]} -eq 0 ]; then
+    echo_success "Notebook executed successfully"
+else
+    echo_error "Notebook execution failed"
+    exit 1
+fi
+
+# EOF

--- a/scripts/maintenance/pdf.sh
+++ b/scripts/maintenance/pdf.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/pdf.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Generating PDF from notebook"
+cd "$GIT_ROOT"
+
+# Execute notebook first
+"$THIS_DIR/notebook.sh"
+
+echo_info "Converting notebook to PDF..."
+jupyter nbconvert --to pdf examples/figrecipe_demo.ipynb --output-dir=examples 2>&1 | tee -a "$LOG_PATH"
+rm -rf plotspec_demo_files notebook.* 2>/dev/null || true
+echo_success "PDF generated: examples/figrecipe_demo.pdf"
+
+# EOF

--- a/scripts/maintenance/pre-commit.sh
+++ b/scripts/maintenance/pre-commit.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/pre-commit.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Installing pre-commit hooks"
+cd "$GIT_ROOT"
+pip install pre-commit 2>&1 | tee -a "$LOG_PATH"
+pre-commit install 2>&1 | tee -a "$LOG_PATH"
+echo_success "Pre-commit hooks installed"
+
+# EOF

--- a/scripts/maintenance/test.sh
+++ b/scripts/maintenance/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-01-11 11:30:00 (ywatanabe)"
+# File: ./scripts/maintenance/test.sh
+
+ORIG_DIR="$(pwd)"
+THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename $0).log"
+echo > "$LOG_PATH"
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+echo_header() { echo_info "=== $1 ==="; }
+# ---------------------------------------
+
+echo_header "Running tests"
+cd "$GIT_ROOT"
+python3 -m pytest tests/ -v 2>&1 | tee -a "$LOG_PATH"
+if [ ${PIPESTATUS[0]} -eq 0 ]; then
+    echo_success "All tests passed"
+else
+    echo_error "Some tests failed"
+    exit 1
+fi
+
+# EOF


### PR DESCRIPTION
## Summary
- Create `scripts/maintenance/` directory with 15 shell scripts following a consistent template
- Makefile now acts as a thin wrapper, delegating all logic to maintenance scripts
- Add `install_arial.sh` for Arial font installation on Linux (Debian/Ubuntu, Fedora/RHEL, Arch)
- Rename `gui` targets to `demo-gui` for clarity

## Changes
- 15 new scripts in `scripts/maintenance/`:
  - `install.sh`, `install-dev.sh`, `install_arial.sh`
  - `test.sh`, `lint.sh`, `lint-fix.sh`, `format.sh`
  - `clean.sh`, `clean-outputs.sh`
  - `notebook.sh`, `pdf.sh`
  - `pre-commit.sh`
  - `demo-gui.sh`, `demo-gui-browser.sh`, `demo-gui-periodic.sh`
- All scripts use template with colored logging (`echo_info`, `echo_success`, `echo_warning`, `echo_error`)
- Makefile reduced from 87 to 69 lines

## Test plan
- [ ] Run `make help` to verify target listing
- [ ] Run `make test` to verify test script works
- [ ] Run `make lint` to verify lint script works

🤖 Generated with [Claude Code](https://claude.com/claude-code)