### PR TITLE
docs: Add CLI reference and MCP tools documentation

### DIFF
--- a/docs/sphinx/cli_reference.rst
+++ b/docs/sphinx/cli_reference.rst
@@ -1,0 +1,253 @@
+CLI Reference
+=============
+
+FigRecipe provides a comprehensive command-line interface for working with figures.
+
+Usage
+-----
+
+.. code-block:: bash
+
+   figrecipe [COMMAND] [OPTIONS]
+
+Run ``figrecipe --help`` to see all available commands.
+
+Figure Creation
+---------------
+
+plot
+^^^^
+
+Create a figure from a declarative YAML specification.
+
+.. code-block:: bash
+
+   figrecipe plot spec.yaml -o output.png
+
+   # Options:
+   #   -o, --output PATH    Output file path
+   #   --dpi INTEGER        DPI for raster output (default: 300)
+   #   --no-recipe          Don't save recipe file
+
+reproduce
+^^^^^^^^^
+
+Reproduce a figure from its saved recipe.
+
+.. code-block:: bash
+
+   figrecipe reproduce recipe.yaml -o reproduced.png
+
+   # Options:
+   #   -o, --output PATH    Output file path
+   #   --format TEXT        Output format: png, pdf, svg
+   #   --dpi INTEGER        DPI for raster output
+
+compose
+^^^^^^^
+
+Compose multiple figures into a single multi-panel figure.
+
+.. code-block:: bash
+
+   figrecipe compose panel_a.png panel_b.png -o figure.png
+
+   # Options:
+   #   -o, --output PATH    Output file path
+   #   --layout TEXT        Layout: horizontal, vertical, grid
+   #   --gap FLOAT          Gap between panels in mm
+   #   --labels/--no-labels Add panel labels (A, B, C...)
+   #   --label-style TEXT   uppercase, lowercase, numeric
+
+gui
+^^^
+
+Launch the interactive GUI editor for figure styling.
+
+.. code-block:: bash
+
+   figrecipe gui recipe.yaml
+
+   # Options:
+   #   --port INTEGER       Server port (default: 5050)
+   #   --host TEXT          Host address
+   #   --no-browser         Don't open browser automatically
+   #   --desktop            Launch as native desktop window
+
+Image Processing
+----------------
+
+convert
+^^^^^^^
+
+Convert between image formats.
+
+.. code-block:: bash
+
+   figrecipe convert input.png output.pdf
+
+crop
+^^^^
+
+Crop whitespace from figure images.
+
+.. code-block:: bash
+
+   figrecipe crop figure.png -o cropped.png
+
+   # Options:
+   #   -o, --output PATH    Output file path
+   #   --margin FLOAT       Margin to keep in mm (default: 1.0)
+   #   --overwrite          Overwrite input file
+
+diff
+^^^^
+
+Compare two images and show statistics.
+
+.. code-block:: bash
+
+   figrecipe diff original.png reproduced.png
+
+   # Output: MSE, SSIM, and other comparison metrics
+
+hitmap
+^^^^^^
+
+Generate a hitmap visualization showing differences between images.
+
+.. code-block:: bash
+
+   figrecipe hitmap original.png reproduced.png -o diff.png
+
+   # Options:
+   #   -o, --output PATH    Output file path
+
+Data & Validation
+-----------------
+
+extract
+^^^^^^^
+
+Extract plotted data from a recipe file.
+
+.. code-block:: bash
+
+   figrecipe extract recipe.yaml
+
+   # Output: JSON with {call_id: {x: [...], y: [...], ...}}
+
+validate
+^^^^^^^^
+
+Validate that a recipe reproduces its original figure.
+
+.. code-block:: bash
+
+   figrecipe validate recipe.yaml
+
+   # Options:
+   #   --threshold FLOAT    MSE threshold (default: 100)
+
+info
+^^^^
+
+Show information about a recipe file.
+
+.. code-block:: bash
+
+   figrecipe info recipe.yaml
+
+   # Options:
+   #   -v, --verbose        Show detailed call information
+
+Diagram
+-------
+
+diagram
+^^^^^^^
+
+Create diagrams from YAML specifications.
+
+.. code-block:: bash
+
+   figrecipe diagram create spec.yaml -o diagram.png
+
+   # Subcommands:
+   #   create      Create diagram from spec
+   #   compile     Compile to Mermaid/Graphviz format
+   #   render      Render to image file
+   #   presets     List available presets
+
+Style & Appearance
+------------------
+
+style
+^^^^^
+
+Manage figure styles.
+
+.. code-block:: bash
+
+   figrecipe style list              # List available presets
+   figrecipe style show PRESET       # Show preset details
+   figrecipe style apply recipe.yaml # Apply style to recipe
+
+fonts
+^^^^^
+
+Check font availability.
+
+.. code-block:: bash
+
+   figrecipe fonts check "Arial"     # Check if font is available
+   figrecipe fonts list              # List available fonts
+
+Integration
+-----------
+
+mcp
+^^^
+
+MCP (Model Context Protocol) server commands for AI agent integration.
+
+.. code-block:: bash
+
+   figrecipe mcp start               # Start MCP server
+   figrecipe mcp list-tools          # List available MCP tools
+   figrecipe mcp list-tools -v       # Verbose tool listing
+   figrecipe mcp install --claude-code  # Install to Claude Code
+
+list-python-apis
+^^^^^^^^^^^^^^^^
+
+List available Python API functions.
+
+.. code-block:: bash
+
+   figrecipe list-python-apis
+
+   # Options:
+   #   -v, --verbose        Show detailed function signatures
+
+Utility
+-------
+
+completion
+^^^^^^^^^^
+
+Generate shell completion scripts.
+
+.. code-block:: bash
+
+   figrecipe completion bash > ~/.figrecipe-complete.bash
+   figrecipe completion zsh > ~/.figrecipe-complete.zsh
+
+version
+^^^^^^^
+
+Show version information.
+
+.. code-block:: bash
+
+   figrecipe version

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -18,6 +18,7 @@ FigRecipe - Reproducible Scientific Figures
 
    gallery
    style_reference
