### PR TITLE
feat(compose): Support raw image files as sources (#75)

### DIFF
--- a/src/figrecipe/_composition/__init__.py
+++ b/src/figrecipe/_composition/__init__.py
@@ -3,16 +3,19 @@
 """Composition module for combining multiple figures.
 
 This module provides functionality to:
-- Compose new figures from multiple recipe sources
+- Compose new figures from multiple recipe sources or raw images
 - Import axes from external recipes into existing figures
 - Hide/show panels for visual composition
 - Align and distribute panels
+
+Supported image formats for composition:
+PNG, JPG, JPEG, TIFF, BMP, GIF, WEBP, SVG (SVG requires cairosvg)
 
 Phase 1-3 of the composition feature.
 """
 
 from ._alignment import AlignmentMode, align_panels, distribute_panels, smart_align
-from ._compose import compose
+from ._compose import IMAGE_EXTENSIONS, VECTOR_EXTENSIONS, compose
 from ._import_axes import import_axes
 from ._visibility import hide_panel, show_panel, toggle_panel
 
@@ -20,6 +23,9 @@ __all__ = [
     # Phase 1: Composition
     "compose",
     "import_axes",
+    # Image formats supported for composition
+    "IMAGE_EXTENSIONS",
+    "VECTOR_EXTENSIONS",
     # Phase 2: Visibility
     "hide_panel",
     "show_panel",


### PR DESCRIPTION
## Summary

- Add support for composing figures with raw image files (PNG, JPG, JPEG, TIFF, BMP, GIF, WEBP, SVG) in addition to recipe files
- Images are displayed using `ax.imshow()` with axis turned off for clean presentation
- SVG support requires optional `cairosvg` package

## Changes

- Add `_is_image_file()` helper to detect supported image extensions
- Add `_create_image_record()` to convert images to FigureRecord with imshow()
- Modify `_parse_source_spec_with_path()` to handle image files automatically
- Export `IMAGE_EXTENSIONS` and `VECTOR_EXTENSIONS` constants
- Add 8 comprehensive tests for raw image composition

## Usage

```python
import figrecipe as fr

# Compose with mixed sources (recipes and raw images)
fig, axes = fr.compose(
    layout=(1, 3),
    sources={
        (0, 0): "microscopy_image.png",  # Raw PNG
        (0, 1): "diagram.svg",            # Raw SVG (requires cairosvg)
        (0, 2): "my_plot.yaml",           # Recipe file
    }
)
```

## Test plan

- [x] Test single raw image composition
- [x] Test multiple raw images
- [x] Test mixed recipe + image composition
- [x] Test axis off for images
- [x] Test aspect ratio preservation
- [x] Test save and reproduce workflow
- [x] Test 2x2 grid layout
- [x] Test image file extension detection

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)