### PR TITLE
feat: Background color API and serialization fixes

### DIFF
--- a/src/figrecipe/_api/_style_manager.py
+++ b/src/figrecipe/_api/_style_manager.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-def load_style(style="SCITEX", dark=False):
+def load_style(style="SCITEX", dark=False, background=None):
     """Load style configuration and apply it globally.
 
     After calling this function, subsequent `subplots()` calls will
@@ -31,6 +31,10 @@ def load_style(style="SCITEX", dark=False):
     dark : bool, optional
         If True, apply dark theme transformation (default: False).
         Equivalent to appending "_DARK" to preset name.
+    background : str, optional
+        Override default background color. E.g., 'white' for opaque figures.
+        Sets theme.light.figure_bg and theme.light.axes_bg.
+        Use 'transparent' for transparent background.
 
     Returns
     -------
@@ -45,6 +49,9 @@ def load_style(style="SCITEX", dark=False):
     >>> # Load scientific style (default)
     >>> fr.load_style()
     >>> fr.load_style("SCITEX")  # explicit
+
+    >>> # Load with white background (override transparent default)
+    >>> fr.load_style("SCITEX", background='white')
 
     >>> # Load dark theme
     >>> fr.load_style("SCITEX_DARK")
@@ -62,7 +69,24 @@ def load_style(style="SCITEX", dark=False):
     """
     from ..styles import load_style as _load_style
 
-    return _load_style(style, dark=dark)
+    loaded = _load_style(style, dark=dark)
+
+    if loaded is None:
+        return None
+
+    # Apply background override (figure and axes, not legend)
+    if background is not None:
+        theme_key = "dark" if dark else "light"
+        if hasattr(loaded, "theme") and hasattr(loaded.theme, theme_key):
+            theme = getattr(loaded.theme, theme_key)
+            if background == "transparent":
+                theme.figure_bg = "none"
+                theme.axes_bg = "none"
+            else:
+                theme.figure_bg = background
+                theme.axes_bg = background
+
+    return loaded
 
 
 def unload_style():

--- a/src/figrecipe/_graph.py
+++ b/src/figrecipe/_graph.py
@@ -29,7 +29,9 @@ LAYOUTS = {
 }
 
 
-def _get_layout(G, layout: str, pos: Optional[Dict] = None, seed: int = 42, **layout_kwargs):
+def _get_layout(
+    G, layout: str, pos: Optional[Dict] = None, seed: int = 42, **layout_kwargs
+):
     """Compute node positions using specified layout algorithm.
 
     Parameters
@@ -82,9 +84,7 @@ def _get_layout(G, layout: str, pos: Optional[Dict] = None, seed: int = 42, **la
         return nx.spring_layout(G, seed=seed)
 
 
-def _resolve_node_attr(
-    G, attr: Union[str, Callable, Any], default: Any = None
-) -> List:
+def _resolve_node_attr(G, attr: Union[str, Callable, Any], default: Any = None) -> List:
     """Resolve node attribute values from name, callable, or scalar.
 
     Parameters
@@ -112,13 +112,15 @@ def _resolve_node_attr(
     if isinstance(attr, str):
         return [G.nodes[n].get(attr, default) for n in G.nodes()]
 
+    # List/array pass-through (used for replay with pre-computed values)
+    if isinstance(attr, (list, tuple, np.ndarray)):
+        return list(attr)
+
     # Scalar value
     return [attr] * len(G.nodes())
 
 
-def _resolve_edge_attr(
-    G, attr: Union[str, Callable, Any], default: Any = None
-) -> List:
+def _resolve_edge_attr(G, attr: Union[str, Callable, Any], default: Any = None) -> List:
     """Resolve edge attribute values from name, callable, or scalar.
 
     Parameters
@@ -145,6 +147,10 @@ def _resolve_edge_attr(
 
     if isinstance(attr, str):
         return [G.edges[u, v].get(attr, default) for u, v in G.edges()]
+
+    # List/array pass-through (used for replay with pre-computed values)
+    if isinstance(attr, (list, tuple, np.ndarray)):
+        return list(attr)
 
     # Scalar value
     return [attr] * len(G.edges())
@@ -192,7 +198,9 @@ def _normalize_sizes(sizes: List, min_size: float = 20, max_size: float = 300) -
         return [min_size + (max_size - min_size) / 2] * len(sizes)
 
     # Normalize to [min_size, max_size]
-    normalized = min_size + (sizes - sizes_valid.min()) / (sizes_valid.max() - sizes_valid.min()) * (max_size - min_size)
+    normalized = min_size + (sizes - sizes_valid.min()) / (
+        sizes_valid.max() - sizes_valid.min()
+    ) * (max_size - min_size)
     normalized = np.nan_to_num(normalized, nan=min_size)
     return normalized.tolist()
 


### PR DESCRIPTION
## Summary

Incorporates essential features from PR #44 (which has conflicts) into a clean branch.

### Changes

1. **Background color API** - Add `background` parameter to `load_style()`:
   ```python
   fr.load_style("SCITEX", background='white')  # Opaque background
   fr.load_style("SCITEX", background='transparent')  # Transparent
   ```

2. **Transform serialization** - Add `_serialize_transform()` method to `RecordingAxes`:
   - Converts matplotlib transforms (`ax.transAxes`, `ax.transData`, etc.) to serializable string markers
   - Enables recipe replay for `ax.text(..., transform=ax.transAxes)`

3. **Graph replay fix** - Add list/array pass-through in `_resolve_node_attr()` and `_resolve_edge_attr()`:
   - Allows pre-computed node_size/node_color arrays to pass through during replay
   - Fixes graph visualization recipe replay

## Test plan

- [x] All 898 tests pass
- [x] `tests/test_annotation_fontsize.py` - 7 tests for text/annotate styling
- [x] `tests/test_graph.py` - 51 tests for graph visualization

Supersedes #44 (close after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)