+   cli_reference
    mcp_spec
 
 .. toctree::

--- a/docs/sphinx/mcp_spec.rst
+++ b/docs/sphinx/mcp_spec.rst
@@ -374,3 +374,123 @@ Get supported plot types:
 
    types = plt_get_plot_types()
    # Returns: {"plot_types": [...], "categories": {...}}
+
+Diagram Tools
+-------------
+
+diagram_create
+^^^^^^^^^^^^^^
+
+Create a diagram from YAML specification:
+
+.. code-block:: python
+
+   result = diagram_create(
+       spec_dict={...},       # Or spec_path="diagram.yaml"
+   )
+   # Returns: {"mermaid": "...", "graphviz": "..."}
+
+diagram_render
+^^^^^^^^^^^^^^
+
+Render diagram to image:
+
+.. code-block:: python
+
+   result = diagram_render(
+       spec_path="diagram.yaml",
+       output_path="diagram.png",
+       format="png",           # png, svg, pdf
+       backend="auto",         # mermaid-cli, graphviz, mermaid.ink
+       scale=2.0
+   )
+
+diagram_compile_mermaid
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Compile to Mermaid format:
+
+.. code-block:: python
+
+   result = diagram_compile_mermaid(
+       spec_path="diagram.yaml",
+       output_path="diagram.mmd"
+   )
+
+diagram_compile_graphviz
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Compile to Graphviz DOT format:
+
+.. code-block:: python
+
+   result = diagram_compile_graphviz(
+       spec_path="diagram.yaml",
+       output_path="diagram.dot"
+   )
+
+diagram_list_presets
+^^^^^^^^^^^^^^^^^^^^
+
+List available diagram presets:
+
+.. code-block:: python
+
+   presets = diagram_list_presets()
+   # Returns: {"workflow": ..., "decision": ..., "pipeline": ..., "scientific": ...}
+
+diagram_get_backends
+^^^^^^^^^^^^^^^^^^^^
+
+Check rendering backend availability:
+
+.. code-block:: python
+
+   backends = diagram_get_backends()
+   # Returns availability and installation instructions
+
+All MCP Tools Summary
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tool
+     - Description
+   * - **plt_plot**
+     - Create figure from declarative spec
+   * - **plt_reproduce**
+     - Reproduce figure from recipe
+   * - **plt_compose**
+     - Combine multiple figures
+   * - **plt_info**
+     - Get recipe information
+   * - **plt_validate**
+     - Validate reproduction fidelity
+   * - **plt_crop**
+     - Crop whitespace from image
+   * - **plt_extract_data**
+     - Extract plotted data arrays
+   * - **plt_list_styles**
+     - List style presets
+   * - **plt_get_plot_types**
+     - Get supported plot types
+   * - **diagram_create**
+     - Create diagram from spec
+   * - **diagram_render**
+     - Render diagram to image
+   * - **diagram_compile_mermaid**
+     - Compile to Mermaid format
+   * - **diagram_compile_graphviz**
+     - Compile to Graphviz format
+   * - **diagram_list_presets**
+     - List diagram presets
+   * - **diagram_get_preset**
+     - Get preset configuration
+   * - **diagram_get_backends**
+     - Check backend availability
+   * - **diagram_split**
+     - Split large diagram into parts
+   * - **diagram_get_paper_modes**
+     - Get paper layout modes


### PR DESCRIPTION
## Summary
- Add comprehensive CLI reference page with all commands
- Expand MCP tools documentation with diagram tools
- Add MCP tools summary table

🤖 Generated with [Claude Code](https://claude.com/claude-code)