### PR TITLE
feat: add _skills/ with non-monolith skills layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,9 @@ exclude = [
     "src/figrecipe/_django/frontend/eslint.config.js",
 ]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/figrecipe/_skills" = "figrecipe/_skills"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/figrecipe/_django/frontend/src/main.tsx
+++ b/src/figrecipe/_django/frontend/src/main.tsx
@@ -18,6 +18,7 @@ import "./styles/panels.css";
 import "./styles/gallery.css";
 import "./styles/export-dialog.css";
 import "./styles/feedback.css";
+import "./styles/mobile.css";
 
 // scitex-ui CSS — single bundle import (shell + app + utils)
 // @ts-ignore

--- a/src/figrecipe/_django/frontend/src/styles/mobile.css
+++ b/src/figrecipe/_django/frontend/src/styles/mobile.css
@@ -1,0 +1,102 @@
+/**
+ * FigRecipe Mobile Layout — 90° rotation for vertical stacking.
+ *
+ * Desktop: .editor-body is flex-direction row (panels side by side)
+ * Mobile:  .editor-body becomes flex-direction column (panels stacked)
+ *
+ * Same rotation principle as the workspace shell.
+ */
+
+@media (max-width: 768px) {
+  /* ── Editor body: vertical stacking ──────────────────── */
+  .editor-body {
+    flex-direction: column !important;
+    height: auto !important;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  /* ── All split panes: full width, share height equally ── */
+  .split-pane {
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 100% !important;
+    flex: 1 1 0% !important;
+    height: 0;
+    min-height: 44px;
+  }
+
+  .split-pane-left,
+  .split-pane-right {
+    width: 100% !important;
+    border-right: none !important;
+    border-left: none !important;
+    border-bottom: 1px solid var(--vis-border, #30363d);
+  }
+
+  .split-pane-center {
+    min-width: 100% !important;
+    min-height: 150px;
+  }
+
+  /* ── Collapsed panes: horizontal header bar (not vertical strip) ── */
+  .split-pane.collapsed {
+    width: 100% !important;
+    min-width: 100% !important;
+    max-width: 100% !important;
+    height: auto !important;
+    min-height: 0 !important;
+    flex: 0 0 auto !important;
+  }
+
+  .split-pane.collapsed .pane-header {
+    flex-direction: row !important;
+    height: auto !important;
+    min-height: 44px !important;
+    padding: 0 12px !important;
+    align-items: center !important;
+    gap: 8px !important;
+    border-bottom: 1px solid var(--vis-border, #30363d) !important;
+  }
+
+  .split-pane.collapsed .panel-title {
+    flex-direction: row !important;
+    font-size: 0.85rem !important;
+    gap: 6px !important;
+  }
+
+  /* ── Panel resizers: horizontal drag handles ──────────── */
+  .panel-resizer,
+  .split-resizer {
+    position: relative !important;
+    top: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: auto !important;
+    width: 100% !important;
+    height: 6px !important;
+    flex: 0 0 6px !important;
+    cursor: row-resize !important;
+  }
+
+  .panel-resizer::before,
+  .split-resizer::before {
+    cursor: row-resize !important;
+    left: 0 !important;
+    right: 0 !important;
+    top: -12px !important;
+    bottom: -12px !important;
+  }
+
+  /* ── Inner editor tabs: scrollable on mobile ──────────── */
+  .inner-editor__tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* ── Status bar: compact ──────────────────────────────── */
+  .status-bar {
+    padding: 4px 8px;
+    font-size: 11px;
+  }
+}

--- a/src/figrecipe/_skills/figrecipe/SKILL.md
+++ b/src/figrecipe/_skills/figrecipe/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: figrecipe
+description: Reproducible matplotlib figures with mm-precision layouts, declarative specs, YAML recipes, multi-panel composition, and diagram generation. Use when creating publication-ready figures.
+allowed-tools: mcp__scitex__plt_*
+---
+
+# figrecipe
+
+Reproducible, style-editable scientific figures via YAML recipes. Drop-in replacement for `plt.subplots()` that records all plotting calls for exact reproduction.
+
+## Sub-skills
+
+* [quick-start](quick-start.md) — Core workflow: subplots, save, reproduce
+* [plot-types](plot-types.md) — All supported plot types with examples
+* [composition](composition.md) — Multi-panel figure composition (grid and mm-based)
+* [cropping](cropping.md) — Figure cropping, whitespace removal
+* [styles](styles.md) — Style presets, SCITEX/MATPLOTLIB, custom styles
+* [bundle](bundle.md) — ZIP bundle format (spec.json + data.csv + exports)
+* [diagram](diagram.md) — Box-and-arrow diagrams, Mermaid, Graphviz
+* [cli-reference](cli-reference.md) — All CLI commands
+* [mcp-tools](mcp-tools.md) — MCP tool reference for AI agents
+
+## MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `plt_plot` | Create figure from declarative spec dict |
+| `plt_reproduce` | Reproduce figure from YAML recipe |
+| `plt_compose` | Compose multi-panel figure |
+| `plt_crop` | Crop whitespace from figure image |
+| `plt_validate` | Validate recipe reproducibility |
+| `plt_extract_data` | Extract plotted data arrays |
+| `plt_info` | Get recipe metadata |
+| `plt_get_plot_types` | List all supported plot types |
+| `plt_list_styles` | List available style presets |
+| `plt_diagram_create` | Create box-and-arrow diagram |
+| `plt_diagram_render` | Render diagram to image |
+| `plt_diagram_compile_mermaid` | Compile Mermaid diagram |
+| `plt_diagram_compile_graphviz` | Compile Graphviz diagram |
+| `plt_diagram_list_presets` | List diagram presets |
+| `plt_line`, `plt_scatter`, `plt_bar`, ... | Per-type plot tools |
+
+## CLI Summary
+
+```bash
+figrecipe plot spec.yaml           # Create from spec
+figrecipe reproduce recipe.yaml    # Reproduce figure
+figrecipe compose a.yaml b.yaml -o out.png  # Compose panels
+figrecipe crop figure.png          # Crop whitespace
+figrecipe validate recipe.yaml     # Check reproducibility
+figrecipe gui recipe.yaml          # Launch GUI editor
+figrecipe style list               # List style presets
+figrecipe diagram render flow.mmd  # Render diagram
+figrecipe mcp start                # Start MCP server
+```

--- a/src/figrecipe/_skills/figrecipe/bundle.md
+++ b/src/figrecipe/_skills/figrecipe/bundle.md
@@ -1,0 +1,83 @@
+---
+name: bundle
+description: ZIP bundle format — self-contained figures with spec.json, style.json, data.csv, and exported images.
+---
+
+# Bundle Format
+
+A bundle is a self-contained ZIP file containing everything needed to view, edit, and reproduce a figure.
+
+## Bundle structure
+
+```
+my_figure.zip
+├── spec.json          # WHAT to plot (semantic specification)
+├── style.json         # HOW it looks (colors, fonts, sizes)
+├── data.csv           # Raw data (immutable source)
+├── recipe.yaml        # Reproducible recipe (for fr.reproduce())
+└── exports/
+    ├── figure.png
+    └── figure_hitmap.png
+```
+
+## fr.save_bundle()
+
+```python
+def save_bundle(
+    fig,
+    path: str | Path,              # output .zip path (extension added if missing)
+    dpi: Optional[int] = None,     # default from style or 300
+    image_formats: Optional[list] = None,  # default: ["png"]
+    save_hitmap: bool = True,
+    verbose: bool = True,
+) -> Path
+```
+
+```python
+import figrecipe as fr
+import numpy as np
+
+fig, ax = fr.subplots(axes_width_mm=80, axes_height_mm=60)
+ax.plot(np.linspace(0, 10, 100), np.sin(np.linspace(0, 10, 100)), id="sine")
+
+bundle_path = fr.save_bundle(fig, "my_figure")
+# → my_figure.zip
+```
+
+## fr.load_bundle()
+
+```python
+spec, style, data = fr.load_bundle("my_figure.zip")
+# spec: dict (spec.json contents)
+# style: dict (style.json contents)
+# data: DataFrame or None (data.csv contents)
+```
+
+## fr.reproduce_bundle()
+
+```python
+fig, axes = fr.reproduce_bundle("my_figure.zip")
+# Reproduces the figure from bundle contents
+```
+
+`fr.reproduce()` also accepts `.zip` bundles and auto-detects the format.
+
+## Figz and Pltz classes
+
+`Figz` and `Pltz` are the bundle-aware figure/axes wrappers:
+
+```python
+from figrecipe import Figz, Pltz
+```
+
+These are returned by `reproduce_bundle()` and provide structured access to bundle contents.
+
+## Principles
+
+| Component | Editable | Notes |
+|-----------|----------|-------|
+| `spec.json` | Yes | Change to modify what is plotted |
+| `style.json` | Yes | Change to modify appearance |
+| `data.csv` | No | Immutable source data |
+| `exports/` | No | Regenerated from spec + data |
+| `cache/` | No | Regenerable, safe to delete |

--- a/src/figrecipe/_skills/figrecipe/cli-reference.md
+++ b/src/figrecipe/_skills/figrecipe/cli-reference.md
@@ -1,0 +1,198 @@
+---
+name: cli-reference
+description: Complete figrecipe CLI reference — all commands with options and examples.
+---
+
+# CLI Reference
+
+Entry point: `figrecipe` (installed by `pip install figrecipe`).
+
+```bash
+figrecipe --help
+figrecipe --version
+figrecipe --help-recursive    # full help for all commands
+```
+
+## Figure Creation
+
+### figrecipe plot
+
+Create a figure from a declarative YAML/JSON spec file.
+
+```bash
+figrecipe plot spec.yaml
+figrecipe plot spec.yaml -o figure.png
+figrecipe plot spec.yaml -f pdf --dpi 600
+figrecipe plot spec.yaml --style SCITEX
+figrecipe plot spec.yaml --show              # display interactively
+figrecipe plot spec.yaml --save-recipe       # also save .yaml recipe
+```
+
+Options: `-o/--output`, `-f/--format [png|pdf|svg]`, `--dpi`, `--style`, `--show`, `--save-recipe`
+
+### figrecipe reproduce
+
+Recreate a figure from a saved YAML recipe.
+
+```bash
+figrecipe reproduce recipe.yaml
+figrecipe reproduce recipe.yaml -o output.png
+figrecipe reproduce recipe.yaml -f pdf --dpi 600
+figrecipe reproduce recipe.yaml --show
+```
+
+Options: `-o/--output`, `-f/--format [png|pdf|svg]`, `--dpi`, `--show`
+
+### figrecipe compose
+
+Combine multiple figures into one.
+
+```bash
+figrecipe compose panel_a.yaml panel_b.yaml -o composed.png
+figrecipe compose a.png b.png c.png -o out.png --layout horizontal
+figrecipe compose a.png b.png c.png d.png -o out.png --layout grid --cols 2
+figrecipe compose a.png b.png -o out.png --layout vertical --dpi 600
+```
+
+Options: `-o/--output` (required), `--layout [horizontal|vertical|grid]`, `--cols`, `--dpi`
+
+### figrecipe gui
+
+Launch the interactive GUI editor.
+
+```bash
+figrecipe gui
+figrecipe gui recipe.yaml
+figrecipe gui recipe.yaml --port 8080
+figrecipe gui recipe.yaml --desktop          # native window (requires figrecipe[desktop])
+```
+
+## Image Processing
+
+### figrecipe convert
+
+Convert figure between formats.
+
+```bash
+figrecipe convert figure.eps -o figure.png
+figrecipe convert figure.pdf -o figure.svg
+```
+
+### figrecipe crop
+
+Crop whitespace from a figure image. Requires `figrecipe[imaging]`.
+
+```bash
+figrecipe crop figure.png
+figrecipe crop figure.png -o figure_tight.png
+figrecipe crop figure.png --margin 2mm
+figrecipe crop figure.png --margin 10px
+figrecipe crop figure.png --overwrite
+```
+
+Options: `-o/--output`, `--margin` (e.g., `2mm`, `10px`, default `1mm`), `--overwrite`
+
+### figrecipe diff
+
+Show pixel difference between two figures.
+
+```bash
+figrecipe diff old.png new.png -o diff.png
+```
+
+### figrecipe hitmap
+
+Generate hitmap for GUI element selection.
+
+```bash
+figrecipe hitmap recipe.yaml
+```
+
+## Data & Validation
+
+### figrecipe extract
+
+Extract data arrays from a figure.
+
+```bash
+figrecipe extract recipe.yaml
+figrecipe extract recipe.yaml -o data.csv
+```
+
+### figrecipe validate
+
+Validate that a recipe can reproduce its original figure.
+
+```bash
+figrecipe validate recipe.yaml
+figrecipe validate recipe.yaml --threshold 50.0
+figrecipe validate recipe.yaml --strict         # threshold = 0
+figrecipe validate recipe.yaml -q               # quiet: PASS/FAIL only
+```
+
+Options: `--threshold` (MSE, default 100), `--strict`, `-q/--quiet`
+
+### figrecipe info
+
+Show recipe metadata.
+
+```bash
+figrecipe info recipe.yaml
+```
+
+## Diagram
+
+### figrecipe diagram
+
+```bash
+figrecipe diagram render flow.mmd -o flow.png
+figrecipe diagram create --preset WORKFLOW
+figrecipe diagram --help
+```
+
+## Style & Appearance
+
+### figrecipe style
+
+```bash
+figrecipe style list              # list all presets
+figrecipe style show SCITEX       # show preset details
+figrecipe style apply SCITEX      # apply globally
+figrecipe style reset             # reset to matplotlib defaults
+```
+
+### figrecipe fonts
+
+```bash
+figrecipe fonts list              # list available fonts
+```
+
+## Integration
+
+### figrecipe mcp
+
+```bash
+figrecipe mcp start               # start MCP server
+figrecipe mcp install             # install MCP configuration
+```
+
+### figrecipe list-python-apis
+
+```bash
+figrecipe list-python-apis        # list all public Python API functions
+```
+
+## Utility
+
+### figrecipe completion
+
+```bash
+figrecipe completion bash         # generate bash completion
+figrecipe completion zsh          # generate zsh completion
+```
+
+### figrecipe version
+
+```bash
+figrecipe version
+```

--- a/src/figrecipe/_skills/figrecipe/composition.md
+++ b/src/figrecipe/_skills/figrecipe/composition.md
@@ -1,0 +1,143 @@
+---
+name: composition
+description: Multi-panel figure composition — combining multiple recipe files or images into a single figure using grid-based or mm-based positioning.
+---
+
+# Composition
+
+## fr.compose()
+
+```python
+def compose(
+    sources: dict,
+    layout: Optional[Tuple[int, int]] = None,
+    canvas_size_mm: Optional[Tuple[float, float]] = None,
+    gap_mm: float = 5.0,
+    dpi: int = 300,
+    panel_labels: bool = False,
+    label_style: str = "uppercase",    # "uppercase", "lowercase", "numeric"
+    **kwargs,
+) -> Tuple[RecordingFigure, RecordingAxes | ndarray | list]
+```
+
+Two modes are auto-detected from the `sources` format.
+
+## Mode 1: Grid-based
+
+Sources keyed by `(row, col)` tuples.
+
+```python
+import figrecipe as fr
+
+fig, axes = fr.compose(
+    layout=(1, 2),
+    sources={
+        (0, 0): "panel_a.yaml",
+        (0, 1): "panel_b.yaml",
+    },
+    panel_labels=True,
+)
+fr.save(fig, "composed_2panel.png")
+```
+
+Layout is auto-detected if not provided (uses max row/col from keys).
+
+```python
+# 2x2 grid, auto-detected layout
+fig, axes = fr.compose(
+    sources={
+        (0, 0): "panel_a.yaml",
+        (0, 1): "panel_b.yaml",
+        (1, 0): "panel_c.yaml",
+        (1, 1): "panel_d.yaml",
+    },
+    panel_labels=True,
+    label_style="uppercase",   # labels: A, B, C, D
+)
+```
+
+## Mode 2: Mm-based free-form
+
+Sources keyed by file path, with explicit `xy_mm` and `size_mm`.
+
+```python
+fig, axes = fr.compose(
+    canvas_size_mm=(180, 120),
+    sources={
+        "panel_a.yaml": {"xy_mm": (0, 0), "size_mm": (85, 55)},
+        "panel_b.yaml": {"xy_mm": (90, 0), "size_mm": (85, 55)},
+        "panel_c.yaml": {"xy_mm": (0, 60), "size_mm": (175, 55)},
+    },
+    panel_labels=True,
+)
+fr.save(fig, "composed_freeform.png")
+```
+
+`xy_mm` is `(left, top)` offset from canvas origin (top-left = (0, 0)).
+
+If `canvas_size_mm` is omitted, it is auto-calculated from the source extents + 5mm padding.
+
+## MCP tool: plt_compose
+
+```python
+# Grid-based via MCP
+result = plt_compose(
+    sources=["panel_a.png", "panel_b.png", "panel_c.png"],
+    output_path="figure.png",
+    layout="horizontal",     # "horizontal", "vertical", "grid"
+    gap_mm=5.0,
+    panel_labels=True,
+    label_style="uppercase",
+    dpi=300,
+    save_recipe=True,
+)
+# result: {"output_path": ..., "success": True, "layout_spec": ..., "recipe_path": ...}
+
+# Free-form mm-based via MCP
+result = plt_compose(
+    sources={
+        "panel_a.yaml": {"xy_mm": [0, 0], "size_mm": [80, 50]},
+        "panel_b.yaml": {"xy_mm": [90, 0], "size_mm": [80, 50]},
+    },
+    output_path="figure.png",
+    canvas_size_mm=[180, 60],
+)
+```
+
+`plt_compose` auto-converts list sources to mm-based positioning using `solve_layout_to_mm()`.
+
+## Alignment helpers
+
+```python
+import figrecipe as fr
+
+# Align panels to left/right/top/bottom/center
+fr.align_panels(axes, mode="left")      # AlignmentMode enum or string
+fr.align_panels(axes, mode="top")
+fr.align_panels(axes, mode="center_h")
+
+# Distribute panels with equal spacing
+fr.distribute_panels(axes, direction="horizontal")
+fr.distribute_panels(axes, direction="vertical")
+
+# Smart alignment: combine alignment + distribution
+fr.align_smart(axes, strategy="row_align")
+```
+
+## Visibility helpers
+
+```python
+from figrecipe._composition import hide_panel, show_panel, toggle_panel
+
+hide_panel(ax)     # hide a panel (invisible but retains layout space)
+show_panel(ax)     # show hidden panel
+toggle_panel(ax)   # toggle visibility
+```
+
+## Supported source formats
+
+Composition accepts: `.yaml`, `.yml` (recipe files), `.png`, `.jpg`, `.jpeg`, `.tiff`, `.bmp`, `.gif`, `.webp`, `.svg` (SVG requires `cairosvg`).
+
+## Composition figures auto-crop
+
+Figures created by `compose()` are automatically marked for 1mm-margin cropping when saved with `fr.save()`. No manual crop step needed.

--- a/src/figrecipe/_skills/figrecipe/cropping.md
+++ b/src/figrecipe/_skills/figrecipe/cropping.md
@@ -1,0 +1,85 @@
+---
+name: cropping
+description: Crop whitespace from figure images using mm or pixel margins. Requires Pillow (figrecipe[imaging]).
+---
+
+# Cropping
+
+Removes whitespace border from saved figure images, leaving only the content area with a specified margin.
+
+Requires: `pip install figrecipe[imaging]` (Pillow).
+
+## fr.crop()
+
+```python
+def crop(
+    input_path,
+    output_path=None,       # default: input with "_cropped" suffix
+    margin_mm=1.0,          # margin in millimeters (default: 1.0)
+    margin_px=None,         # margin in pixels (overrides margin_mm)
+    overwrite=False,        # overwrite input file in place
+    verbose=False,
+    return_offset=False,    # if True, return (path, offset_dict)
+) -> Path | Tuple[Path, dict]
+```
+
+## Examples
+
+```python
+import figrecipe as fr
+
+# Crop with default 1mm margin
+fr.crop("figure.png")
+# → figure_cropped.png
+
+# Specify output path
+fr.crop("figure.png", output_path="figure_tight.png")
+
+# Larger margin
+fr.crop("figure.pdf", margin_mm=3.0)
+
+# Pixel margin
+fr.crop("figure.png", margin_px=10)
+
+# Overwrite in place
+fr.crop("figure.png", overwrite=True)
+
+# Get crop offset metadata
+path, offset = fr.crop("figure.png", return_offset=True)
+# offset: {"left": N, "top": N, "right": N, "bottom": N}  (pixels)
+```
+
+## CLI: figrecipe crop
+
+```bash
+# Default 1mm margin
+figrecipe crop figure.png
+
+# Specify output
+figrecipe crop figure.png -o figure_tight.png
+
+# Custom margin in mm
+figrecipe crop figure.png --margin 2mm
+
+# Custom margin in pixels
+figrecipe crop figure.png --margin 10px
+
+# Overwrite in place
+figrecipe crop figure.png --overwrite
+```
+
+## MCP tool: plt_crop
+
+```python
+result = plt_crop(
+    input_path="figure.png",
+    output_path=None,       # optional; defaults to input + ".cropped" suffix
+    margin_mm=1.0,
+    overwrite=False,
+)
+# result: {"output_path": "figure.cropped.png", "success": True}
+```
+
+## Auto-crop on compose
+
+Figures created by `fr.compose()` are automatically marked for 1mm-margin cropping when saved. This happens transparently during `fr.save()` — no explicit crop call needed for composed figures.

--- a/src/figrecipe/_skills/figrecipe/diagram.md
+++ b/src/figrecipe/_skills/figrecipe/diagram.md
@@ -1,0 +1,90 @@
+---
+name: diagram
+description: Box-and-arrow diagram builder and Mermaid/Graphviz diagram compilation via fr.Diagram.
+---
+
+# Diagrams
+
+figrecipe supports two diagram types: box-and-arrow builders (Python API) and text-format diagrams (Mermaid and Graphviz).
+
+## fr.Diagram — Box-and-arrow builder
+
+```python
+import figrecipe as fr
+
+diagram = fr.Diagram()
+# Build diagram programmatically
+diagram.render("flow.png")
+```
+
+## Mermaid diagrams
+
+```python
+from figrecipe._diagram._mermaid.mermaid import Mermaid
+
+m = Mermaid("graph LR; A-->B; B-->C")
+m.render("flow.png")
+```
+
+## Graphviz diagrams
+
+```python
+from figrecipe._diagram._graphviz.graphviz import Graphviz
+
+g = Graphviz("digraph { A -> B -> C }")
+g.render("graph.png")
+```
+
+## Diagram presets
+
+```python
+from figrecipe._diagram import list_presets, get_preset
+
+presets = list_presets()
+# ["WORKFLOW", "DECISION", "PIPELINE", "SCIENTIFIC"]
+
+preset = get_preset("WORKFLOW")
+```
+
+## MCP tools
+
+| Tool | Purpose |
+|------|---------|
+| `plt_diagram_create` | Create diagram from spec dict |
+| `plt_diagram_render` | Render diagram to image |
+| `plt_diagram_compile_mermaid` | Compile Mermaid text to image |
+| `plt_diagram_compile_graphviz` | Compile Graphviz DOT to image |
+| `plt_diagram_list_presets` | List available diagram presets |
+| `plt_diagram_get_preset` | Get preset configuration |
+| `plt_diagram_get_backends` | List available render backends |
+| `plt_diagram_get_paper_modes` | List paper size modes |
+| `plt_diagram_split` | Split diagram across pages |
+
+## CLI: figrecipe diagram
+
+```bash
+# Render a Mermaid file
+figrecipe diagram render flow.mmd -o flow.png
+
+# Create from preset
+figrecipe diagram create --preset WORKFLOW
+
+# List available backends
+figrecipe diagram --help
+```
+
+## Diagram schema types
+
+```python
+from figrecipe._diagram import (
+    DiagramSpec,    # full diagram specification
+    NodeSpec,       # node definition
+    EdgeSpec,       # edge/arrow definition
+    DiagramType,    # "flowchart", "sequence", etc.
+    PaperMode,      # "A4", "letter", custom
+    SpacingLevel,   # "compact", "normal", "spacious"
+    ColumnLayout,   # column arrangement hints
+    LayoutHints,    # layout algorithm hints
+    PaperConstraints,
+)
+```

--- a/src/figrecipe/_skills/figrecipe/mcp-tools.md
+++ b/src/figrecipe/_skills/figrecipe/mcp-tools.md
@@ -1,0 +1,234 @@
+---
+name: mcp-tools
+description: figrecipe MCP tools for AI agents — creating, composing, cropping, validating, and extracting data from figures.
+---
+
+# MCP Tools
+
+All tools are prefixed `plt_` and available via the figrecipe MCP server.
+
+Start server: `figrecipe mcp start`
+
+## Core figure tools
+
+### plt_plot
+
+Create a matplotlib figure from a declarative specification dict.
+
+```python
+result = plt_plot(
+    spec={
+        "figure": {"width_mm": 80, "height_mm": 60, "style": "SCITEX"},
+        "plots": [
+            {"type": "line", "x": [1,2,3,4,5], "y": [1,4,9,16,25],
+             "color": "blue", "label": "quadratic"}
+        ],
+        "xlabel": "X",
+        "ylabel": "Y",
+        "title": "My Plot",
+    },
+    output_path="figure.png",
+    dpi=300,
+    save_recipe=True,
+)
+# result: {"image_path": "figure.png", "recipe_path": "figure.yaml", "success": True}
+```
+
+Full spec format: see `figrecipe://spec-schema` MCP resource.
+
+### plt_reproduce
+
+Reproduce a figure from a saved YAML recipe.
+
+```python
+result = plt_reproduce(
+    recipe_path="figure.yaml",
+    output_path=None,        # defaults to figure.reproduced.png
+    format="png",            # "png", "pdf", "svg"
+    dpi=300,
+)
+# result: {"output_path": "figure.reproduced.png", "success": True}
+```
+
+### plt_compose
+
+Compose multiple figures into one panel figure.
+
+```python
+# Grid-based (list sources)
+result = plt_compose(
+    sources=["panel_a.png", "panel_b.png", "panel_c.png"],
+    output_path="figure.png",
+    layout="horizontal",       # "horizontal", "vertical", "grid"
+    gap_mm=5.0,
+    panel_labels=True,
+    label_style="uppercase",   # "uppercase", "lowercase", "numeric"
+    dpi=300,
+    save_recipe=True,
+)
+
+# Free-form mm-based (dict sources)
+result = plt_compose(
+    sources={
+        "panel_a.yaml": {"xy_mm": [0, 0], "size_mm": [80, 50]},
+        "panel_b.yaml": {"xy_mm": [90, 0], "size_mm": [80, 50]},
+    },
+    output_path="figure.png",
+    canvas_size_mm=[180, 60],
+)
+# result: {"output_path": ..., "success": True, "layout_spec": ..., "recipe_path": ...}
+```
+
+## Image processing
+
+### plt_crop
+
+Crop whitespace from a figure image.
+
+```python
+result = plt_crop(
+    input_path="figure.png",
+    output_path=None,          # defaults to input + ".cropped" suffix
+    margin_mm=1.0,
+    overwrite=False,
+)
+# result: {"output_path": "figure.cropped.png", "success": True}
+```
+
+## Information and validation
+
+### plt_info
+
+Get metadata about a recipe file.
+
+```python
+result = plt_info(
+    recipe_path="figure.yaml",
+    verbose=False,
+)
+# result: dict with figure dimensions, axes count, call counts, etc.
+```
+
+### plt_validate
+
+Validate that a recipe can reproduce its original figure.
+
+```python
+result = plt_validate(
+    recipe_path="figure.yaml",
+    mse_threshold=100.0,
+)
+# result: {"valid": True, "mse": 0.5, "message": "...", "recipe_path": "..."}
+```
+
+### plt_extract_data
+
+Extract plotted data arrays from a recipe.
+
+```python
+result = plt_extract_data(recipe_path="figure.yaml")
+# result: {"call_id": {"x": [...], "y": [...]}, ...}
+# Arrays are serialized as lists for JSON compatibility
+```
+
+## Discovery
+
+### plt_get_plot_types
+
+```python
+result = plt_get_plot_types()
+# result: {
+#   "plot_types": ["line", "scatter", "bar", ...],
+#   "mapping": {"line": "plot", "scatter": "scatter", ...},
+#   "categories": {
+#     "line_curve": ["line", "plot", "step", ...],
+#     "scatter_points": ["scatter"],
+#     ...
+#   }
+# }
+```
+
+### plt_list_styles
+
+```python
+result = plt_list_styles()
+# result: {"presets": ["SCITEX", "SCITEX_DARK", "MATPLOTLIB", ...], "count": N}
+```
+
+## Per-type plot tools
+
+Individual tools for each standard matplotlib plot type. Accept `data_file` + column names or inline arrays.
+
+| Tool | Plot type |
+|------|-----------|
+| `plt_line` / `plt_plot` | Line plot |
+| `plt_scatter` | Scatter plot |
+| `plt_bar` | Vertical bar chart |
+| `plt_barh` | Horizontal bar chart |
+| `plt_hist` | Histogram |
+| `plt_hist2d` | 2D histogram |
+| `plt_boxplot` | Box plot |
+| `plt_violinplot` | Violin plot |
+| `plt_errorbar` | Error bar plot |
+| `plt_fill_between` | Filled band |
+| `plt_fill_betweenx` | Horizontal filled band |
+| `plt_stackplot` | Stacked area |
+| `plt_contour` | Contour lines |
+| `plt_contourf` | Filled contours |
+| `plt_imshow` | Image / heatmap |
+| `plt_pcolormesh` | 2D grid mesh |
+| `plt_pie` | Pie chart |
+| `plt_stem` | Stem plot |
+| `plt_stairs` | Stair/step plot |
+| `plt_hexbin` | Hexbin density |
+| `plt_quiver` | Vector field |
+| `plt_streamplot` | Flow streamlines |
+| `plt_ecdf` | Empirical CDF |
+| `plt_acorr` | Autocorrelation |
+| `plt_xcorr` | Cross-correlation |
+| `plt_psd` | Power spectral density |
+| `plt_csd` | Cross spectral density |
+| `plt_specgram` | Spectrogram |
+| `plt_cohere` | Coherence |
+
+## SciTeX scientific plot tools
+
+| Tool | Plot type |
+|------|-----------|
+| `plt_stx_line` | Styled line |
+| `plt_stx_shaded_line` | Line with error band |
+| `plt_stx_mean_std` | Mean ± std |
+| `plt_stx_mean_ci` | Mean with CI |
+| `plt_stx_median_iqr` | Median with IQR |
+| `plt_stx_violin` | Violin with points |
+| `plt_stx_scatter_hist` | Scatter + marginal histograms |
+| `plt_stx_heatmap` | Annotated heatmap |
+| `plt_stx_conf_mat` | Confusion matrix |
+| `plt_stx_raster` | Spike raster |
+| `plt_stx_ecdf` | ECDF (styled) |
+| `plt_stx_fillv` | Vertical fill regions |
+| `plt_stx_image` | Image with scale bar |
+| `plt_stx_rectangle` | Annotated rectangle |
+
+## Diagram tools
+
+| Tool | Purpose |
+|------|---------|
+| `plt_diagram_create` | Create from spec dict |
+| `plt_diagram_render` | Render to image |
+| `plt_diagram_compile_mermaid` | Compile Mermaid text |
+| `plt_diagram_compile_graphviz` | Compile Graphviz DOT |
+| `plt_diagram_list_presets` | List presets |
+| `plt_diagram_get_preset` | Get preset config |
+| `plt_diagram_get_backends` | List backends |
+| `plt_diagram_get_paper_modes` | List paper modes |
+| `plt_diagram_split` | Split across pages |
+
+## MCP Resources
+
+| Resource URI | Contents |
+|-------------|---------|
+| `figrecipe://spec-schema` | Full declarative spec format documentation |
+| `figrecipe://cheatsheet` | Quick reference |
+| `figrecipe://mcp-spec` | MCP tool specification format |
+| `figrecipe://api/core` | Full API documentation |

--- a/src/figrecipe/_skills/figrecipe/plot-types.md
+++ b/src/figrecipe/_skills/figrecipe/plot-types.md
@@ -1,0 +1,169 @@
+---
+name: plot-types
+description: All plot types supported in figrecipe declarative specs and MCP tools, with usage guidance.
+---
+
+# Plot Types Reference
+
+## Using plot types
+
+### Via Python API (direct)
+
+```python
+fig, ax = fr.subplots()
+ax.plot(x, y)           # any standard matplotlib method works
+ax.scatter(x, y)
+ax.bar(categories, values)
+```
+
+### Via declarative spec (plt_plot MCP tool or figrecipe plot CLI)
+
+```yaml
+figure:
+  width_mm: 80
+  height_mm: 60
+  style: SCITEX
+plots:
+  - type: line
+    x: [1, 2, 3, 4, 5]
+    y: [1, 4, 9, 16, 25]
+    color: blue
+    label: "data"
+xlabel: "X"
+ylabel: "Y"
+title: "My Plot"
+```
+
+## Line / Curve
+
+| Type | matplotlib method | Use when |
+|------|-------------------|----------|
+| `line` | `plot` | Time series, trends |
+| `plot` | `plot` | Same as line |
+| `step` | `step` | Step functions, histograms |
+| `fill` | `fill` | Filled polygon areas |
+| `fill_between` | `fill_between` | Confidence bands, ranges |
+| `fill_betweenx` | `fill_betweenx` | Horizontal confidence bands |
+| `errorbar` | `errorbar` | Data with uncertainty |
+| `loglog` | `loglog` | Both axes log-scale |
+| `semilogx` | `semilogx` | X-axis log-scale |
+| `semilogy` | `semilogy` | Y-axis log-scale |
+
+## Scatter / Points
+
+| Type | matplotlib method | Use when |
+|------|-------------------|----------|
+| `scatter` | `scatter` | Two continuous variables |
+| `hexbin` | `hexbin` | Large scatter → density |
+
+## Bar / Categorical
+
+| Type | matplotlib method | Use when |
+|------|-------------------|----------|
+| `bar` | `bar` | Category comparison (vertical) |
+| `barh` | `barh` | Category comparison (horizontal) |
+
+## Distribution
+
+| Type | matplotlib method | Use when |
+|------|-------------------|----------|
+| `hist` | `hist` | Single variable distribution |
+| `hist2d` | `hist2d` | Joint distribution of two variables |
+| `boxplot` / `box` | `boxplot` | Distribution comparison |
+| `violinplot` / `violin` | `violinplot` | Distribution shape comparison |
+| `ecdf` | `ecdf` | Empirical CDF |
+| `stairs` | `stairs` | Step function / histogram |
+| `stackplot` | `stackplot` | Cumulative stacked area |
+
+## Image / Matrix
+
+| Type | matplotlib method | Use when |
+|------|-------------------|----------|
+| `imshow` / `heatmap` | `imshow` | Images, heatmaps, 2D arrays |
+| `matshow` | `matshow` | Matrix visualization |
+| `pcolormesh` | `pcolormesh` | Non-uniform 2D grids |
+| `pcolor` | `pcolor` | Non-uniform 2D grids (slower) |
+| `contour` | `contour` | 2D scalar field contour lines |
+| `contourf` | `contourf` | 2D scalar field filled contours |
+| `spy` | `spy` | Sparse matrix sparsity pattern |
+
+## Special
+
+| Type | matplotlib method | Use when |
+|------|-------------------|----------|
+| `pie` | `pie` | Part-of-whole proportions |
+| `stem` | `stem` | Discrete signals |
+| `eventplot` | `eventplot` | Event sequences |
+
+## Vector fields
+
+| Type | matplotlib method | Use when |
+|------|-------------------|----------|
+| `quiver` | `quiver` | Arrow/vector fields |
+| `streamplot` | `streamplot` | Flow streamlines |
+
+## Correlation
+
+| Type | matplotlib method | Use when |
+|------|-------------------|----------|
+| `acorr` | `acorr` | Autocorrelation |
+| `xcorr` | `xcorr` | Cross-correlation |
+
+## Spectral analysis
+
+| Type | matplotlib method | Use when |
+|------|-------------------|----------|
+| `psd` | `psd` | Power spectral density |
+| `csd` | `csd` | Cross spectral density |
+| `specgram` | `specgram` | Spectrogram |
+| `cohere` | `cohere` | Coherence between signals |
+| `magnitude_spectrum` | `magnitude_spectrum` | Frequency magnitude |
+| `phase_spectrum` | `phase_spectrum` | Frequency phase |
+| `angle_spectrum` | `angle_spectrum` | Angle spectrum |
+
+## SciTeX scientific plots
+
+These are provided by the scitex/figrecipe scientific plot library. Available as `stx_*` or `fr_*` prefix.
+
+| Type | MCP tool | Use when |
+|------|----------|----------|
+| `stx_line` | `plt_stx_line` | Styled line plot |
+| `stx_shaded_line` | `plt_stx_shaded_line` | Line with shaded error band |
+| `stx_mean_std` | `plt_stx_mean_std` | Mean ± standard deviation |
+| `stx_mean_ci` | `plt_stx_mean_ci` | Mean with confidence interval |
+| `stx_median_iqr` | `plt_stx_median_iqr` | Median with IQR |
+| `stx_violin` | `plt_stx_violin` | Violin with individual points |
+| `stx_scatter_hist` | `plt_stx_scatter_hist` | Scatter with marginal histograms |
+| `stx_heatmap` | `plt_stx_heatmap` | Annotated heatmap |
+| `stx_conf_mat` | `plt_stx_conf_mat` | Confusion matrix |
+| `stx_raster` | `plt_stx_raster` | Spike raster plot |
+| `stx_ecdf` | `plt_stx_ecdf` | Empirical CDF (styled) |
+| `stx_fillv` | `plt_stx_fillv` | Vertical fill regions |
+| `stx_image` | `plt_stx_image` | Image with scale bar |
+| `stx_rectangle` | `plt_stx_rectangle` | Annotated rectangle regions |
+
+## CSV column data in specs
+
+Instead of inline arrays, reference columns from a CSV file:
+
+```yaml
+plots:
+  - type: scatter
+    data_file: experiment.csv  # path to CSV
+    x: time                    # column name
+    y: temperature             # column name
+    color: red
+```
+
+## Choosing the right plot
+
+| Goal | Recommended types |
+|------|------------------|
+| Show one variable distribution | `hist`, `ecdf`, `boxplot`, `violinplot` |
+| Compare two continuous variables | `scatter`, `line`, `hexbin` |
+| Compare groups/categories | `bar`, `barh`, `boxplot`, `violinplot` |
+| Show time series | `line`, `fill_between`, `stackplot` |
+| Show 2D field data | `contour`, `contourf`, `pcolormesh`, `imshow` |
+| Statistical summary with error | `stx_mean_ci`, `stx_mean_std`, `stx_median_iqr` |
+| Neuroscience / EEG | `stx_raster`, `specgram`, `psd`, `cohere` |
+| Confusion matrix / classification | `stx_conf_mat`, `stx_heatmap` |

--- a/src/figrecipe/_skills/figrecipe/quick-start.md
+++ b/src/figrecipe/_skills/figrecipe/quick-start.md
@@ -1,0 +1,136 @@
+---
+name: quick-start
+description: Core figrecipe workflow — creating figures, saving YAML recipes, and reproducing them exactly.
+---
+
+# Quick Start
+
+## Core workflow
+
+```python
+import figrecipe as fr
+import numpy as np
+
+# 1. Create figure with recording-enabled axes
+fig, ax = fr.subplots(
+    axes_width_mm=80,    # axes width in mm
+    axes_height_mm=60,   # axes height in mm
+)
+
+# 2. Plot — all calls are recorded automatically
+x = np.linspace(0, 10, 100)
+ax.plot(x, np.sin(x), color="red", label="sin", id="sine_wave")
+ax.set_xlabel("Time (s)")
+ax.set_ylabel("Amplitude")
+ax.legend()
+
+# 3. Save — creates figure.png + figure.yaml + figure_data/
+fr.save(fig, "figure.png")
+
+# 4. Reproduce exactly from recipe
+fig2, ax2 = fr.reproduce("figure.yaml")
+```
+
+## fr.subplots()
+
+```python
+def subplots(
+    nrows: int = 1,
+    ncols: int = 1,
+    axes_width_mm: Optional[float] = None,
+    axes_height_mm: Optional[float] = None,
+    margin_left_mm: Optional[float] = None,
+    margin_right_mm: Optional[float] = None,
+    margin_bottom_mm: Optional[float] = None,
+    margin_top_mm: Optional[float] = None,
+    space_w_mm: Optional[float] = None,
+    space_h_mm: Optional[float] = None,
+    style: Optional[dict] = None,
+    apply_style_mm: bool = True,
+    panel_labels: Optional[bool] = None,
+    **kwargs,            # passed to plt.subplots()
+) -> Tuple[RecordingFigure, RecordingAxes | ndarray]
+```
+
+Drop-in replacement for `plt.subplots()`. All mm parameters are optional; omit for matplotlib defaults.
+
+## fr.save()
+
+```python
+def save(
+    fig,
+    path: str | Path,         # .png, .pdf, .svg, .yaml, etc.
+    save_recipe: bool = True, # save .yaml recipe alongside image
+    include_data: bool = True,
+    data_format: str = "csv", # "csv", "npz", or "inline"
+    csv_format: str = "separate",  # "separate" or "single"
+    validate: bool = True,
+    validate_mse_threshold: float = 100.0,
+    validate_error_level: str = "error",
+    verbose: bool = True,
+    dpi: Optional[int] = None,
+    image_format: Optional[str] = None,
+    facecolor: Optional[str] = None,
+    save_hitmap: bool = True,
+) -> Tuple[Path, Path | None, ValidationResult | None]
+```
+
+Returns `(image_path, yaml_path, validation_result)`.
+
+## fr.reproduce()
+
+```python
+def reproduce(
+    path: str | Path,
+    calls: Optional[list[str]] = None,  # reproduce only these call IDs
+    skip_decorations: bool = False,
+    apply_style: bool = True,
+) -> Tuple[Figure, Axes | list[Axes]]
+```
+
+Accepts `.yaml`, `.yml`, image paths (loads `.yaml` sibling), bundle directories, and `.zip` bundles.
+
+`fr.load` is an alias for `fr.reproduce`.
+
+## fr.info()
+
+```python
+fr.info("figure.yaml")
+# Returns dict with figure dimensions, axes count, call counts, etc.
+```
+
+## fr.extract_data()
+
+```python
+data = fr.extract_data("figure.yaml")
+# Returns {call_id: {"x": array, "y": array, ...}}
+```
+
+## fr.validate()
+
+```python
+result = fr.validate("figure.yaml", mse_threshold=100.0)
+# result.valid, result.mse, result.message
+```
+
+## Multi-axes example
+
+```python
+fig, axes = fr.subplots(nrows=2, ncols=3, axes_width_mm=55, axes_height_mm=45)
+
+for i, ax in enumerate(axes.flat):
+    ax.scatter(x, y + i, s=5, id=f"data_{i}")
+
+fr.save(fig, "multi_panel.png")
+```
+
+## call id parameter
+
+Every plotting call accepts an optional `id` kwarg for traceability:
+
+```python
+ax.plot(x, y, id="my_trace")         # named trace
+ax.bar(categories, values, id="bars")
+```
+
+IDs appear in the YAML recipe and are used by `extract_data()` and `reproduce(calls=[...])`.

--- a/src/figrecipe/_skills/figrecipe/styles.md
+++ b/src/figrecipe/_skills/figrecipe/styles.md
@@ -1,0 +1,101 @@
+---
+name: styles
+description: Figure style presets — loading, applying, and customizing SCITEX/MATPLOTLIB styles and dark themes.
+---
+
+# Styles
+
+## fr.load_style()
+
+```python
+def load_style(
+    style="SCITEX",      # preset name, path to YAML, None/False to unload
+    dark=False,          # apply dark theme transformation
+    background=None,     # override background: "white", "transparent", etc.
+) -> DotDict | None
+```
+
+After calling `load_style()`, subsequent `fr.subplots()` calls automatically use the loaded style.
+
+## Built-in presets
+
+| Preset | Description |
+|--------|-------------|
+| `"SCITEX"` / `"FIGRECIPE"` | Scientific publication style (default) |
+| `"SCITEX_DARK"` / `"FIGRECIPE_DARK"` | Dark variant |
+| `"MATPLOTLIB"` | Vanilla matplotlib defaults |
+
+```python
+import figrecipe as fr
+
+# Scientific publication style (default)
+fr.load_style()
+fr.load_style("SCITEX")  # explicit
+
+# Dark theme
+fr.load_style("SCITEX_DARK")
+fr.load_style("SCITEX", dark=True)  # equivalent
+
+# Opaque white background (default is transparent)
+fr.load_style("SCITEX", background="white")
+
+# Vanilla matplotlib
+fr.load_style("MATPLOTLIB")
+fr.load_style(None)   # unload (same as MATPLOTLIB)
+fr.load_style(False)  # unload
+```
+
+## fr.unload_style()
+
+```python
+fr.unload_style()
+# Resets to matplotlib defaults; next subplots() is unstyled
+```
+
+## fr.list_presets()
+
+```python
+presets = fr.list_presets()
+# Returns list of available preset names
+```
+
+## CLI: figrecipe style
+
+```bash
+figrecipe style list              # list all presets
+figrecipe style show SCITEX       # show SCITEX style details
+figrecipe style apply SCITEX      # apply style globally
+figrecipe style reset             # reset to matplotlib defaults
+```
+
+## MCP: plt_list_styles
+
+```python
+result = plt_list_styles()
+# result: {"presets": ["SCITEX", "SCITEX_DARK", "MATPLOTLIB", ...], "count": N}
+```
+
+## Custom style from YAML
+
+```python
+fr.load_style("/path/to/my_style.yaml")
+```
+
+## Accessing style values
+
+```python
+style = fr.load_style("SCITEX")
+style.axes.width_mm   # 40 (default axes width)
+style.axes.height_mm
+style.fonts.size
+```
+
+## Style in declarative spec
+
+```yaml
+figure:
+  width_mm: 80
+  height_mm: 60
+  style: SCITEX          # applied before plotting
+  facecolor: white       # optional opaque background
+```

--- a/src/figrecipe/_skills/figrecipe/workflows.md
+++ b/src/figrecipe/_skills/figrecipe/workflows.md
@@ -1,0 +1,15 @@
+---
+name: workflows
+description: Common figrecipe workflows — redirects to focused sub-skill files.
+---
+
+# Common Workflows
+
+See the focused sub-skill files for accurate, source-verified content:
+
+- [quick-start.md](quick-start.md) — Core workflow: subplots, save, reproduce
+- [plot-types.md](plot-types.md) — All plot types with examples
+- [composition.md](composition.md) — Multi-panel figure composition
+- [cropping.md](cropping.md) — Figure cropping
+- [styles.md](styles.md) — Style presets
+- [diagram.md](diagram.md) — Diagrams (Mermaid, Graphviz)


### PR DESCRIPTION
## Summary
- Add `_skills/<pkg>/` directory with non-monolith skills layout
- SKILL.md is index-only with links to focused sub-skill files
- Each sub-skill verified against actual source code
- pyproject.toml force-include for wheel bundling
- Real files (no symlinks)

## Test plan
- [ ] Verify `_skills/` directory exists in installed package
- [ ] Verify SKILL.md links resolve correctly
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)