### PR TITLE
fix: Issues #42 and #43 - savefig consistency and annotation fontsize

### DIFF
--- a/src/figrecipe/_wrappers/_axes.py
+++ b/src/figrecipe/_wrappers/_axes.py
@@ -572,6 +572,154 @@ class RecordingAxes:
 
         return artists
 
+    def text(
+        self,
+        x,
+        y,
+        s,
+        *,
+        id: Optional[str] = None,
+        track: bool = True,
+        fontsize=None,
+        **kwargs,
+    ):
+        """Add text to axes with style-aware default fontsize.
+
+        When using a figrecipe style (e.g., SCITEX), the `annotation_pt` font size
+        from the style is used as the default if `fontsize` is not specified.
+
+        Parameters
+        ----------
+        x, y : float
+            Position for text.
+        s : str
+            Text string.
+        fontsize : float, optional
+            Font size in points. If None, uses style's `fonts.annotation_pt`.
+        **kwargs
+            Additional kwargs passed to matplotlib's ax.text().
+
+        Returns
+        -------
+        Text
+            Matplotlib Text artist.
+
+        Examples
+        --------
+        >>> import figrecipe as fr
+        >>> fr.load_style('SCITEX')  # annotation_pt: 6
+        >>> fig, ax = fr.subplots()
+        >>> ax.text(0.05, 0.95, 'r = 0.47')  # Uses 6pt from style
+        >>> ax.text(0.05, 0.85, 'p < 0.01', fontsize=8)  # Overrides to 8pt
+        """
+        from ..styles import get_style
+
+        # Apply annotation_pt from style if fontsize not specified
+        if fontsize is None:
+            style = get_style()
+            if style:
+                fontsize = style.get("fonts", {}).get("annotation_pt", None)
+
+        # Build kwargs with fontsize
+        text_kwargs = kwargs.copy()
+        if fontsize is not None:
+            text_kwargs["fontsize"] = fontsize
+
+        # Call matplotlib's text method
+        result = self._ax.text(x, y, s, **text_kwargs)
+
+        # Record the call if tracking is enabled
+        if self._track and track:
+            record_kwargs = text_kwargs.copy()
+            from ._axes_helpers import record_call_with_color_capture
+
+            record_call_with_color_capture(
+                self._recorder,
+                self._position,
+                "text",
+                (x, y, s),
+                record_kwargs,
+                result,
+                id,
+                self._result_refs,
+                self.RESULT_REFERENCING_METHODS,
+                self.RESULT_REFERENCEABLE_METHODS,
+            )
+
+        return result
+
+    def annotate(
+        self,
+        text,
+        xy,
+        *,
+        xytext=None,
+        id: Optional[str] = None,
+        track: bool = True,
+        fontsize=None,
+        **kwargs,
+    ):
+        """Add annotation to axes with style-aware default fontsize.
+
+        When using a figrecipe style (e.g., SCITEX), the `annotation_pt` font size
+        from the style is used as the default if `fontsize` is not specified.
+
+        Parameters
+        ----------
+        text : str
+            Annotation text.
+        xy : tuple
+            Point to annotate.
+        xytext : tuple, optional
+            Position of the text.
+        fontsize : float, optional
+            Font size in points. If None, uses style's `fonts.annotation_pt`.
+        **kwargs
+            Additional kwargs passed to matplotlib's ax.annotate().
+
+        Returns
+        -------
+        Annotation
+            Matplotlib Annotation artist.
+        """
+        from ..styles import get_style
+
+        # Apply annotation_pt from style if fontsize not specified
+        if fontsize is None:
+            style = get_style()
+            if style:
+                fontsize = style.get("fonts", {}).get("annotation_pt", None)
+
+        # Build kwargs with fontsize
+        annotate_kwargs = kwargs.copy()
+        if fontsize is not None:
+            annotate_kwargs["fontsize"] = fontsize
+        if xytext is not None:
+            annotate_kwargs["xytext"] = xytext
+
+        # Call matplotlib's annotate method
+        result = self._ax.annotate(text, xy, **annotate_kwargs)
+
+        # Record the call if tracking is enabled
+        if self._track and track:
+            record_kwargs = annotate_kwargs.copy()
+            from ._axes_helpers import record_call_with_color_capture
+
+            record_call_with_color_capture(
+                self._recorder,
+                self._position,
+                "annotate",
+                (text, xy),
+                record_kwargs,
+                result,
+                id,
+                self._result_refs,
+                self.RESULT_REFERENCING_METHODS,
+                self.RESULT_REFERENCEABLE_METHODS,
+            )
+
+        return result
+
 
 class _NoRecordContext:
     """Context manager to temporarily disable recording."""

