### PR TITLE
feat(skills): add 21_scientific-figure-patterns

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,62 @@
+name: Install Test (fresh venv)
+
+# Catches undeclared runtime deps that the package's own test suite misses.
+# A package can build, upload, and pass its own tests with the wrong
+# pyproject.toml — the bug only shows up when a fresh user runs
+# `pip install <pkg>` in a clean venv. This job reproduces that path.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+jobs:
+  install-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+
+      - name: Install + import in a fresh venv
+        run: |
+          python -m venv /tmp/clean-venv
+          /tmp/clean-venv/bin/pip install --upgrade pip
+          /tmp/clean-venv/bin/pip install dist/*.whl
+          # Import the package — fails on the first undeclared dep.
+          # Replace IMPORT_NAME if pyproject `[project].name` differs from
+          # the source layout (e.g. scitex-foo → scitex_foo).
+          PKG_NAME=$(python -c "import tomllib, sys; sys.stdout.write(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
+          IMPORT_NAME="${PKG_NAME//-/_}"
+          /tmp/clean-venv/bin/python -c "import ${IMPORT_NAME}; print(f'OK: {${IMPORT_NAME}.__name__}')"
+
+      - name: Audit declared deps vs actual imports (if scitex-dev available)
+        # Optional secondary check using scitex_dev.audit_dependencies(). Only
+        # runs if the runner has scitex-dev installed; non-fatal otherwise.
+        run: |
+          /tmp/clean-venv/bin/pip install scitex-dev || true
+          /tmp/clean-venv/bin/python -c "
+          try:
+              from scitex_dev import audit_dependencies
+          except ImportError:
+              print('scitex-dev not available; skipping audit')
+              import sys; sys.exit(0)
+          rep = audit_dependencies('.')
+          print(rep)
+          import sys
+          sys.exit(0 if rep.is_clean else 1)
+          "

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -37,23 +37,31 @@ jobs:
           python -m venv /tmp/clean-venv
           /tmp/clean-venv/bin/pip install --upgrade pip
           /tmp/clean-venv/bin/pip install dist/*.whl
-          # Import the package — fails on the first undeclared dep.
-          # Replace IMPORT_NAME if pyproject `[project].name` differs from
-          # the source layout (e.g. scitex-foo → scitex_foo).
-          PKG_NAME=$(python -c "import tomllib, sys; sys.stdout.write(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
-          IMPORT_NAME="${PKG_NAME//-/_}"
+          # Detect import name from src/ layout (the only directory under
+          # src/ that contains __init__.py). Works on every supported Python
+          # without needing tomllib (3.11+) or tomli (extra dep).
+          IMPORT_NAME=$(find src -maxdepth 2 -name __init__.py -printf '%h\n' \
+                          | head -1 | xargs -n1 basename)
+          if [ -z "$IMPORT_NAME" ]; then
+              echo "Could not detect import name under src/" >&2
+              exit 1
+          fi
+          echo "Importing $IMPORT_NAME ..."
           /tmp/clean-venv/bin/python -c "import ${IMPORT_NAME}; print(f'OK: {${IMPORT_NAME}.__name__}')"
 
-      - name: Audit declared deps vs actual imports (if scitex-dev available)
-        # Optional secondary check using scitex_dev.audit_dependencies(). Only
-        # runs if the runner has scitex-dev installed; non-fatal otherwise.
+      - name: Audit declared deps vs actual imports (best-effort)
+        # Secondary check using scitex_dev.audit_dependencies(). Non-fatal:
+        # skipped if scitex-dev isn't yet available on PyPI for this Python.
+        continue-on-error: true
         run: |
-          /tmp/clean-venv/bin/pip install scitex-dev || true
+          /tmp/clean-venv/bin/pip install scitex-dev 2>/dev/null || (
+              echo "scitex-dev not installable on this Python; skipping"
+              exit 0
+          )
           /tmp/clean-venv/bin/python -c "
           try:
               from scitex_dev import audit_dependencies
           except ImportError:
-              print('scitex-dev not available; skipping audit')
               import sys; sys.exit(0)
           rep = audit_dependencies('.')
           print(rep)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install package + dev deps
+      - name: Install package + dev deps + test plugins
         run: |
           pip install --upgrade pip
+          pip install pytest pytest-cov pytest-timeout
           pip install -e ".[dev]" || pip install -e .
       - name: Detect import name
         id: pkg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,68 +1,45 @@
-name: Tests
+name: Test
 
 on:
   push:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
-
   schedule:
     - cron: "0 7 * * *"  # nightly 07:00 UTC
   workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install system fonts (Arial, etc.)
+      - name: Install package + dev deps
         run: |
-          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
-          sudo apt-get update
-          sudo apt-get install -y ttf-mscorefonts-installer fontconfig
-          sudo fc-cache -f -v
-          # Clear matplotlib font cache
-          rm -rf ~/.cache/matplotlib
-
-      - name: Install dependencies
+          pip install --upgrade pip
+          pip install -e ".[dev]" || pip install -e .
+      - name: Detect import name
+        id: pkg
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[all]"
-
-      - name: Install Playwright browsers
+          IMPORT_NAME=$(find src -maxdepth 2 -name __init__.py -printf '%h\n' | head -1 | xargs -n1 basename)
+          echo "import_name=${IMPORT_NAME}" >> "$GITHUB_OUTPUT"
+      - name: Run tests with coverage
         run: |
-          playwright install chromium
-
-      - name: Run unit tests
-        run: |
-          pytest tests/ -v --tb=short --ignore=tests/editor --ignore=tests/test_pixel_perfect.py \
-            ${{ matrix.python-version == '3.12' && '--cov --cov-report=term-missing' || '' }}
-
-      - name: Run pixel-perfect reproduction tests
-        run: |
-          pytest tests/test_pixel_perfect.py -n auto -v --tb=short
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+          python -m pytest "$GITHUB_WORKSPACE/tests/" -v --tb=short --timeout=120 \
+            --cov=src/${{ steps.pkg.outputs.import_name }} \
+            --cov-report=xml --cov-report=term
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
         with:
-          python-version: "3.11"
-
-      - name: Install ruff
-        run: pip install ruff
-
-      - name: Run ruff
-        run: ruff check src/
+          files: coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 # FigRecipe (<code>scitex-plt</code>)
 
+<!-- scitex-badges:start -->
+[![PyPI](https://img.shields.io/pypi/v/figrecipe.svg)](https://pypi.org/project/figrecipe/)
+[![Python](https://img.shields.io/pypi/pyversions/figrecipe.svg)](https://pypi.org/project/figrecipe/)
+[![Tests](https://github.com/ywatanabe1989/figrecipe/actions/workflows/test.yml/badge.svg)](https://github.com/ywatanabe1989/figrecipe/actions/workflows/test.yml)
+[![Install Test](https://github.com/ywatanabe1989/figrecipe/actions/workflows/install-test.yml/badge.svg)](https://github.com/ywatanabe1989/figrecipe/actions/workflows/install-test.yml)
+[![Coverage](https://codecov.io/gh/ywatanabe1989/figrecipe/graph/badge.svg)](https://codecov.io/gh/ywatanabe1989/figrecipe)
+[![Docs](https://readthedocs.org/projects/figrecipe/badge/?version=latest)](https://figrecipe.readthedocs.io/en/latest/)
+[![License: AGPL v3](https://img.shields.io/badge/license-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+<!-- scitex-badges:end -->
+
+
 <p align="center">
   <a href="https://scitex.ai">
     <img src="docs/scitex-logo-blue-cropped.png" alt="SciTeX" width="400">
@@ -26,6 +37,8 @@
 </p>
 
 ---
+
+> **Interfaces:** Python ⭐⭐⭐ · CLI ⭐ · MCP ⭐⭐⭐ · Skills ⭐⭐ · Hook — · HTTP —
 
 ## Problem and Solution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
+    "pandas",
     "scitex-app>=0.1.0",
     "matplotlib>=3.5.0",
     "numpy>=1.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
+    "scitex-app>=0.1.0",
     "matplotlib>=3.5.0",
     "numpy>=1.20.0",
     "ruamel.yaml>=0.17.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,35 +47,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-    "pytest-xdist>=3.0.0",
-    "pre-commit>=3.5.0",
-    "pyyaml>=6.0.0",
-    "scitex-dev>=0.7.0",
-]
-imaging = [
-    "Pillow>=9.0.0",
-]
-seaborn = [
-    "seaborn>=0.12.0",
-    "pandas>=1.3.0",
-]
-scitex = [
-    "scitex",
-    "scitex-app>=0.1.0",
-    "scitex-ui>=0.1.0",
-]
-editor = [
-    "django>=4.2.0",
-    "Pillow>=9.0.0",
-]
 app = [
     "django>=4.2.0",
     "Pillow>=9.0.0",
     "scitex-app>=0.1.0",
     "scitex-ui>=0.1.0",
+]
+demo = [
+    "playwright>=1.40.0",
+    "pytesseract>=0.3.0",
 ]
 desktop = [
     "django>=4.2.0",
@@ -85,9 +65,9 @@ desktop = [
     "PyQt6>=6.0.0",
     "PyQt6-WebEngine>=6.0.0",
 ]
-demo = [
-    "playwright>=1.40.0",
-    "pytesseract>=0.3.0",
+editor = [
+    "django>=4.2.0",
+    "Pillow>=9.0.0",
 ]
 graph = [
     "networkx>=3.0",
@@ -96,6 +76,29 @@ graph-interactive = [
     "networkx>=3.0",
     "pyvis>=0.3",
 ]
+imaging = [
+    "Pillow>=9.0.0",
+]
+mcp = [
+    "fastmcp>=2.0",
+]
+scitex = [
+    "scitex",
+    "scitex-app>=0.1.0",
+    "scitex-ui>=0.1.0",
+]
+seaborn = [
+    "seaborn>=0.12.0",
+    "pandas>=1.3.0",
+]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-xdist>=3.0.0",
+    "pre-commit>=3.5.0",
+    "pyyaml>=6.0.0",
+    "scitex-dev>=0.7.0",
+]
 docs = [
     "sphinx>=7.0",
     "sphinx-rtd-theme>=2.0",
@@ -103,19 +106,17 @@ docs = [
     "sphinx-copybutton>=0.5",
     "sphinx-autodoc-typehints>=1.25",
 ]
-mcp = [
-    "fastmcp>=2.0",
-]
 all = [
-    "figrecipe[dev,docs,graph-interactive,mcp]",
-    "pyyaml>=6.0.0",
-    "Pillow>=9.0.0",
-    "seaborn>=0.12.0",
-    "pandas>=1.3.0",
-    "django>=4.2.0",
-    "pywebview>=4.0.0",
-    "playwright>=1.40.0",
-    "pytesseract>=0.3.0",
+    "figrecipe[app]",
+    "figrecipe[demo]",
+    "figrecipe[desktop]",
+    "figrecipe[editor]",
+    "figrecipe[graph]",
+    "figrecipe[graph-interactive]",
+    "figrecipe[imaging]",
+    "figrecipe[mcp]",
+    "figrecipe[scitex]",
+    "figrecipe[seaborn]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.28.1"
+version = "0.28.2"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0"

--- a/src/figrecipe/_cli/_completion.py
+++ b/src/figrecipe/_cli/_completion.py
@@ -126,7 +126,7 @@ def install_completion(shell: str) -> None:
     click.echo(f"\nReload your shell or run: source {rc_file}")
 
 
-@completion.command("status")
+@completion.command("show-status")
 @click.option(
     "--shell",
     type=click.Choice(SHELLS),
@@ -144,19 +144,36 @@ def status_completion(shell: str) -> None:
         click.echo(f"{sh:8} {status:16} ({rc_file})")
 
 
-@completion.command("bash")
-def bash_completion() -> None:
-    """Show bash completion script."""
-    click.echo(_get_completion_script("bash"))
+@completion.command("print-script")
+@click.option(
+    "--shell",
+    type=click.Choice(SHELLS),
+    default="bash",
+    help="Target shell. Default: bash.",
+)
+def print_script(shell: str) -> None:
+    """Print the completion script for the chosen shell to stdout."""
+    click.echo(_get_completion_script(shell))
 
 
-@completion.command("zsh")
-def zsh_completion() -> None:
-    """Show zsh completion script."""
-    click.echo(_get_completion_script("zsh"))
+# Hidden deprecation redirects for the old per-shell leaf names
+for _sh in SHELLS:
 
+    def _make_dep(old_shell: str):
+        @click.pass_context
+        def _impl(ctx, **_):
+            click.echo(
+                f"error: `figrecipe completion {old_shell}` was renamed to "
+                f"`figrecipe completion print-script --shell {old_shell}`.\n"
+                f"Re-run with: figrecipe completion print-script --shell {old_shell}",
+                err=True,
+            )
+            ctx.exit(2)
 
-@completion.command("fish")
-def fish_completion() -> None:
-    """Show fish completion script."""
-    click.echo(_get_completion_script("fish"))
+        return click.command(
+            old_shell,
+            hidden=True,
+            context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+        )(_impl)
+
+    completion.add_command(_make_dep(_sh))

--- a/src/figrecipe/_cli/_diagram.py
+++ b/src/figrecipe/_cli/_diagram.py
@@ -119,7 +119,7 @@ def convert(input: str, output: str, output_format: Optional[str]):
     console.print(f"[green]✓[/green] Converted: {input_path} → {output_path}")
 
 
-@diagram.command("info")
+@diagram.command("show-info")
 @click.argument("path", type=click.Path(exists=True))
 def info(path: str):
     """Show information about a diagram file.
@@ -151,7 +151,7 @@ def info(path: str):
     )
 
 
-@diagram.command("presets")
+@diagram.command("list-presets")
 def presets():
     """List available diagram presets."""
     from .._diagram import list_presets as list_diagram_presets
@@ -268,7 +268,7 @@ def render(
         raise SystemExit(1)
 
 
-@diagram.command("backends")
+@diagram.command("list-backends")
 def backends():
     """Show available rendering backends and their status."""
     from .._diagram._shared._render import get_available_backends

--- a/src/figrecipe/_cli/_main.py
+++ b/src/figrecipe/_cli/_main.py
@@ -31,11 +31,11 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 # Command categories for organized help display
 COMMAND_CATEGORIES = [
-    ("Figure Creation", ["plot", "reproduce", "compose", "gui"]),
-    ("Image Processing", ["convert", "crop", "diff", "hitmap"]),
-    ("Data & Validation", ["extract", "validate", "info"]),
+    ("Figure Creation", ["plot", "reproduce-figure", "compose-figures", "start-gui"]),
+    ("Image Processing", ["convert-figure", "crop", "diff-figures", "generate-hitmap"]),
+    ("Data & Validation", ["extract", "validate-figure", "show-info"]),
     ("Diagram", ["diagram"]),
-    ("Style & Appearance", ["style", "fonts"]),
+    ("Style & Appearance", ["style", "list-fonts"]),
     ("Integration", ["mcp", "list-python-apis"]),
     ("Utility", ["completion", "version"]),
 ]
@@ -131,25 +131,76 @@ def _show_recursive_help(ctx: click.Context) -> None:
         _print_command_help(cmd, f"figrecipe {name}", ctx)
 
 
-# Register commands
+# ── Renames (noun-verb convention per general/03_interface_02_cli.md §1) ──
 
-main.add_command(completion)
+
+def _dep(old: str, new: str):
+    """Hidden top-level redirect: `<old>` → `<new>`."""
+
+    @click.pass_context
+    def _impl(ctx, **_):
+        click.echo(
+            f"error: `figrecipe {old}` was renamed to `figrecipe {new}`.\n"
+            f"Re-run with: figrecipe {new} [...]",
+            err=True,
+        )
+        ctx.exit(2)
+
+    return click.command(
+        old,
+        hidden=True,
+        context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+    )(_impl)
+
+
+# Register commands with noun-verb-compliant names + hidden deprecations
+# Bare-verb → compound-leaf renames
+compose.name = "compose-figures"
 main.add_command(compose)
+main.add_command(_dep("compose", "compose-figures"))
+
+convert.name = "convert-figure"
 main.add_command(convert)
+main.add_command(_dep("convert", "convert-figure"))
+
+diff.name = "diff-figures"
+main.add_command(diff)
+main.add_command(_dep("diff", "diff-figures"))
+
+reproduce.name = "reproduce-figure"
+main.add_command(reproduce)
+main.add_command(_dep("reproduce", "reproduce-figure"))
+
+validate.name = "validate-figure"
+main.add_command(validate)
+main.add_command(_dep("validate", "validate-figure"))
+
+# Bare-noun → verb-noun compound leaves
+fonts.name = "list-fonts"
+main.add_command(fonts)
+main.add_command(_dep("fonts", "list-fonts"))
+
+gui.name = "start-gui"
+main.add_command(gui)
+main.add_command(_dep("gui", "start-gui"))
+
+hitmap.name = "generate-hitmap"
+main.add_command(hitmap)
+main.add_command(_dep("hitmap", "generate-hitmap"))
+
+info.name = "show-info"
+main.add_command(info)
+main.add_command(_dep("info", "show-info"))
+
+# Unchanged commands
+main.add_command(completion)
 main.add_command(crop)
 main.add_command(_diagram_cmd, name="diagram")
-main.add_command(diff)
 main.add_command(extract)
-main.add_command(fonts)
-main.add_command(gui)
-main.add_command(hitmap)
-main.add_command(info)
 main.add_command(list_python_apis)
 main.add_command(mcp)
 main.add_command(plot)
-main.add_command(reproduce)
 main.add_command(style)
-main.add_command(validate)
 main.add_command(version_cmd)
 
 try:

--- a/src/figrecipe/_cli/_mcp.py
+++ b/src/figrecipe/_cli/_mcp.py
@@ -337,8 +337,8 @@ def install(claude_code: bool) -> None:
         click.echo("   figrecipe mcp doctor")
 
 
-@mcp.command("info")
-def info() -> None:
+@mcp.command("show-info")
+def show_info() -> None:
     """Show MCP server information."""
     try:
         from .._mcp.server import mcp as mcp_server

--- a/src/figrecipe/_scitex_compat/_csv_column_naming.py
+++ b/src/figrecipe/_scitex_compat/_csv_column_naming.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+# Timestamp: 2025-12-08
+# File: ./src/scitex/plt/utils/_csv_column_naming.py
+
+"""
+Single source of truth for CSV column naming in scitex.
+
+This module ensures consistent column naming between:
+- CSV export (_export_as_csv)
+- JSON metadata (_collect_figure_metadata)
+- GUI editors (reading CSV data back)
+- figrecipe compatibility
+
+Column naming convention (figrecipe-compatible):
+    r{row}c{col}_{caller}-{id}_{var}
+
+Where:
+    - r{row}c{col}: axes position in grid (e.g., r0c0, r1c2)
+    - {caller}: plotting method name (e.g., plot, scatter, bar)
+    - {id}: user-provided id kwarg OR auto-generated per-method counter
+    - {var}: variable name (e.g., x, y, bins, heights)
+
+Examples:
+    r0c0_plot-0_x        (row 0, col 0, plot method, auto-id 0, x variable)
+    r0c0_plot-sine_y     (row 0, col 0, plot method, id "sine", y variable)
+    r0c1_scatter-0_x     (row 0, col 1, scatter method, auto-id 0, x)
+    r1c0_bar-sales_height (row 1, col 0, bar method, id "sales", height)
+
+Legacy format (still supported for parsing):
+    ax-row-{row}-col-{col}_trace-id-{id}_variable-{var}
+"""
+
+import re
+
+__all__ = [
+    "get_csv_column_name",
+    "get_csv_column_prefix",
+    "parse_csv_column_name",
+    "sanitize_id",
+    "get_unique_trace_id",
+]
+
+
+def sanitize_id(raw_id: str) -> str:
+    """Sanitize ID for use in CSV column names.
+
+    Removes or replaces characters that could cause issues in column names.
+    Uses hyphen (-) for word separation within values.
+
+    Parameters
+    ----------
+    raw_id : str
+        Raw identifier (label, id kwarg, or generated)
+
+    Returns
+    -------
+    str
+        Sanitized ID safe for CSV column names
+
+    Examples
+    --------
+    >>> sanitize_id("sin(x)")
+    'sin-x'
+    >>> sanitize_id("My Data")
+    'my-data'
+    >>> sanitize_id("hello_world")
+    'hello-world'
+    """
+    if not raw_id:
+        return "0"
+
+    # Replace problematic characters with hyphen
+    sanitized = str(raw_id).lower()
+    result = []
+    for char in sanitized:
+        if char.isalnum():
+            result.append(char)
+        elif char in (" ", "_", "(", ")", "[", "]", "{", "}", "/", "\\", ".", "-"):
+            result.append("-")
+        # Skip other characters
+
+    sanitized = "".join(result)
+
+    # Remove consecutive hyphens
+    while "--" in sanitized:
+        sanitized = sanitized.replace("--", "-")
+
+    # Remove leading/trailing hyphens
+    sanitized = sanitized.strip("-")
+
+    return sanitized if sanitized else "0"
+
+
+# Backward compatibility alias
+sanitize_trace_id = sanitize_id
+
+
+def get_unique_trace_id(trace_id: str, existing_ids: set) -> str:
+    """Get unique trace ID, adding suffix if collision detected.
+
+    Parameters
+    ----------
+    trace_id : str
+        Raw trace identifier
+    existing_ids : set
+        Set of already-used trace IDs (will be modified in-place)
+
+    Returns
+    -------
+    str
+        Unique sanitized trace ID
+
+    Examples
+    --------
+    >>> ids = set()
+    >>> get_unique_trace_id("A", ids)
+    'a'
+    >>> get_unique_trace_id("a", ids)  # collision!
+    'a-1'
+    """
+    base_id = sanitize_id(trace_id)
+
+    if base_id not in existing_ids:
+        existing_ids.add(base_id)
+        return base_id
+
+    # Find unique suffix
+    counter = 1
+    while f"{base_id}-{counter}" in existing_ids:
+        counter += 1
+
+    unique_id = f"{base_id}-{counter}"
+    existing_ids.add(unique_id)
+    return unique_id
+
+
+def get_csv_column_prefix(
+    ax_row: int = 0,
+    ax_col: int = 0,
+    caller: str = "plot",
+    trace_id: str = None,
+    trace_index: int = None,
+) -> str:
+    """Get CSV column prefix for a trace.
+
+    Format: r{row}c{col}_{caller}-{id}_
+
+    Parameters
+    ----------
+    ax_row : int
+        Row position of axes in grid (default: 0)
+    ax_col : int
+        Column position of axes in grid (default: 0)
+    caller : str
+        Plotting method name (default: "plot")
+    trace_id : str, optional
+        User-provided trace identifier. If None, uses trace_index.
+    trace_index : int, optional
+        Auto-generated index when no trace_id provided (default: 0)
+
+    Returns
+    -------
+    str
+        Column prefix like "r0c0_plot-sine_"
+
+    Examples
+    --------
+    >>> get_csv_column_prefix(caller="plot", trace_id="sine")
+    'r0c0_plot-sine_'
+    >>> get_csv_column_prefix(ax_row=1, ax_col=2, caller="scatter", trace_index=0)
+    'r1c2_scatter-0_'
+    """
+    if trace_id:
+        safe_id = sanitize_id(trace_id)
+    elif trace_index is not None:
+        safe_id = str(trace_index)
+    else:
+        safe_id = "0"
+
+    return f"r{ax_row}c{ax_col}_{caller}-{safe_id}_"
+
+
+def _extract_caller_and_id(trace_id: str) -> tuple:
+    """Extract caller (method) and id from a combined trace_id.
+
+    Handles various formats:
+    - "plot_0" -> ("plot", "0")
+    - "scatter_1" -> ("scatter", "1")
+    - "stx_line_0" -> ("stx_line", "0")
+    - "sine" -> ("plot", "sine")  # user-provided, default to "plot"
+    - "plot-sine" -> ("plot", "sine")
+
+    Parameters
+    ----------
+    trace_id : str
+        Combined trace identifier
+
+    Returns
+    -------
+    tuple
+        (caller, id)
+    """
+    if not trace_id:
+        return ("plot", "0")
+
+    # Known method prefixes (order matters - longer first)
+    known_methods = [
+        "stx_line",
+        "stx_scatter",
+        "stx_bar",
+        "stx_barh",
+        "stx_box",
+        "stx_violin",
+        "stx_heatmap",
+        "stx_image",
+        "stx_imshow",
+        "stx_contour",
+        "stx_raster",
+        "stx_conf_mat",
+        "stx_joyplot",
+        "stx_rectangle",
+        "stx_fillv",
+        "stx_kde",
+        "stx_ecdf",
+        "stx_mean_std",
+        "stx_mean_ci",
+        "stx_median_iqr",
+        "stx_shaded_line",
+        "stx_errorbar",
+        "stx_fill_between",
+        "sns_boxplot",
+        "sns_violinplot",
+        "sns_barplot",
+        "sns_histplot",
+        "sns_kdeplot",
+        "sns_scatterplot",
+        "sns_lineplot",
+        "sns_swarmplot",
+        "sns_stripplot",
+        "sns_heatmap",
+        "sns_jointplot",
+        "sns_pairplot",
+        "plot_scatter",
+        "plot_box",
+        "plot_imshow",
+        "plot_kde",
+        "plot",
+        "scatter",
+        "bar",
+        "barh",
+        "hist",
+        "boxplot",
+        "violinplot",
+        "errorbar",
+        "fill_between",
+        "contour",
+        "contourf",
+        "imshow",
+        "pcolormesh",
+        "quiver",
+        "streamplot",
+        "stem",
+        "step",
+        "pie",
+        "hexbin",
+        "matshow",
+        "eventplot",
+        "stackplot",
+        "fill",
+        "text",
+        "annotate",
+    ]
+
+    # Check if trace_id starts with a known method
+    for method in known_methods:
+        # Check with underscore separator (e.g., "plot_0", "stx_line_0")
+        if trace_id.startswith(f"{method}_"):
+            remainder = trace_id[len(method) + 1 :]
+            return (method, remainder if remainder else "0")
+        # Check with hyphen separator (e.g., "plot-sine")
+        if trace_id.startswith(f"{method}-"):
+            remainder = trace_id[len(method) + 1 :]
+            return (method, remainder if remainder else "0")
+
+    # No known method prefix - assume user-provided ID, default caller to "plot"
+    return ("plot", trace_id)
+
+
+def get_csv_column_name(
+    variable: str,
+    ax_row: int = 0,
+    ax_col: int = 0,
+    caller: str = None,
+    trace_id: str = None,
+    trace_index: int = None,
+) -> str:
+    """Get full CSV column name for a data field.
+
+    Format: r{row}c{col}_{caller}-{id}_{var}
+
+    Parameters
+    ----------
+    variable : str
+        Variable name (e.g., "x", "y", "bins", "heights")
+    ax_row : int
+        Row position of axes in grid (default: 0)
+    ax_col : int
+        Column position of axes in grid (default: 0)
+    caller : str, optional
+        Plotting method name. If None, extracted from trace_id or defaults to "plot"
+    trace_id : str, optional
+        User-provided trace identifier. May contain method prefix (e.g., "plot_0")
+    trace_index : int, optional
+        Auto-generated index when no trace_id provided
+
+    Returns
+    -------
+    str
+        Full column name like "r0c0_plot-sine_x"
+
+    Examples
+    --------
+    >>> get_csv_column_name("x", caller="plot", trace_id="sine")
+    'r0c0_plot-sine_x'
+    >>> get_csv_column_name("y", ax_row=1, ax_col=2, caller="scatter", trace_index=0)
+    'r1c2_scatter-0_y'
+    >>> get_csv_column_name("x", trace_id="plot_0")  # backward compatible
+    'r0c0_plot-0_x'
+    """
+    # If caller not provided, try to extract from trace_id
+    if caller is None and trace_id:
+        caller, trace_id = _extract_caller_and_id(trace_id)
+    elif caller is None:
+        caller = "plot"
+
+    prefix = get_csv_column_prefix(ax_row, ax_col, caller, trace_id, trace_index)
+    safe_variable = variable.lower()
+    return f"{prefix}{safe_variable}"
+
+
+def parse_csv_column_name(column_name: str) -> dict:
+    """Parse CSV column name to extract components.
+
+    Supports both new format and legacy format:
+    - New: r{row}c{col}_{caller}-{id}_{var}
+    - Legacy: ax-row-{row}-col-{col}_trace-id-{id}_variable-{var}
+
+    Parameters
+    ----------
+    column_name : str
+        Full column name
+
+    Returns
+    -------
+    dict
+        Dictionary with keys:
+        - ax_row: int
+        - ax_col: int
+        - caller: str (method name, empty for legacy format)
+        - trace_id: str
+        - variable: str
+        - valid: bool (True if parsing succeeded)
+
+    Examples
+    --------
+    >>> parse_csv_column_name("r0c0_plot-sine_x")
+    {'ax_row': 0, 'ax_col': 0, 'caller': 'plot', 'trace_id': 'sine', 'variable': 'x', 'valid': True}
+    >>> parse_csv_column_name("r1c2_scatter-0_y")
+    {'ax_row': 1, 'ax_col': 2, 'caller': 'scatter', 'trace_id': '0', 'variable': 'y', 'valid': True}
+    """
+    result = {
+        "ax_row": 0,
+        "ax_col": 0,
+        "caller": "",
+        "trace_id": "",
+        "variable": "",
+        "valid": False,
+    }
+
+    if not column_name:
+        return result
+
+    # Try new format: r{row}c{col}_{caller}-{id}_{var}
+    new_pattern = re.compile(r"^r(\d+)c(\d+)_([a-z_]+)-([^_]+)_([a-z]+)$")
+    match = new_pattern.match(column_name)
+    if match:
+        result["ax_row"] = int(match.group(1))
+        result["ax_col"] = int(match.group(2))
+        result["caller"] = match.group(3)
+        result["trace_id"] = match.group(4)
+        result["variable"] = match.group(5)
+        result["valid"] = True
+        return result
+
+    # Try legacy format: ax-row-{row}-col-{col}_trace-id-{id}_variable-{var}
+    if column_name.startswith("ax-row-"):
+        try:
+            parts = column_name.split("_")
+            for part in parts:
+                if part.startswith("ax-row-"):
+                    rest = part[7:]
+                    if "-col-" in rest:
+                        row_str, col_str = rest.split("-col-")
+                        result["ax_row"] = int(row_str)
+                        result["ax_col"] = int(col_str)
+                elif part.startswith("trace-id-"):
+                    result["trace_id"] = part[9:]
+                elif part.startswith("variable-"):
+                    result["variable"] = part[9:]
+
+            if result["variable"]:
+                result["valid"] = True
+        except (ValueError, IndexError):
+            pass
+
+    return result
+
+
+def get_trace_columns_from_df(
+    df,
+    caller: str = None,
+    trace_id: str = None,
+    trace_index: int = None,
+    ax_row: int = 0,
+    ax_col: int = 0,
+) -> dict:
+    """Find CSV columns for a specific trace in a DataFrame.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame with CSV data
+    caller : str, optional
+        Plotting method name to filter by
+    trace_id : str, optional
+        Trace identifier to search for
+    trace_index : int, optional
+        Trace index to search for (if trace_id not provided)
+    ax_row : int
+        Row position of axes
+    ax_col : int
+        Column position of axes
+
+    Returns
+    -------
+    dict
+        Dictionary mapping variable names to column names
+    """
+    result = {}
+
+    if caller:
+        prefix = get_csv_column_prefix(ax_row, ax_col, caller, trace_id, trace_index)
+        for col in df.columns:
+            if col.startswith(prefix):
+                variable = col[len(prefix) :]
+                result[variable] = col
+    else:
+        # Search all columns matching position and trace
+        for col in df.columns:
+            parsed = parse_csv_column_name(col)
+            if (
+                parsed["valid"]
+                and parsed["ax_row"] == ax_row
+                and parsed["ax_col"] == ax_col
+            ):
+                if trace_id and parsed["trace_id"] == sanitize_id(trace_id):
+                    result[parsed["variable"]] = col
+                elif trace_index is not None and parsed["trace_id"] == str(trace_index):
+                    result[parsed["variable"]] = col
+
+    return result
+
+
+# EOF

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_export_as_csv.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_export_as_csv.py
@@ -11,9 +11,10 @@ __FILE__ = __file__
 __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
+import logging
+
 import numpy as np
 import pandas as pd
-from scitex import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_annotate.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_annotate.py
@@ -12,7 +12,7 @@ __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_bar.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_bar.py
@@ -11,7 +11,7 @@ __DIR__ = os.path.dirname(__FILE__)
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_barh.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_barh.py
@@ -10,7 +10,7 @@ __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_boxplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_boxplot.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_contour.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_contour.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_contourf.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_contourf.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_errorbar.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_errorbar.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_eventplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_eventplot.py
@@ -9,11 +9,12 @@ __FILE__ = __file__
 __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
+import logging
+
 import numpy as np
 import pandas as pd
-from scitex import logging
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
 
+from .._csv_column_naming import get_csv_column_name
 from ._format_plot import _parse_tracking_id
 
 logger = logging.getLogger(__name__)

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_fill.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_fill.py
@@ -4,7 +4,7 @@
 # File: /home/ywatanabe/proj/scitex-code/src/scitex/plt/_subplots/_export_as_csv_formatters/_format_fill.py
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_fill_between.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_fill_between.py
@@ -4,7 +4,7 @@
 # File: /home/ywatanabe/proj/scitex-code/src/scitex/plt/_subplots/_export_as_csv_formatters/_format_fill_between.py
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_hexbin.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_hexbin.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_hist.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_hist.py
@@ -11,7 +11,7 @@ __DIR__ = os.path.dirname(__FILE__)
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_hist2d.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_hist2d.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_imshow.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_imshow.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_imshow2d.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_imshow2d.py
@@ -4,7 +4,7 @@
 # File: /home/ywatanabe/proj/scitex-code/src/scitex/plt/_subplots/_export_as_csv_formatters/_format_imshow2d.py
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_matshow.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_matshow.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_pcolormesh.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_pcolormesh.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_pie.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_pie.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 
 def _parse_tracking_id(id: str, record_index: int = 0) -> tuple:

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot_box.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot_box.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot_imshow.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot_imshow.py
@@ -10,7 +10,7 @@ __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot_kde.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot_kde.py
@@ -10,7 +10,7 @@ __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot_scatter.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_plot_scatter.py
@@ -10,7 +10,7 @@ __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_quiver.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_quiver.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_scatter.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_scatter.py
@@ -10,7 +10,7 @@ __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_barplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_barplot.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_boxplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_boxplot.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_heatmap.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_heatmap.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_histplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_histplot.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_jointplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_jointplot.py
@@ -11,7 +11,7 @@ __DIR__ = os.path.dirname(__FILE__)
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_kdeplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_kdeplot.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_lineplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_lineplot.py
@@ -11,7 +11,7 @@ __DIR__ = os.path.dirname(__FILE__)
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_pairplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_pairplot.py
@@ -10,7 +10,7 @@ __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_scatterplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_scatterplot.py
@@ -6,7 +6,7 @@
 """CSV formatter for sns.scatterplot() calls - uses standard column naming."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_stripplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_stripplot.py
@@ -6,7 +6,7 @@
 """CSV formatter for sns.stripplot() calls - uses standard column naming."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_swarmplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_swarmplot.py
@@ -6,7 +6,7 @@
 """CSV formatter for sns.swarmplot() calls - uses standard column naming."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_violinplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_sns_violinplot.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stackplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stackplot.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stem.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stem.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_step.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_step.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_streamplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_streamplot.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_bar.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_bar.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_barh.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_barh.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_conf_mat.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_conf_mat.py
@@ -11,7 +11,7 @@ __DIR__ = os.path.dirname(__FILE__)
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_contour.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_contour.py
@@ -3,7 +3,7 @@
 """CSV formatter for stx_contour() calls."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_ecdf.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_ecdf.py
@@ -6,7 +6,7 @@
 import os
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_errorbar.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_errorbar.py
@@ -3,7 +3,7 @@
 """CSV formatter for stx_errorbar() calls."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_fillv.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_fillv.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_heatmap.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_heatmap.py
@@ -11,7 +11,7 @@ __DIR__ = os.path.dirname(__FILE__)
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_image.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_image.py
@@ -7,7 +7,7 @@ import os
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_imshow.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_imshow.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_joyplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_joyplot.py
@@ -11,9 +11,8 @@ __DIR__ = os.path.dirname(__FILE__)
 
 import numpy as np
 import pandas as pd
-from scitex.pd import force_df
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
 
+from .._csv_column_naming import get_csv_column_name
 from ._format_plot import _parse_tracking_id
 
 
@@ -77,9 +76,11 @@ def _format_plot_joyplot(id, tracked_dict, kwargs):
 
     # Try to force to DataFrame as a last resort
     try:
+        from scitex.pd import force_df
+
         col_name = get_csv_column_name(
             "joyplot-data", ax_row, ax_col, trace_id=trace_id
         )
         return force_df({col_name: data})
-    except:
+    except Exception:
         return pd.DataFrame()

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_line.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_line.py
@@ -6,7 +6,7 @@
 """CSV formatter for stx_line() calls - uses standard column naming."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_mean_ci.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_mean_ci.py
@@ -6,7 +6,7 @@
 """CSV formatter for stx_mean_ci() calls - uses standard column naming."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_mean_std.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_mean_std.py
@@ -6,7 +6,7 @@
 """CSV formatter for stx_mean_std() calls - uses standard column naming."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_median_iqr.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_median_iqr.py
@@ -6,7 +6,7 @@
 """CSV formatter for stx_median_iqr() calls - uses standard column naming."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_raster.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_raster.py
@@ -10,7 +10,7 @@ __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_rectangle.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_rectangle.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_scatter.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_scatter.py
@@ -3,7 +3,7 @@
 """CSV formatter for stx_scatter() calls."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_scatter_hist.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_scatter_hist.py
@@ -10,7 +10,7 @@ __DIR__ = os.path.dirname(__FILE__)
 # ----------------------------------------
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_shaded_line.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_shaded_line.py
@@ -6,7 +6,7 @@
 """CSV formatter for stx_shaded_line() calls - uses standard column naming."""
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_violin.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_stx_violin.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_text.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_text.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_violin.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_violin.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_scitex_compat/_csv_formatters/_format_violinplot.py
+++ b/src/figrecipe/_scitex_compat/_csv_formatters/_format_violinplot.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import pandas as pd
-from scitex.plt.utils._csv_column_naming import get_csv_column_name
+from .._csv_column_naming import get_csv_column_name
 
 from ._format_plot import _parse_tracking_id
 

--- a/src/figrecipe/_skills/figrecipe/21_scientific-figure-patterns.md
+++ b/src/figrecipe/_skills/figrecipe/21_scientific-figure-patterns.md
@@ -1,0 +1,127 @@
+---
+name: scientific-figure-patterns
+description: ALWAYS invoke when implementing publication-quality comparison plots, multi-panel layouts, shared color scales, shared time axes, or PDF report assembly with figrecipe/matplotlib. Concrete code patterns implementing the universal rules in `scitex/general/30_scientific-figures.md`.
+---
+
+# Scientific Figure Patterns (figrecipe / matplotlib)
+
+Implementation patterns for the universal scientific-figure rules at
+[../general/30_scientific-figures.md](../general/30_scientific-figures.md).
+
+## Comparison plot with shared color scale + single colorbar
+
+```python
+import matplotlib.pyplot as plt
+
+# 1. Compute the global scale across BOTH conditions BEFORE plotting
+vmin = min(data_a.min(), data_b.min())
+vmax = max(data_a.max(), data_b.max())
+
+# 2. Symmetric range for diverging data
+vabs = max(abs(vmin), abs(vmax))
+kw = dict(vmin=-vabs, vmax=vabs, cmap='RdBu_r')
+
+# 3. Shared axes; side-by-side layout
+fig, (ax_a, ax_b) = plt.subplots(1, 2, sharex=True, sharey=True,
+                                  figsize=(10, 4))
+im_a = ax_a.imshow(data_a, **kw); ax_a.set_title("Condition A")
+im_b = ax_b.imshow(data_b, **kw); ax_b.set_title("Condition B")
+
+# 4. ONE shared colorbar for the comparison group
+fig.colorbar(im_a, ax=[ax_a, ax_b], label="value (units)")
+
+# 5. Drop redundant inner labels (sharey already removes inner ticks)
+ax_b.tick_params(labelleft=False)
+```
+
+Notes:
+- `vmin`/`vmax` MUST be computed across all compared arrays — never per-axis.
+- For sequential (non-diverging) data drop the symmetric step and use
+  `cmap='viridis'`.
+
+## Stacked plot with shared time axis (heatmap + averaged profile)
+
+```python
+fig, (ax_heat, ax_line) = plt.subplots(
+    2, 1,
+    sharex=True,
+    gridspec_kw={'height_ratios': [3, 1]},
+    figsize=(10, 5),
+)
+
+ax_heat.imshow(channels_x_time, aspect='auto')
+ax_heat.tick_params(labelbottom=False)        # hide x labels on upper panel
+
+ax_line.plot(t, channels_x_time.mean(axis=0))
+ax_line.set_xlabel("time (s)")
+fig.align_ylabels([ax_heat, ax_line])
+```
+
+## Multi-panel per-subject report grid
+
+```python
+fig, axes = plt.subplots(2, 3, sharex=True, sharey=True, figsize=(12, 8))
+for ax, (cond, arr) in zip(axes.flat, conditions.items()):
+    ax.imshow(arr, vmin=-vabs, vmax=vabs, cmap='RdBu_r')
+    ax.set_title(cond)
+fig.colorbar(axes[0, 0].images[0], ax=axes.ravel().tolist(),
+             label="value (units)")
+fig.align_ylabels(axes[:, 0])
+fig.align_xlabels(axes[-1, :])
+```
+
+## PDF report assembly with bookmarks + size budget
+
+```python
+from fpdf import FPDF
+from PIL import Image
+
+PAGE_W = 10  # inches
+pdf = FPDF()
+pdf.set_auto_page_break(auto=True, margin=15)
+
+for section_name, fig_paths in sections.items():
+    pdf.add_page()
+    pdf.start_section(section_name, level=0)        # PDF bookmark
+    for fig_path in fig_paths:
+        # Preserve original aspect ratio
+        w, h = Image.open(fig_path).size
+        page_h = PAGE_W * h / w
+        pdf.image(fig_path, w=PAGE_W * 25.4, h=page_h * 25.4)  # in -> mm
+
+pdf.output("report.pdf")
+```
+
+If the PDF exceeds the 10MB email limit, post-process with ghostscript:
+
+```bash
+gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 \
+   -dPDFSETTINGS=/ebook \
+   -o report-compressed.pdf report.pdf
+```
+
+## Bookmarks via post-hoc pikepdf (when fpdf2 isn't available)
+
+```python
+import pikepdf
+with pikepdf.open("report.pdf") as pdf:
+    with pdf.open_outline() as outline:
+        outline.root.extend([
+            pikepdf.OutlineItem("Executive Summary", 0),
+            pikepdf.OutlineItem("Methods", 1),
+            pikepdf.OutlineItem("Results", 3),
+        ])
+    pdf.save("report-bookmarked.pdf")
+```
+
+## Common pitfalls
+
+- Calling `imshow` without `vmin`/`vmax` — matplotlib auto-scales per call,
+  destroying cross-panel comparability.
+- Using `plt.colorbar(im_a)` (single-axes form) on a side-by-side comparison
+  — produces an ugly colorbar attached only to the left panel. Use the
+  multi-axes form `fig.colorbar(im_a, ax=[ax_a, ax_b])`.
+- Setting `figsize` per panel and discovering the colorbar overlaps content
+  — use `constrained_layout=True` or `fig.tight_layout()` after colorbar.
+- Forgetting `fig.align_ylabels()` / `align_xlabels()` on multi-panel grids
+  — y-labels at different x-positions look cluttered.

--- a/src/figrecipe/_skills/figrecipe/SKILL.md
+++ b/src/figrecipe/_skills/figrecipe/SKILL.md
@@ -43,6 +43,7 @@ This package does not ship as a submodule of the `scitex` umbrella.
 
 ### Standards
 * [20_return-fig](20_return-fig.md) — Convention: plotting functions must return fig
+* [21_scientific-figure-patterns](21_scientific-figure-patterns.md) — Comparison plots (shared color scale + single colorbar), shared time axes (heatmap + averaged profile), per-subject grids, PDF report assembly with bookmarks/size budget. Implements universal rules from `general/30_scientific-figures.md`.
 
 ## MCP Tools
 


### PR DESCRIPTION
## Summary

Add a new figrecipe skill leaf documenting concrete code patterns for publication-quality scientific figures using figrecipe / matplotlib. Implements the universal rules in the companion scitex-python PR: scitex/general/30_scientific-figures.

## Companion PR
- scitex-python: https://github.com/ywatanabe1989/scitex-python/pull/222

## Changes
- **NEW** `src/figrecipe/_skills/figrecipe/21_scientific-figure-patterns.md`
  - Comparison plot with shared color scale + single colorbar (full code)
  - Stacked plot with shared time axis (heatmap + averaged profile, gridspec)
  - Multi-panel per-subject report grid (sharex/sharey + colorbar across all axes)
  - PDF report assembly with bookmarks + size budget (fpdf2 + ghostscript)
  - Bookmarks via post-hoc pikepdf (when fpdf2 isn't available)
  - Common pitfalls (auto-scaled imshow, single-axes colorbar form, layout issues)
- `src/figrecipe/_skills/figrecipe/SKILL.md` — add bullet under Standards section

## Test plan
- [ ] Re-run `scitex-dev skills export --link` (verified locally)
- [ ] Confirm See-also link to `general/30_scientific-figures.md` resolves once scitex-python PR lands