--- a/src/figrecipe/_wrappers/_figure.py
+++ b/src/figrecipe/_wrappers/_figure.py
@@ -338,9 +338,13 @@ class RecordingFigure:
         save_recipe: bool = True,
         recipe_format: Literal["csv", "npz", "inline"] = "csv",
         verbose: bool = True,
+        validate: bool = False,
         **kwargs,
     ):
         """Save the figure image and optionally the recipe.
+
+        This method delegates to figrecipe's save() function to ensure consistent
+        behavior with auto-cropping, tick finalization, and recipe generation.
 
         Parameters
         ----------
@@ -353,14 +357,26 @@ class RecordingFigure:
             Format for data in recipe: 'csv' (default), 'npz', or 'inline'.
         verbose : bool
             If True (default), print save status.
+        validate : bool
+            If True, validate reproducibility. Default False for backwards
+            compatibility (fr.save() defaults to True).
         **kwargs
-            Passed to matplotlib's savefig().
+            Passed to matplotlib's savefig(). Common options:
+            - dpi: Output resolution (default: from style or 300)
+            - transparent: Whether background is transparent
+            - bbox_inches: Bounding box ('tight' disables mm_layout precision)
 
         Returns
         -------
         Path or tuple
             If save_recipe=False: image path.
             If save_recipe=True: (image_path, recipe_path) tuple.
+
+        Notes
+        -----
+        This method behaves the same as fr.save(fig, path) for consistency.
+        The auto-cropping, tick finalization, and mm_layout precision are
+        applied automatically when using a figrecipe style.
 
         Examples
         --------
@@ -369,33 +385,81 @@ class RecordingFigure:
         >>> fig.savefig('figure.png')  # Saves both figure.png and figure.yaml
         >>> fig.savefig('figure.png', save_recipe=False)  # Image only
         """
-        # Finalize ticks and special plots before saving
         from ..styles._style_applier import finalize_special_plots, finalize_ticks
         from ..styles._style_loader import get_current_style_dict
 
+        # Finalize ticks and special plots before any save
         style_dict = get_current_style_dict()
         for ax in self._fig.get_axes():
             finalize_ticks(ax)
             finalize_special_plots(ax, style_dict)
 
-        # Handle file-like objects (BytesIO, etc.) - just pass through
+        # Handle file-like objects (BytesIO, etc.) - direct matplotlib save
         if hasattr(fname, "write"):
             self._fig.savefig(fname, **kwargs)
             return fname
 
         fname = Path(fname)
-        self._fig.savefig(fname, **kwargs)
 
-        if save_recipe:
-            recipe_path = fname.with_suffix(".yaml")
-            self.save_recipe(recipe_path, include_data=True, data_format=recipe_format)
+        # If save_recipe=False, do a simpler save without recipe generation
+        # but still with auto-crop for consistency
+        if not save_recipe:
+            from .._api._save import get_save_dpi, get_save_transparency
+
+            dpi = kwargs.pop("dpi", None) or get_save_dpi()
+            transparent = get_save_transparency()
+
+            # Save the image
+            self._fig.savefig(fname, dpi=dpi, transparent=transparent, **kwargs)
+
+            # Apply auto-crop if mm_layout is set
+            croppable_formats = {".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp"}
+            is_croppable = fname.suffix.lower() in croppable_formats
+
+            if (
+                is_croppable
+                and hasattr(self, "_mm_layout")
+                and self._mm_layout is not None
+            ):
+                mm_layout = self._mm_layout
+                if "crop_margin_left_mm" in mm_layout:
+                    from .._utils._crop import crop
+
+                    crop(
+                        fname,
+                        margin_left_mm=mm_layout.get("crop_margin_left_mm", 1),
+                        margin_right_mm=mm_layout.get("crop_margin_right_mm", 1),
+                        margin_top_mm=mm_layout.get("crop_margin_top_mm", 1),
+                        margin_bottom_mm=mm_layout.get("crop_margin_bottom_mm", 1),
+                        output_path=fname,
+                    )
+
             if verbose:
-                print(f"Saved: {fname} + {recipe_path}")
-            return fname, recipe_path
+                print(f"Saved: {fname}")
+            return fname
 
-        if verbose:
-            print(f"Saved: {fname}")
-        return fname
+        # Use the core save function for full save with recipe
+        from .._api._save import save_figure
+
+        # Extract matplotlib-specific kwargs that save_figure handles
+        dpi = kwargs.pop("dpi", None)
+
+        # Call save_figure which handles:
+        # - Auto-cropping via mm_layout
+        # - Tick finalization
+        # - Axes bbox capture
+        # - Recipe saving with proper validation
+        image_path, yaml_path, result = save_figure(
+            self,
+            fname,
+            include_data=True,
+            data_format=recipe_format,
+            validate=validate,
+            verbose=verbose,
+            dpi=dpi,
+        )
+
+        return image_path, yaml_path
 
     def save_recipe(
         self,

--- a/tests/test_annotation_fontsize.py
+++ b/tests/test_annotation_fontsize.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for annotation fontsize styling (Issue #43).
+
+Tests that ax.text() and ax.annotate() use the style's annotation_pt
+as the default fontsize when no fontsize is specified.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def fig_ax_with_scitex():
+    """Create figure and axes with SCITEX style loaded."""
+    import figrecipe as fr
+
+    fr.load_style("SCITEX")
+    fig, ax = fr.subplots()
+    yield fig, ax
+    import matplotlib.pyplot as plt
+
+    plt.close(fig.fig)
+
+
+class TestTextAnnotationFontsize:
+    """Tests for ax.text() annotation_pt default."""
+
+    def test_text_uses_scitex_annotation_pt(self, fig_ax_with_scitex):
+        """ax.text() should use annotation_pt (6pt) from SCITEX style."""
+        fig, ax = fig_ax_with_scitex
+        text_obj = ax.text(0.5, 0.5, "Test annotation")
+
+        # SCITEX defines annotation_pt: 6
+        assert text_obj.get_fontsize() == 6
+
+    def test_text_override_fontsize(self, fig_ax_with_scitex):
+        """Explicit fontsize should override style default."""
+        fig, ax = fig_ax_with_scitex
+        text_obj = ax.text(0.5, 0.5, "Test annotation", fontsize=12)
+
+        assert text_obj.get_fontsize() == 12
+
+
+class TestAnnotateAnnotationFontsize:
+    """Tests for ax.annotate() annotation_pt default."""
+
+    def test_annotate_uses_scitex_annotation_pt(self, fig_ax_with_scitex):
+        """ax.annotate() should use annotation_pt (6pt) from SCITEX style."""
+        fig, ax = fig_ax_with_scitex
+        annot_obj = ax.annotate("Test", xy=(0.5, 0.5))
+
+        # SCITEX defines annotation_pt: 6
+        assert annot_obj.get_fontsize() == 6
+
+    def test_annotate_override_fontsize(self, fig_ax_with_scitex):
+        """Explicit fontsize should override style default."""
+        fig, ax = fig_ax_with_scitex
+        annot_obj = ax.annotate("Test", xy=(0.5, 0.5), fontsize=10)
+
+        assert annot_obj.get_fontsize() == 10
+
+    def test_annotate_with_xytext(self, fig_ax_with_scitex):
+        """ax.annotate() with xytext should still use annotation_pt."""
+        fig, ax = fig_ax_with_scitex
+        annot_obj = ax.annotate(
+            "Test", xy=(0.5, 0.5), xytext=(0.7, 0.7), arrowprops=dict(arrowstyle="->")
+        )
+
+        assert annot_obj.get_fontsize() == 6
+
+
+class TestTextRecording:
+    """Tests that text calls are properly recorded for reproduction."""
+
+    def test_text_is_recorded(self, fig_ax_with_scitex, tmp_path):
+        """ax.text() calls should be recorded in the recipe."""
+        import figrecipe as fr
+
+        fig, ax = fig_ax_with_scitex
+        ax.plot([1, 2, 3], [1, 2, 3])
+        ax.text(0.05, 0.95, "r = 0.99", transform=ax.transAxes)
+
+        # Save and check the recipe contains the text call
+        output_path = tmp_path / "test.png"
+        fr.save(fig, output_path, validate=False, verbose=False)
+
+        # Check that the decoration (text) is recorded
+        ax_record = fig.record.get_or_create_axes(0, 0)
+        assert len(ax_record.decorations) > 0
+
+        # Find the text call
+        text_calls = [d for d in ax_record.decorations if d.function == "text"]
+        assert len(text_calls) == 1
+        assert "fontsize" in text_calls[0].kwargs
+        assert text_calls[0].kwargs["fontsize"] == 6
+
+    def test_annotate_is_recorded(self, fig_ax_with_scitex, tmp_path):
+        """ax.annotate() calls should be recorded in the recipe."""
+        import figrecipe as fr
+
+        fig, ax = fig_ax_with_scitex
+        ax.plot([1, 2, 3], [1, 2, 3])
+        ax.annotate("Peak", xy=(2, 2))
+
+        # Save and check the recipe contains the annotate call
+        output_path = tmp_path / "test.png"
+        fr.save(fig, output_path, validate=False, verbose=False)
+
+        # Check that the decoration (annotate) is recorded
+        ax_record = fig.record.get_or_create_axes(0, 0)
+        annotate_calls = [d for d in ax_record.decorations if d.function == "annotate"]
+        assert len(annotate_calls) == 1
+        assert "fontsize" in annotate_calls[0].kwargs
+        assert annotate_calls[0].kwargs["fontsize"] == 6

--- a/tests/test_savefig_consistency.py
+++ b/tests/test_savefig_consistency.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for savefig() consistency with fr.save() (Issue #42).
+
+Tests that fig.savefig() and fr.save() produce consistent outputs,
+both going through the same save pipeline with auto-crop and finalization.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fig_ax():
+    """Create a simple figure with SCITEX style."""
+    import figrecipe as fr
+
+    fr.load_style("SCITEX")
+    fig, ax = fr.subplots()
+    ax.plot([1, 2, 3], [1, 2, 3], id="test")
+    ax.set_xlabel("X axis")
+    ax.set_ylabel("Y axis")
+    yield fig, ax
+    import matplotlib.pyplot as plt
+
+    plt.close(fig.fig)
+
+
+class TestSavefigConsistency:
+    """Tests that savefig() delegates to save_figure()."""
+
+    def test_savefig_creates_yaml(self, fig_ax, tmp_path):
+        """savefig() should create a YAML recipe by default."""
+        fig, ax = fig_ax
+        output = tmp_path / "test.png"
+
+        result = fig.savefig(output, verbose=False)
+
+        # Should return (image_path, yaml_path) tuple
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert result[0].exists()
+        assert result[1].exists()
+        assert result[1].suffix == ".yaml"
+
+    def test_savefig_no_recipe(self, fig_ax, tmp_path):
+        """savefig(save_recipe=False) should only save the image."""
+        fig, ax = fig_ax
+        output = tmp_path / "test.png"
+
+        result = fig.savefig(output, save_recipe=False, verbose=False)
+
+        # Should return just the image path
+        assert isinstance(result, Path)
+        assert result.exists()
+        # YAML should NOT be created
+        assert not (tmp_path / "test.yaml").exists()
+
+    def test_savefig_same_as_fr_save(self, fig_ax, tmp_path):
+        """savefig() output should match fr.save() output dimensions."""
+        from PIL import Image
+
+        import figrecipe as fr
+
+        fig1, ax1 = fig_ax
+
+        # Save with savefig()
+        savefig_path = tmp_path / "savefig.png"
+        fig1.savefig(savefig_path, verbose=False, validate=False)
+
+        # Create second figure for fr.save()
+        fr.load_style("SCITEX")
+        fig2, ax2 = fr.subplots()
+        ax2.plot([1, 2, 3], [1, 2, 3], id="test")
+        ax2.set_xlabel("X axis")
+        ax2.set_ylabel("Y axis")
+
+        frsave_path = tmp_path / "frsave.png"
+        fr.save(fig2, frsave_path, verbose=False, validate=False)
+
+        # Compare image dimensions (should be identical)
+        with Image.open(savefig_path) as img1, Image.open(frsave_path) as img2:
+            assert (
+                img1.size == img2.size
+            ), f"savefig() produced {img1.size}, fr.save() produced {img2.size}"
+
+        import matplotlib.pyplot as plt
+
+        plt.close(fig2.fig)
+
+    def test_savefig_applies_autocrop(self, tmp_path):
+        """savefig() should apply auto-crop from mm_layout."""
+        from PIL import Image
+
+        import figrecipe as fr
+
+        fr.load_style("SCITEX")
+        fig, ax = fr.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        output = tmp_path / "test.png"
+        fig.savefig(output, verbose=False, validate=False)
+
+        # Check that image was created and has reasonable dimensions
+        # (auto-crop should make it smaller than the uncropped figure)
+        with Image.open(output) as img:
+            # With SCITEX style at 300 DPI, cropped figure should be
+            # roughly 40mm wide * 300/25.4 ≈ 472px, plus margins
+            # Just check it's not too large (uncropped would be ~2k px)
+            assert img.width < 1000, f"Image seems uncropped: {img.width}px wide"
+            assert img.height < 800, f"Image seems uncropped: {img.height}px tall"
+
+        import matplotlib.pyplot as plt
+
+        plt.close(fig.fig)
+
+    def test_savefig_respects_dpi_kwarg(self, fig_ax, tmp_path):
+        """savefig() should respect the dpi keyword argument."""
+        from PIL import Image
+
+        fig, ax = fig_ax
+
+        # Save at different DPIs
+        output_300 = tmp_path / "dpi300.png"
+        output_150 = tmp_path / "dpi150.png"
+
+        fig.savefig(output_300, dpi=300, verbose=False, validate=False)
+
+        # Create new figure for 150 DPI test
+        import figrecipe as fr
+
+        fr.load_style("SCITEX")
+        fig2, ax2 = fr.subplots()
+        ax2.plot([1, 2, 3], [1, 2, 3], id="test")
+        ax2.set_xlabel("X axis")
+        ax2.set_ylabel("Y axis")
+        fig2.savefig(output_150, dpi=150, verbose=False, validate=False)
+
+        with Image.open(output_300) as img300, Image.open(output_150) as img150:
+            # 300 DPI should be roughly 2x the size of 150 DPI
+            ratio = img300.width / img150.width
+            assert 1.8 < ratio < 2.2, f"DPI ratio unexpected: {ratio}"
+
+        import matplotlib.pyplot as plt
+
+        plt.close(fig2.fig)
+
+
+class TestSavefigRecording:
+    """Tests that savefig() properly records calls for reproduction."""
+
+    def test_savefig_recipe_contains_plot(self, fig_ax, tmp_path):
+        """Recipe from savefig() should contain the plot call."""
+        from ruamel.yaml import YAML
+
+        fig, ax = fig_ax
+        output = tmp_path / "test.png"
+
+        fig.savefig(output, verbose=False, validate=False)
+
+        # Read the recipe
+        yaml_path = tmp_path / "test.yaml"
+        yaml_loader = YAML(typ="safe")
+        with open(yaml_path) as f:
+            recipe = yaml_loader.load(f)
+
+        # Should contain axes with a plot call
+        assert "axes" in recipe
+        ax_key = list(recipe["axes"].keys())[0]
+        assert "calls" in recipe["axes"][ax_key]
+        assert len(recipe["axes"][ax_key]["calls"]) > 0
+
+        # Verify the plot call is recorded correctly
+        calls = recipe["axes"][ax_key]["calls"]
+        plot_calls = [c for c in calls if c["function"] == "plot"]
+        assert len(plot_calls) == 1


### PR DESCRIPTION
## Summary

- **Issue #42**: `fig.savefig()` now delegates to `save_figure()` for consistent output with `fr.save()`
- **Issue #43**: `ax.text()` and `ax.annotate()` now use `fonts.annotation_pt` from style as default fontsize

## Changes

### Issue #42 - savefig() consistency
- `fig.savefig()` delegates to `save_figure()` from `_save.py`
- Both methods now produce identical output (same auto-crop, finalization)
- `save_recipe=False` skips recipe generation but still applies auto-crop

### Issue #43 - annotation_pt not applied
- Added custom `text()` method to `RecordingAxes`
- Added custom `annotate()` method to `RecordingAxes`
- Both methods look up `fonts.annotation_pt` from loaded style (e.g., SCITEX defines 6pt)
- Explicit `fontsize` parameter overrides style default

## Test plan
- [x] `tests/test_annotation_fontsize.py` - 7 tests for annotation styling
- [x] `tests/test_savefig_consistency.py` - 6 tests for savefig behavior
- [x] All pre-commit hooks pass (ruff, ruff-format, pytest)

Closes #42, Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)