### PR TITLE
chore(tests): eliminate PA-306 (no-mocks) and PA-307 (test-quality) violations

### DIFF
--- a/tests/figrecipe/_annotations/test__auto_placement.py
+++ b/tests/figrecipe/_annotations/test__auto_placement.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__annotations__auto_placement_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._annotations._auto_placement")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._annotations._auto_placement'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_annotations/test__stat_bracket.py
+++ b/tests/figrecipe/_annotations/test__stat_bracket.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__annotations__stat_bracket_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._annotations._stat_bracket")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._annotations._stat_bracket'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__data_resolver.py
+++ b/tests/figrecipe/_api/test__data_resolver.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__data_resolver_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._data_resolver")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._data_resolver'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__decorations.py
+++ b/tests/figrecipe/_api/test__decorations.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__decorations_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._decorations")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._decorations'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__extract.py
+++ b/tests/figrecipe/_api/test__extract.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__extract_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._extract")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._extract'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__notebook.py
+++ b/tests/figrecipe/_api/test__notebook.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__notebook_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._notebook")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._notebook'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__panel.py
+++ b/tests/figrecipe/_api/test__panel.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__panel_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._panel")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._panel'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__plot.py
+++ b/tests/figrecipe/_api/test__plot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__plot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._plot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._plot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__plot_helpers.py
+++ b/tests/figrecipe/_api/test__plot_helpers.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__plot_helpers_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._plot_helpers")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._plot_helpers'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__public.py
+++ b/tests/figrecipe/_api/test__public.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__public_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._public")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._public'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__save.py
+++ b/tests/figrecipe/_api/test__save.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__save_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._save")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._save'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__save_helpers.py
+++ b/tests/figrecipe/_api/test__save_helpers.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__save_helpers_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._save_helpers")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._save_helpers'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__seaborn_proxy.py
+++ b/tests/figrecipe/_api/test__seaborn_proxy.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__seaborn_proxy_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._seaborn_proxy")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._seaborn_proxy'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__signature.py
+++ b/tests/figrecipe/_api/test__signature.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__signature_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._signature")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._signature'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__style_manager.py
+++ b/tests/figrecipe/_api/test__style_manager.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__style_manager_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._style_manager")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._style_manager'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__subplots.py
+++ b/tests/figrecipe/_api/test__subplots.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__subplots_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._subplots")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._subplots'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_api/test__validate.py
+++ b/tests/figrecipe/_api/test__validate.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__api__validate_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._api._validate")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._api._validate'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_bundle/test__extract.py
+++ b/tests/figrecipe/_bundle/test__extract.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__bundle__extract_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._bundle._extract")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._bundle._extract'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_bundle/test__figz.py
+++ b/tests/figrecipe/_bundle/test__figz.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__bundle__figz_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._bundle._figz")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._bundle._figz'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_bundle/test__paths.py
+++ b/tests/figrecipe/_bundle/test__paths.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__bundle__paths_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._bundle._paths")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._bundle._paths'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_bundle/test__pltz.py
+++ b/tests/figrecipe/_bundle/test__pltz.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__bundle__pltz_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._bundle._pltz")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._bundle._pltz'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_captions/test__convenience.py
+++ b/tests/figrecipe/_captions/test__convenience.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__captions__convenience_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._captions._convenience")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._captions._convenience'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_captions/test__formats.py
+++ b/tests/figrecipe/_captions/test__formats.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__captions__formats_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._captions._formats")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._captions._formats'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__completion.py
+++ b/tests/figrecipe/_cli/test__completion.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__completion_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._completion")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._completion'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__compose.py
+++ b/tests/figrecipe/_cli/test__compose.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__compose_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._compose")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._compose'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__convert.py
+++ b/tests/figrecipe/_cli/test__convert.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__convert_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._convert")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._convert'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__crop.py
+++ b/tests/figrecipe/_cli/test__crop.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__crop_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._crop")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._crop'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__diagram.py
+++ b/tests/figrecipe/_cli/test__diagram.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__diagram_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._diagram")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._diagram'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__diff.py
+++ b/tests/figrecipe/_cli/test__diff.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__diff_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._diff")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._diff'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__extract.py
+++ b/tests/figrecipe/_cli/test__extract.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__extract_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._extract")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._extract'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__fonts.py
+++ b/tests/figrecipe/_cli/test__fonts.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__fonts_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._fonts")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._fonts'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__gui.py
+++ b/tests/figrecipe/_cli/test__gui.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__gui_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._gui")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._gui'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__hitmap.py
+++ b/tests/figrecipe/_cli/test__hitmap.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__hitmap_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._hitmap")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._hitmap'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__info.py
+++ b/tests/figrecipe/_cli/test__info.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__info_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._info")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._info'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__mcp.py
+++ b/tests/figrecipe/_cli/test__mcp.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__mcp_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._mcp")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._mcp'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__plot.py
+++ b/tests/figrecipe/_cli/test__plot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__plot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._plot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._plot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__reproduce.py
+++ b/tests/figrecipe/_cli/test__reproduce.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__reproduce_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._reproduce")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._reproduce'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__style.py
+++ b/tests/figrecipe/_cli/test__style.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__style_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._style")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._style'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_cli/test__version.py
+++ b/tests/figrecipe/_cli/test__version.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__cli__version_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._cli._version")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._cli._version'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_composition/test__import_axes.py
+++ b/tests/figrecipe/_composition/test__import_axes.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__composition__import_axes_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._composition._import_axes")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._composition._import_axes'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_composition/test__source_parser.py
+++ b/tests/figrecipe/_composition/test__source_parser.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__composition__source_parser_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._composition._source_parser")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._composition._source_parser'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_composition/test__visibility.py
+++ b/tests/figrecipe/_composition/test__visibility.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__composition__visibility_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._composition._visibility")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._composition._visibility'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/_video_trim/test__detection.py
+++ b/tests/figrecipe/_dev/browser/_video_trim/test__detection.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__video_trim__detection_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._video_trim._detection")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._video_trim._detection'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/_video_trim/test__markers.py
+++ b/tests/figrecipe/_dev/browser/_video_trim/test__markers.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__video_trim__markers_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._video_trim._markers")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._video_trim._markers'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/test__audio.py
+++ b/tests/figrecipe/_dev/browser/test__audio.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__audio_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._audio")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._audio'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/test__caption.py
+++ b/tests/figrecipe/_dev/browser/test__caption.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__caption_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._caption")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._caption'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/test__click_effect.py
+++ b/tests/figrecipe/_dev/browser/test__click_effect.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__click_effect_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._click_effect")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._click_effect'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/test__cursor.py
+++ b/tests/figrecipe/_dev/browser/test__cursor.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__cursor_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._cursor")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._cursor'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/test__highlight.py
+++ b/tests/figrecipe/_dev/browser/test__highlight.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__highlight_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._highlight")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._highlight'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/test__narration.py
+++ b/tests/figrecipe/_dev/browser/test__narration.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__narration_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._narration")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._narration'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/test__recorder.py
+++ b/tests/figrecipe/_dev/browser/test__recorder.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__recorder_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._recorder")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._recorder'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/browser/test__utils.py
+++ b/tests/figrecipe/_dev/browser/test__utils.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_browser__utils_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.browser._utils")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.browser._utils'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/bar_categorical/test_plot_bar.py
+++ b/tests/figrecipe/_dev/demo_plotters/bar_categorical/test_plot_bar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_bar_categorical_plot_bar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.bar_categorical.plot_bar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.bar_categorical.plot_bar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/bar_categorical/test_plot_barh.py
+++ b/tests/figrecipe/_dev/demo_plotters/bar_categorical/test_plot_barh.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_bar_categorical_plot_barh_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.bar_categorical.plot_barh")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.bar_categorical.plot_barh'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_contour.py
+++ b/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_contour.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_contour_surface_plot_contour_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.contour_surface.plot_contour")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.contour_surface.plot_contour'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_contourf.py
+++ b/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_contourf.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_contour_surface_plot_contourf_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.contour_surface.plot_contourf")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.contour_surface.plot_contourf'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_tricontour.py
+++ b/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_tricontour.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_contour_surface_plot_tricontour_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.contour_surface.plot_tricontour")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.contour_surface.plot_tricontour'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_tricontourf.py
+++ b/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_tricontourf.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_contour_surface_plot_tricontourf_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.contour_surface.plot_tricontourf")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.contour_surface.plot_tricontourf'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_tripcolor.py
+++ b/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_tripcolor.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_contour_surface_plot_tripcolor_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.contour_surface.plot_tripcolor")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.contour_surface.plot_tripcolor'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_triplot.py
+++ b/tests/figrecipe/_dev/demo_plotters/contour_surface/test_plot_triplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_contour_surface_plot_triplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.contour_surface.plot_triplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.contour_surface.plot_triplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_boxplot.py
+++ b/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_boxplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_distribution_plot_boxplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.distribution.plot_boxplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.distribution.plot_boxplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_ecdf.py
+++ b/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_ecdf.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_distribution_plot_ecdf_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.distribution.plot_ecdf")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.distribution.plot_ecdf'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_hist.py
+++ b/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_hist.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_distribution_plot_hist_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.distribution.plot_hist")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.distribution.plot_hist'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_hist2d.py
+++ b/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_hist2d.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_distribution_plot_hist2d_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.distribution.plot_hist2d")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.distribution.plot_hist2d'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_violinplot.py
+++ b/tests/figrecipe/_dev/demo_plotters/distribution/test_plot_violinplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_distribution_plot_violinplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.distribution.plot_violinplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.distribution.plot_violinplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_hexbin.py
+++ b/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_hexbin.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_image_matrix_plot_hexbin_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.image_matrix.plot_hexbin")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.image_matrix.plot_hexbin'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_imshow.py
+++ b/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_imshow.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_image_matrix_plot_imshow_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.image_matrix.plot_imshow")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.image_matrix.plot_imshow'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_matshow.py
+++ b/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_matshow.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_image_matrix_plot_matshow_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.image_matrix.plot_matshow")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.image_matrix.plot_matshow'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_pcolor.py
+++ b/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_pcolor.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_image_matrix_plot_pcolor_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.image_matrix.plot_pcolor")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.image_matrix.plot_pcolor'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_pcolormesh.py
+++ b/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_pcolormesh.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_image_matrix_plot_pcolormesh_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.image_matrix.plot_pcolormesh")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.image_matrix.plot_pcolormesh'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_spy.py
+++ b/tests/figrecipe/_dev/demo_plotters/image_matrix/test_plot_spy.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_image_matrix_plot_spy_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.image_matrix.plot_spy")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.image_matrix.plot_spy'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_errorbar.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_errorbar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_line_curve_plot_errorbar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.line_curve.plot_errorbar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.line_curve.plot_errorbar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_fill.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_fill.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_line_curve_plot_fill_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.line_curve.plot_fill")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.line_curve.plot_fill'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_fill_between.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_fill_between.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_line_curve_plot_fill_between_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.line_curve.plot_fill_between")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.line_curve.plot_fill_between'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_fill_betweenx.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_fill_betweenx.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_line_curve_plot_fill_betweenx_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.line_curve.plot_fill_betweenx")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.line_curve.plot_fill_betweenx'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_plot.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_plot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_line_curve_plot_plot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.line_curve.plot_plot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.line_curve.plot_plot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_stackplot.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_stackplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_line_curve_plot_stackplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.line_curve.plot_stackplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.line_curve.plot_stackplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_stairs.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_stairs.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_line_curve_plot_stairs_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.line_curve.plot_stairs")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.line_curve.plot_stairs'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_step.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_step.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_line_curve_plot_step_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.line_curve.plot_step")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.line_curve.plot_step'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/scatter_points/test_plot_scatter.py
+++ b/tests/figrecipe/_dev/demo_plotters/scatter_points/test_plot_scatter.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_scatter_points_plot_scatter_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.scatter_points.plot_scatter")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.scatter_points.plot_scatter'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/special/test_plot_eventplot.py
+++ b/tests/figrecipe/_dev/demo_plotters/special/test_plot_eventplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_special_plot_eventplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.special.plot_eventplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.special.plot_eventplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/special/test_plot_graph.py
+++ b/tests/figrecipe/_dev/demo_plotters/special/test_plot_graph.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_special_plot_graph_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.special.plot_graph")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.special.plot_graph'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/special/test_plot_loglog.py
+++ b/tests/figrecipe/_dev/demo_plotters/special/test_plot_loglog.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_special_plot_loglog_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.special.plot_loglog")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.special.plot_loglog'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/special/test_plot_pie.py
+++ b/tests/figrecipe/_dev/demo_plotters/special/test_plot_pie.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_special_plot_pie_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.special.plot_pie")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.special.plot_pie'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/special/test_plot_semilogx.py
+++ b/tests/figrecipe/_dev/demo_plotters/special/test_plot_semilogx.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_special_plot_semilogx_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.special.plot_semilogx")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.special.plot_semilogx'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/special/test_plot_semilogy.py
+++ b/tests/figrecipe/_dev/demo_plotters/special/test_plot_semilogy.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_special_plot_semilogy_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.special.plot_semilogy")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.special.plot_semilogy'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/special/test_plot_stem.py
+++ b/tests/figrecipe/_dev/demo_plotters/special/test_plot_stem.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_special_plot_stem_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.special.plot_stem")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.special.plot_stem'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_acorr.py
+++ b/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_acorr.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_spectral_signal_plot_acorr_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.spectral_signal.plot_acorr")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.spectral_signal.plot_acorr'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_angle_spectrum.py
+++ b/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_angle_spectrum.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_spectral_signal_plot_angle_spectrum_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.spectral_signal.plot_angle_spectrum")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.spectral_signal.plot_angle_spectrum'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_cohere.py
+++ b/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_cohere.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_spectral_signal_plot_cohere_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.spectral_signal.plot_cohere")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.spectral_signal.plot_cohere'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_csd.py
+++ b/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_csd.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_spectral_signal_plot_csd_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.spectral_signal.plot_csd")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.spectral_signal.plot_csd'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_magnitude_spectrum.py
+++ b/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_magnitude_spectrum.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_spectral_signal_plot_magnitude_spectrum_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.spectral_signal.plot_magnitude_spectrum")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.spectral_signal.plot_magnitude_spectrum'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_phase_spectrum.py
+++ b/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_phase_spectrum.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_spectral_signal_plot_phase_spectrum_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.spectral_signal.plot_phase_spectrum")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.spectral_signal.plot_phase_spectrum'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_psd.py
+++ b/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_psd.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_spectral_signal_plot_psd_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.spectral_signal.plot_psd")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.spectral_signal.plot_psd'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_specgram.py
+++ b/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_specgram.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_spectral_signal_plot_specgram_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.spectral_signal.plot_specgram")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.spectral_signal.plot_specgram'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_xcorr.py
+++ b/tests/figrecipe/_dev/demo_plotters/spectral_signal/test_plot_xcorr.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_spectral_signal_plot_xcorr_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.spectral_signal.plot_xcorr")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.spectral_signal.plot_xcorr'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/test__categories.py
+++ b/tests/figrecipe/_dev/demo_plotters/test__categories.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters__categories_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters._categories")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters._categories'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/test__figure_creators.py
+++ b/tests/figrecipe/_dev/demo_plotters/test__figure_creators.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters__figure_creators_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters._figure_creators")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters._figure_creators'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/test__helpers.py
+++ b/tests/figrecipe/_dev/demo_plotters/test__helpers.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters__helpers_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters._helpers")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters._helpers'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/test__registry.py
+++ b/tests/figrecipe/_dev/demo_plotters/test__registry.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters__registry_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters._registry")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters._registry'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/vector_flow/test_plot_barbs.py
+++ b/tests/figrecipe/_dev/demo_plotters/vector_flow/test_plot_barbs.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_vector_flow_plot_barbs_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.vector_flow.plot_barbs")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.vector_flow.plot_barbs'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/vector_flow/test_plot_quiver.py
+++ b/tests/figrecipe/_dev/demo_plotters/vector_flow/test_plot_quiver.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_vector_flow_plot_quiver_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.vector_flow.plot_quiver")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.vector_flow.plot_quiver'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/vector_flow/test_plot_streamplot.py
+++ b/tests/figrecipe/_dev/demo_plotters/vector_flow/test_plot_streamplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev_demo_plotters_vector_flow_plot_streamplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev.demo_plotters.vector_flow.plot_streamplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev.demo_plotters.vector_flow.plot_streamplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/test__plotters.py
+++ b/tests/figrecipe/_dev/test__plotters.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev__plotters_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev._plotters")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev._plotters'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/test__run_demos.py
+++ b/tests/figrecipe/_dev/test__run_demos.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__dev__run_demos_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._dev._run_demos")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._dev._run_demos'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__autofix.py
+++ b/tests/figrecipe/_diagram/_diagram/test__autofix.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__autofix_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._autofix")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._autofix'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__codeblock.py
+++ b/tests/figrecipe/_diagram/_diagram/test__codeblock.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__codeblock_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._codeblock")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._codeblock'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__color.py
+++ b/tests/figrecipe/_diagram/_diagram/test__color.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__color_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._color")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._color'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__constants.py
+++ b/tests/figrecipe/_diagram/_diagram/test__constants.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__constants_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._constants")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._constants'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__core.py
+++ b/tests/figrecipe/_diagram/_diagram/test__core.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__core_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._core")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._core'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__debug.py
+++ b/tests/figrecipe/_diagram/_diagram/test__debug.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__debug_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._debug")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._debug'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__editor.py
+++ b/tests/figrecipe/_diagram/_diagram/test__editor.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__editor_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._editor")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._editor'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__fix_arrows.py
+++ b/tests/figrecipe/_diagram/_diagram/test__fix_arrows.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__fix_arrows_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._fix_arrows")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._fix_arrows'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__fix_layout.py
+++ b/tests/figrecipe/_diagram/_diagram/test__fix_layout.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__fix_layout_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._fix_layout")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._fix_layout'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__flex.py
+++ b/tests/figrecipe/_diagram/_diagram/test__flex.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__flex_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._flex")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._flex'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__geom.py
+++ b/tests/figrecipe/_diagram/_diagram/test__geom.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__geom_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._geom")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._geom'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__hitmap.py
+++ b/tests/figrecipe/_diagram/_diagram/test__hitmap.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__hitmap_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._hitmap")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._hitmap'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__icons.py
+++ b/tests/figrecipe/_diagram/_diagram/test__icons.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__icons_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._icons")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._icons'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__io.py
+++ b/tests/figrecipe/_diagram/_diagram/test__io.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__io_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._io")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._io'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__layout.py
+++ b/tests/figrecipe/_diagram/_diagram/test__layout.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__layout_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._layout")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._layout'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__layout_graph.py
+++ b/tests/figrecipe/_diagram/_diagram/test__layout_graph.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__layout_graph_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._layout_graph")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._layout_graph'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__overlap.py
+++ b/tests/figrecipe/_diagram/_diagram/test__overlap.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__overlap_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._overlap")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._overlap'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__render.py
+++ b/tests/figrecipe/_diagram/_diagram/test__render.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__render_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._render")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._render'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__specs.py
+++ b/tests/figrecipe/_diagram/_diagram/test__specs.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__specs_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._specs")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._specs'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_diagram/test__validate.py
+++ b/tests/figrecipe/_diagram/_diagram/test__validate.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__diagram__validate_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._diagram._validate")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._diagram._validate'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_graphviz/test__compile.py
+++ b/tests/figrecipe/_diagram/_graphviz/test__compile.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__graphviz__compile_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._graphviz._compile")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._graphviz._compile'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_graphviz/test__render.py
+++ b/tests/figrecipe/_diagram/_graphviz/test__render.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__graphviz__render_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._graphviz._render")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._graphviz._render'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_graphviz/test_graphviz.py
+++ b/tests/figrecipe/_diagram/_graphviz/test_graphviz.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__graphviz_graphviz_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._graphviz.graphviz")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._graphviz.graphviz'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_mermaid/test__compile.py
+++ b/tests/figrecipe/_diagram/_mermaid/test__compile.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__mermaid__compile_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._mermaid._compile")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._mermaid._compile'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_mermaid/test__render.py
+++ b/tests/figrecipe/_diagram/_mermaid/test__render.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__mermaid__render_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._mermaid._render")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._mermaid._render'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_mermaid/test_mermaid.py
+++ b/tests/figrecipe/_diagram/_mermaid/test_mermaid.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__mermaid_mermaid_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._mermaid.mermaid")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._mermaid.mermaid'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__arrows.py
+++ b/tests/figrecipe/_diagram/_shared/test__arrows.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__arrows_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._arrows")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._arrows'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__compile_utils.py
+++ b/tests/figrecipe/_diagram/_shared/test__compile_utils.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__compile_utils_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._compile_utils")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._compile_utils'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__graph.py
+++ b/tests/figrecipe/_diagram/_shared/test__graph.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__graph_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._graph")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._graph'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__layout.py
+++ b/tests/figrecipe/_diagram/_shared/test__layout.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__layout_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._layout")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._layout'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__native_render.py
+++ b/tests/figrecipe/_diagram/_shared/test__native_render.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__native_render_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._native_render")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._native_render'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__presets.py
+++ b/tests/figrecipe/_diagram/_shared/test__presets.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__presets_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._presets")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._presets'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__render.py
+++ b/tests/figrecipe/_diagram/_shared/test__render.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__render_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._render")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._render'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__rich_nodes.py
+++ b/tests/figrecipe/_diagram/_shared/test__rich_nodes.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__rich_nodes_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._rich_nodes")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._rich_nodes'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__schema.py
+++ b/tests/figrecipe/_diagram/_shared/test__schema.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__schema_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._schema")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._schema'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__shapes.py
+++ b/tests/figrecipe/_diagram/_shared/test__shapes.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__shapes_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._shapes")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._shapes'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__split.py
+++ b/tests/figrecipe/_diagram/_shared/test__split.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__split_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._split")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._split'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_diagram/_shared/test__styles_native.py
+++ b/tests/figrecipe/_diagram/_shared/test__styles_native.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__diagram__shared__styles_native_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._diagram._shared._styles_native")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._diagram._shared._styles_native'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_django/frontend/test_configure.py
+++ b/tests/figrecipe/_django/frontend/test_configure.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__django_frontend_configure_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._django.frontend.configure")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._django.frontend.configure'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_django/management/commands/test_figrecipe_editor.py
+++ b/tests/figrecipe/_django/management/commands/test_figrecipe_editor.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__django_management_commands_figrecipe_editor_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._django.management.commands.figrecipe_editor")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._django.management.commands.figrecipe_editor'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_bbox/test__collections.py
+++ b/tests/figrecipe/_editor/_bbox/test__collections.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__bbox__collections_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._bbox._collections")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._bbox._collections'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_bbox/test__elements.py
+++ b/tests/figrecipe/_editor/_bbox/test__elements.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__bbox__elements_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._bbox._elements")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._bbox._elements'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_bbox/test__extract.py
+++ b/tests/figrecipe/_editor/_bbox/test__extract.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__bbox__extract_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._bbox._extract")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._bbox._extract'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_bbox/test__extract_axes.py
+++ b/tests/figrecipe/_editor/_bbox/test__extract_axes.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__bbox__extract_axes_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._bbox._extract_axes")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._bbox._extract_axes'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_bbox/test__extract_text.py
+++ b/tests/figrecipe/_editor/_bbox/test__extract_text.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__bbox__extract_text_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._bbox._extract_text")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._bbox._extract_text'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_bbox/test__lines.py
+++ b/tests/figrecipe/_editor/_bbox/test__lines.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__bbox__lines_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._bbox._lines")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._bbox._lines'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_bbox/test__per_element.py
+++ b/tests/figrecipe/_editor/_bbox/test__per_element.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__bbox__per_element_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._bbox._per_element")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._bbox._per_element'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_bbox/test__transforms.py
+++ b/tests/figrecipe/_editor/_bbox/test__transforms.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__bbox__transforms_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._bbox._transforms")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._bbox._transforms'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__linecoll.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__linecoll.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__collections__linecoll_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._collections._linecoll")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._collections._linecoll'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__mesh.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__mesh.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__collections__mesh_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._collections._mesh")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._collections._mesh'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__polycoll.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__polycoll.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__collections__polycoll_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._collections._polycoll")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._collections._polycoll'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__quiver.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__quiver.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__collections__quiver_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._collections._quiver")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._collections._quiver'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__scatter.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_collections/test__scatter.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__collections__scatter_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._collections._scatter")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._collections._scatter'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__bar.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__bar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__bar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._bar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._bar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__base.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__base.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__base_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._base")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._base'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__boxplot.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__boxplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__boxplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._boxplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._boxplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__contour.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__contour.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__contour_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._contour")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._contour'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__dispatcher.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__dispatcher.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__dispatcher_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._dispatcher")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._dispatcher'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__event.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__event.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__event_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._event")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._event'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__fill.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__fill.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__fill_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._fill")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._fill'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__heatmap.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__heatmap.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__heatmap_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._heatmap")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._heatmap'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__line.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__line.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__line_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._line")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._line'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__pie.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__pie.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__pie_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._pie")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._pie'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__quiver.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__quiver.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__quiver_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._quiver")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._quiver'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__scatter.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__scatter.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__scatter_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._scatter")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._scatter'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__stem.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__stem.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__stem_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._stem")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._stem'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/_types/test__violin.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/_types/test__violin.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__types__violin_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._types._violin")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._types._violin'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/test__diagram_match.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/test__diagram_match.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__diagram_match_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._diagram_match")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._diagram_match'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/test__images.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/test__images.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__images_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._images")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._images'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/test__lines.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/test__lines.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__lines_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._lines")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._lines'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/test__patches.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/test__patches.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__patches_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._patches")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._patches'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/_artists/test__text.py
+++ b/tests/figrecipe/_editor/_hitmap/_artists/test__text.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__artists__text_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._artists._text")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._artists._text'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/test__colors.py
+++ b/tests/figrecipe/_editor/_hitmap/test__colors.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__colors_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._colors")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._colors'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/test__detect.py
+++ b/tests/figrecipe/_editor/_hitmap/test__detect.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__detect_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._detect")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._detect'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/_hitmap/test__restore.py
+++ b/tests/figrecipe/_editor/_hitmap/test__restore.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__hitmap__restore_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._hitmap._restore")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._hitmap._restore'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/test__datatable_plot_handlers.py
+++ b/tests/figrecipe/_editor/test__datatable_plot_handlers.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__datatable_plot_handlers_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._datatable_plot_handlers")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._datatable_plot_handlers'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_editor/test__figure_layout.py
+++ b/tests/figrecipe/_editor/test__figure_layout.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__editor__figure_layout_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._editor._figure_layout")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._editor._figure_layout'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_graph/test__presets.py
+++ b/tests/figrecipe/_graph/test__presets.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__graph__presets_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._graph._presets")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._graph._presets'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__advanced.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__advanced.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__advanced_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._advanced")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._advanced'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__area2.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__area2.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__area2_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._area2")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._area2'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__bar.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__bar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__bar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._bar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._bar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__base.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__base.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__base_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._base")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._base'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__box.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__box.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__box_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._box")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._box'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__image.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__image.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__image_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._image")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._image'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__line_scatter.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__line_scatter.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__line_scatter_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._line_scatter")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._line_scatter'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__log.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__log.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__log_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._log")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._log'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__pie_hist.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__pie_hist.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__pie_hist_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._pie_hist")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._pie_hist'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__scitex.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__scitex.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__scitex_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._scitex")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._scitex'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__scitex_shaded.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__scitex_shaded.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__scitex_shaded_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._scitex_shaded")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._scitex_shaded'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__scitex_stats.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__scitex_stats.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__scitex_stats_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._scitex_stats")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._scitex_stats'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__scitex_vis.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__scitex_vis.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__scitex_vis_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._scitex_vis")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._scitex_vis'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__special.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__special.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__special_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._special")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._special'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__spectral.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__spectral.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__spectral_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._spectral")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._spectral'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__spectral2.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__spectral2.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__spectral2_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._spectral2")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._spectral2'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/_plot_tools/test__vector_corr.py
+++ b/tests/figrecipe/_mcp/_plot_tools/test__vector_corr.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__plot_tools__vector_corr_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._plot_tools._vector_corr")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._plot_tools._vector_corr'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/test__diagram_tools.py
+++ b/tests/figrecipe/_mcp/test__diagram_tools.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp__diagram_tools_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp._diagram_tools")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp._diagram_tools'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_mcp/test_server.py
+++ b/tests/figrecipe/_mcp/test_server.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__mcp_server_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._mcp.server")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._mcp.server'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_params/test__DECORATION_METHODS.py
+++ b/tests/figrecipe/_params/test__DECORATION_METHODS.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__params__DECORATION_METHODS_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._params._DECORATION_METHODS")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._params._DECORATION_METHODS'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_params/test__PLOTTING_METHODS.py
+++ b/tests/figrecipe/_params/test__PLOTTING_METHODS.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__params__PLOTTING_METHODS_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._params._PLOTTING_METHODS")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._params._PLOTTING_METHODS'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_params/test__REPRESENTATIVE_PLOTS.py
+++ b/tests/figrecipe/_params/test__REPRESENTATIVE_PLOTS.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__params__REPRESENTATIVE_PLOTS_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._params._REPRESENTATIVE_PLOTS")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._params._REPRESENTATIVE_PLOTS'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_recorder/test__utils.py
+++ b/tests/figrecipe/_recorder/test__utils.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__recorder__utils_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._recorder._utils")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._recorder._utils'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__boxplot.py
+++ b/tests/figrecipe/_reproducer/test__boxplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__reproducer__boxplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._reproducer._boxplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._reproducer._boxplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__legend.py
+++ b/tests/figrecipe/_reproducer/test__legend.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__reproducer__legend_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._reproducer._legend")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._reproducer._legend'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__line_styles.py
+++ b/tests/figrecipe/_reproducer/test__line_styles.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__reproducer__line_styles_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._reproducer._line_styles")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._reproducer._line_styles'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__reconstruct.py
+++ b/tests/figrecipe/_reproducer/test__reconstruct.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__reproducer__reconstruct_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._reproducer._reconstruct")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._reproducer._reconstruct'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__replay_diagram.py
+++ b/tests/figrecipe/_reproducer/test__replay_diagram.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__reproducer__replay_diagram_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._reproducer._replay_diagram")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._reproducer._replay_diagram'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__replay_graph.py
+++ b/tests/figrecipe/_reproducer/test__replay_graph.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__reproducer__replay_graph_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._reproducer._replay_graph")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._reproducer._replay_graph'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__seaborn.py
+++ b/tests/figrecipe/_reproducer/test__seaborn.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__reproducer__seaborn_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._reproducer._seaborn")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._reproducer._seaborn'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__stem.py
+++ b/tests/figrecipe/_reproducer/test__stem.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__reproducer__stem_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._reproducer._stem")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._reproducer._stem'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__violin.py
+++ b/tests/figrecipe/_reproducer/test__violin.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__reproducer__violin_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._reproducer._violin")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._reproducer._violin'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__export_as_csv.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__export_as_csv.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__export_as_csv_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._export_as_csv")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._export_as_csv'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_annotate.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_annotate.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_annotate_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_annotate")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_annotate'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_bar.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_bar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_bar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_bar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_bar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_barh.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_barh.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_barh_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_barh")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_barh'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_boxplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_boxplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_boxplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_boxplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_boxplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_contour.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_contour.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_contour_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_contour")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_contour'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_contourf.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_contourf.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_contourf_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_contourf")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_contourf'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_errorbar.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_errorbar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_errorbar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_errorbar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_errorbar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_eventplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_eventplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_eventplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_eventplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_eventplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_fill.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_fill.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_fill_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_fill")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_fill'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_fill_between.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_fill_between.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_fill_between_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_fill_between")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_fill_between'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_hexbin.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_hexbin.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_hexbin_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_hexbin")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_hexbin'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_hist.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_hist.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_hist_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_hist")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_hist'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_hist2d.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_hist2d.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_hist2d_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_hist2d")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_hist2d'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_imshow.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_imshow.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_imshow_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_imshow")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_imshow'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_imshow2d.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_imshow2d.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_imshow2d_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_imshow2d")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_imshow2d'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_matshow.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_matshow.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_matshow_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_matshow")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_matshow'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_pcolormesh.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_pcolormesh.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_pcolormesh_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_pcolormesh")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_pcolormesh'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_pie.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_pie.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_pie_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_pie")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_pie'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_plot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_plot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_plot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot_box.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot_box.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_plot_box_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_plot_box")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_plot_box'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot_imshow.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot_imshow.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_plot_imshow_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_plot_imshow")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_plot_imshow'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot_kde.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot_kde.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_plot_kde_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_plot_kde")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_plot_kde'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot_scatter.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_plot_scatter.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_plot_scatter_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_plot_scatter")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_plot_scatter'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_quiver.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_quiver.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_quiver_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_quiver")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_quiver'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_scatter.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_scatter.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_scatter_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_scatter")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_scatter'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_barplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_barplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_barplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_barplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_barplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_boxplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_boxplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_boxplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_boxplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_boxplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_heatmap.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_heatmap.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_heatmap_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_heatmap")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_heatmap'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_histplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_histplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_histplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_histplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_histplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_jointplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_jointplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_jointplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_jointplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_jointplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_kdeplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_kdeplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_kdeplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_kdeplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_kdeplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_lineplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_lineplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_lineplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_lineplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_lineplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_pairplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_pairplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_pairplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_pairplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_pairplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_scatterplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_scatterplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_scatterplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_scatterplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_scatterplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_stripplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_stripplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_stripplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_stripplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_stripplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_swarmplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_swarmplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_swarmplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_swarmplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_swarmplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_violinplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_sns_violinplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_sns_violinplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_sns_violinplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_sns_violinplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stackplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stackplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stackplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stackplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stackplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stem.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stem.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stem_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stem")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stem'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_step.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_step.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_step_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_step")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_step'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_streamplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_streamplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_streamplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_streamplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_streamplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_bar.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_bar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_bar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_bar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_bar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_barh.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_barh.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_barh_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_barh")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_barh'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_conf_mat.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_conf_mat.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_conf_mat_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_conf_mat")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_conf_mat'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_contour.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_contour.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_contour_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_contour")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_contour'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_ecdf.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_ecdf.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_ecdf_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_ecdf")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_ecdf'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_errorbar.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_errorbar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_errorbar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_errorbar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_errorbar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_fillv.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_fillv.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_fillv_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_fillv")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_fillv'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_heatmap.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_heatmap.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_heatmap_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_heatmap")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_heatmap'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_image.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_image.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_image_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_image")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_image'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_imshow.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_imshow.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_imshow_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_imshow")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_imshow'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_joyplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_joyplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_joyplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_joyplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_joyplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_line.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_line.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_line_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_line")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_line'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_mean_ci.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_mean_ci.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_mean_ci_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_mean_ci")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_mean_ci'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_mean_std.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_mean_std.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_mean_std_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_mean_std")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_mean_std'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_median_iqr.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_median_iqr.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_median_iqr_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_median_iqr")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_median_iqr'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_raster.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_raster.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_raster_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_raster")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_raster'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_rectangle.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_rectangle.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_rectangle_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_rectangle")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_rectangle'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_scatter.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_scatter.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_scatter_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_scatter")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_scatter'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_scatter_hist.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_scatter_hist.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_scatter_hist_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_scatter_hist")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_scatter_hist'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_shaded_line.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_shaded_line.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_shaded_line_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_shaded_line")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_shaded_line'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_violin.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_stx_violin.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_stx_violin_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_stx_violin")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_stx_violin'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_text.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_text.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_text_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_text")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_text'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_violin.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_violin.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_violin_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_violin")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_violin'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_violinplot.py
+++ b/tests/figrecipe/_scitex_compat/_csv_formatters/test__format_violinplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__csv_formatters__format_violinplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._csv_formatters._format_violinplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._csv_formatters._format_violinplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/test__scientific.py
+++ b/tests/figrecipe/_scitex_compat/test__scientific.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__scientific_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._scientific")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._scientific'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_scitex_compat/test__shaded_lines.py
+++ b/tests/figrecipe/_scitex_compat/test__shaded_lines.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__scitex_compat__shaded_lines_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._scitex_compat._shaded_lines")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._scitex_compat._shaded_lines'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_signatures/test__kwargs.py
+++ b/tests/figrecipe/_signatures/test__kwargs.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__signatures__kwargs_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._signatures._kwargs")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._signatures._kwargs'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_signatures/test__loader.py
+++ b/tests/figrecipe/_signatures/test__loader.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__signatures__loader_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._signatures._loader")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._signatures._loader'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_signatures/test__parsing.py
+++ b/tests/figrecipe/_signatures/test__parsing.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__signatures__parsing_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._signatures._parsing")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._signatures._parsing'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_specialized_plots/test__annotation.py
+++ b/tests/figrecipe/_specialized_plots/test__annotation.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__specialized_plots__annotation_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._specialized_plots._annotation")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._specialized_plots._annotation'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_specialized_plots/test__heatmap.py
+++ b/tests/figrecipe/_specialized_plots/test__heatmap.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__specialized_plots__heatmap_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._specialized_plots._heatmap")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._specialized_plots._heatmap'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_specialized_plots/test__neuroscience.py
+++ b/tests/figrecipe/_specialized_plots/test__neuroscience.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__specialized_plots__neuroscience_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._specialized_plots._neuroscience")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._specialized_plots._neuroscience'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_sphinx_html/_static/test_generate_quickstart_images.py
+++ b/tests/figrecipe/_sphinx_html/_static/test_generate_quickstart_images.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__sphinx_html__static_generate_quickstart_images_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._sphinx_html._static.generate_quickstart_images")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._sphinx_html._static.generate_quickstart_images'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_utils/test__bundle.py
+++ b/tests/figrecipe/_utils/test__bundle.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__utils__bundle_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._utils._bundle")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._utils._bundle'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_utils/test__calc_nice_ticks.py
+++ b/tests/figrecipe/_utils/test__calc_nice_ticks.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__utils__calc_nice_ticks_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._utils._calc_nice_ticks")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._utils._calc_nice_ticks'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_utils/test__colorbar.py
+++ b/tests/figrecipe/_utils/test__colorbar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__utils__colorbar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._utils._colorbar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._utils._colorbar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_utils/test__crop.py
+++ b/tests/figrecipe/_utils/test__crop.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__utils__crop_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._utils._crop")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._utils._crop'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_utils/test__diff.py
+++ b/tests/figrecipe/_utils/test__diff.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__utils__diff_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._utils._diff")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._utils._diff'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_utils/test__image_diff.py
+++ b/tests/figrecipe/_utils/test__image_diff.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__utils__image_diff_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._utils._image_diff")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._utils._image_diff'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_utils/test__mk_colorbar.py
+++ b/tests/figrecipe/_utils/test__mk_colorbar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__utils__mk_colorbar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._utils._mk_colorbar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._utils._mk_colorbar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_utils/test__numpy_io.py
+++ b/tests/figrecipe/_utils/test__numpy_io.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__utils__numpy_io_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._utils._numpy_io")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._utils._numpy_io'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_utils/test__units.py
+++ b/tests/figrecipe/_utils/test__units.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__utils__units_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._utils._units")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._utils._units'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__axes_diagram.py
+++ b/tests/figrecipe/_wrappers/test__axes_diagram.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__axes_diagram_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._axes_diagram")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._axes_diagram'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__axes_graph.py
+++ b/tests/figrecipe/_wrappers/test__axes_graph.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__axes_graph_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._axes_graph")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._axes_graph'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__axes_helpers.py
+++ b/tests/figrecipe/_wrappers/test__axes_helpers.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__axes_helpers_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._axes_helpers")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._axes_helpers'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__axes_methods.py
+++ b/tests/figrecipe/_wrappers/test__axes_methods.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__axes_methods_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._axes_methods")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._axes_methods'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__axes_scitex.py
+++ b/tests/figrecipe/_wrappers/test__axes_scitex.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__axes_scitex_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._axes_scitex")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._axes_scitex'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__axes_seaborn.py
+++ b/tests/figrecipe/_wrappers/test__axes_seaborn.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__axes_seaborn_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._axes_seaborn")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._axes_seaborn'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__axes_style_mixin.py
+++ b/tests/figrecipe/_wrappers/test__axes_style_mixin.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__axes_style_mixin_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._axes_style_mixin")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._axes_style_mixin'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__boxplot.py
+++ b/tests/figrecipe/_wrappers/test__boxplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__boxplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._boxplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._boxplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__figure.py
+++ b/tests/figrecipe/_wrappers/test__figure.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__figure_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._figure")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._figure'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__panel_labels.py
+++ b/tests/figrecipe/_wrappers/test__panel_labels.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__panel_labels_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._panel_labels")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._panel_labels'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__pie_helpers.py
+++ b/tests/figrecipe/_wrappers/test__pie_helpers.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__pie_helpers_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._pie_helpers")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._pie_helpers'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__plot_helpers.py
+++ b/tests/figrecipe/_wrappers/test__plot_helpers.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__plot_helpers_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._plot_helpers")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._plot_helpers'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__subplots.py
+++ b/tests/figrecipe/_wrappers/test__subplots.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__subplots_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._subplots")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._subplots'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__violin_helpers.py
+++ b/tests/figrecipe/_wrappers/test__violin_helpers.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__violin_helpers_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._violin_helpers")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._violin_helpers'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_wrappers/test__violin_kde.py
+++ b/tests/figrecipe/_wrappers/test__violin_kde.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import__wrappers__violin_kde_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe._wrappers._violin_kde")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe._wrappers._violin_kde'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/colors/test__PARAMS.py
+++ b/tests/figrecipe/colors/test__PARAMS.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_colors__PARAMS_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.colors._PARAMS")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.colors._PARAMS'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/colors/test__colormap.py
+++ b/tests/figrecipe/colors/test__colormap.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_colors__colormap_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.colors._colormap")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.colors._colormap'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/colors/test__colors.py
+++ b/tests/figrecipe/colors/test__colors.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_colors__colors_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.colors._colors")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.colors._colors'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/colors/test__interpolate.py
+++ b/tests/figrecipe/colors/test__interpolate.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_colors__interpolate_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.colors._interpolate")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.colors._interpolate'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/presets/test__journals.py
+++ b/tests/figrecipe/presets/test__journals.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_presets__journals_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.presets._journals")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.presets._journals'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/_axis_helpers/test__base.py
+++ b/tests/figrecipe/styles/_axis_helpers/test__base.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__axis_helpers__base_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._axis_helpers._base")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._axis_helpers._base'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/_axis_helpers/test__geometry.py
+++ b/tests/figrecipe/styles/_axis_helpers/test__geometry.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__axis_helpers__geometry_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._axis_helpers._geometry")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._axis_helpers._geometry'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/_axis_helpers/test__rotate_labels.py
+++ b/tests/figrecipe/styles/_axis_helpers/test__rotate_labels.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__axis_helpers__rotate_labels_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._axis_helpers._rotate_labels")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._axis_helpers._rotate_labels'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/_axis_helpers/test__sci_note.py
+++ b/tests/figrecipe/styles/_axis_helpers/test__sci_note.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__axis_helpers__sci_note_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._axis_helpers._sci_note")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._axis_helpers._sci_note'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/_axis_helpers/test__spines.py
+++ b/tests/figrecipe/styles/_axis_helpers/test__spines.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__axis_helpers__spines_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._axis_helpers._spines")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._axis_helpers._spines'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/_axis_helpers/test__ticks.py
+++ b/tests/figrecipe/styles/_axis_helpers/test__ticks.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__axis_helpers__ticks_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._axis_helpers._ticks")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._axis_helpers._ticks'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__barplot.py
+++ b/tests/figrecipe/styles/plot_stylers/test__barplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__barplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._barplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._barplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__base.py
+++ b/tests/figrecipe/styles/plot_stylers/test__base.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__base_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._base")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._base'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__boxplot.py
+++ b/tests/figrecipe/styles/plot_stylers/test__boxplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__boxplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._boxplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._boxplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__errorbar.py
+++ b/tests/figrecipe/styles/plot_stylers/test__errorbar.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__errorbar_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._errorbar")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._errorbar'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__heatmap.py
+++ b/tests/figrecipe/styles/plot_stylers/test__heatmap.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__heatmap_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._heatmap")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._heatmap'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__histogram.py
+++ b/tests/figrecipe/styles/plot_stylers/test__histogram.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__histogram_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._histogram")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._histogram'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__imshow.py
+++ b/tests/figrecipe/styles/plot_stylers/test__imshow.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__imshow_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._imshow")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._imshow'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__line.py
+++ b/tests/figrecipe/styles/plot_stylers/test__line.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__line_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._line")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._line'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__pie.py
+++ b/tests/figrecipe/styles/plot_stylers/test__pie.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__pie_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._pie")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._pie'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__scatter.py
+++ b/tests/figrecipe/styles/plot_stylers/test__scatter.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__scatter_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._scatter")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._scatter'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/plot_stylers/test__violinplot.py
+++ b/tests/figrecipe/styles/plot_stylers/test__violinplot.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles_plot_stylers__violinplot_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles.plot_stylers._violinplot")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles.plot_stylers._violinplot'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__color_resolver.py
+++ b/tests/figrecipe/styles/test__color_resolver.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__color_resolver_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._color_resolver")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._color_resolver'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__dotdict.py
+++ b/tests/figrecipe/styles/test__dotdict.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__dotdict_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._dotdict")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._dotdict'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__finalize.py
+++ b/tests/figrecipe/styles/test__finalize.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__finalize_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._finalize")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._finalize'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__fonts.py
+++ b/tests/figrecipe/styles/test__fonts.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__fonts_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._fonts")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._fonts'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__internal.py
+++ b/tests/figrecipe/styles/test__internal.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__internal_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._internal")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._internal'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__kwargs_converter.py
+++ b/tests/figrecipe/styles/test__kwargs_converter.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__kwargs_converter_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._kwargs_converter")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._kwargs_converter'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__plot_styles.py
+++ b/tests/figrecipe/styles/test__plot_styles.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__plot_styles_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._plot_styles")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._plot_styles'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__style_applier.py
+++ b/tests/figrecipe/styles/test__style_applier.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__style_applier_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._style_applier")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._style_applier'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__style_loader.py
+++ b/tests/figrecipe/styles/test__style_loader.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__style_loader_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._style_loader")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._style_loader'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/styles/test__themes.py
+++ b/tests/figrecipe/styles/test__themes.py
@@ -4,13 +4,14 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-import importlib
+
+import pytest
 
 
 def test_import_styles__themes_module():
-    """Module imports without raising hard errors."""
-    try:
-        importlib.import_module("figrecipe.styles._themes")
-    except ImportError:
-        # Optional-dependency module; skip when extras absent.
-        return
+    # Arrange
+    module_path = 'figrecipe.styles._themes'
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/test__branding.py
+++ b/tests/figrecipe/test__branding.py
@@ -1,220 +1,172 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Tests for branding module."""
+"""Tests for branding module.
 
+Real-collaborator tests: each test mutates ``os.environ`` directly and
+restores it via a ``yield``-based fixture (no ``unittest.mock.patch``).
+The branding module reads ``FIGRECIPE_BRAND`` / ``FIGRECIPE_ALIAS`` at
+import time, so the fixture also ``importlib.reload``s it under the
+chosen env, then reloads it again under defaults on teardown.
+"""
+
+import importlib
 import os
-from unittest.mock import patch
 
 import pytest
 
+import figrecipe._branding as branding
+
+
+def _apply_brand(brand: str, alias: str) -> None:
+    os.environ["FIGRECIPE_BRAND"] = brand
+    os.environ["FIGRECIPE_ALIAS"] = alias
+    importlib.reload(branding)
+
+
+@pytest.fixture
+def _branding_env():
+    """Snapshot + restore FIGRECIPE_BRAND/ALIAS and reload module."""
+    saved_brand = os.environ.get("FIGRECIPE_BRAND")
+    saved_alias = os.environ.get("FIGRECIPE_ALIAS")
+    try:
+        yield _apply_brand
+    finally:
+        if saved_brand is None:
+            os.environ.pop("FIGRECIPE_BRAND", None)
+        else:
+            os.environ["FIGRECIPE_BRAND"] = saved_brand
+        if saved_alias is None:
+            os.environ.pop("FIGRECIPE_ALIAS", None)
+        else:
+            os.environ["FIGRECIPE_ALIAS"] = saved_alias
+        importlib.reload(branding)
+
 
 class TestRebrandText:
-    """Tests for rebrand_text function."""
+    """Tests for ``figrecipe._branding.rebrand_text``."""
 
-    def test_no_branding_returns_unchanged(self):
-        """When env vars are default, text is unchanged."""
-
+    def test_default_brand_returns_text_unchanged(self, _branding_env):
+        # Arrange
+        _branding_env("figrecipe", "fr")
         text = "import figrecipe as fr"
-        # With default branding, should return unchanged
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "figrecipe", "FIGRECIPE_ALIAS": "fr"},
-            clear=False,
-        ):
-            # Need to reimport to pick up env vars
-            import importlib
+        # Act
+        result = branding.rebrand_text(text)
+        # Assert
+        assert result == text
 
-            import figrecipe._branding as branding
+    def test_scitex_plt_rebrands_import_statement(self, _branding_env):
+        # Arrange
+        _branding_env("scitex.plt", "plt")
+        text = "import figrecipe as fr"
+        # Act
+        result = branding.rebrand_text(text)
+        # Assert
+        assert result == "import scitex.plt as plt"
 
-            importlib.reload(branding)
-            result = branding.rebrand_text(text)
-            assert result == text
+    def test_scitex_plt_rebrands_variable_usage_in_examples(
+        self, _branding_env
+    ):
+        # Arrange
+        _branding_env("scitex.plt", "plt")
+        text = ">>> fr.subplots()"
+        # Act
+        result = branding.rebrand_text(text)
+        # Assert
+        assert result == ">>> plt.subplots()"
 
-    def test_rebrand_import_statement(self):
-        """Test rebranding of import statement."""
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "scitex.plt", "FIGRECIPE_ALIAS": "plt"},
-            clear=False,
-        ):
-            import importlib
-
-            import figrecipe._branding as branding
-
-            importlib.reload(branding)
-
-            text = "import figrecipe as fr"
-            result = branding.rebrand_text(text)
-            assert result == "import scitex.plt as plt"
-
-    def test_rebrand_variable_usage(self):
-        """Test rebranding of variable usage in examples."""
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "scitex.plt", "FIGRECIPE_ALIAS": "plt"},
-            clear=False,
-        ):
-            import importlib
-
-            import figrecipe._branding as branding
-
-            importlib.reload(branding)
-
-            text = ">>> fr.subplots()"
-            result = branding.rebrand_text(text)
-            assert result == ">>> plt.subplots()"
-
-    def test_rebrand_from_import(self):
-        """Test rebranding of from...import statement."""
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "scitex.plt", "FIGRECIPE_ALIAS": "plt"},
-            clear=False,
-        ):
-            import importlib
-
-            import figrecipe._branding as branding
-
-            importlib.reload(branding)
-
-            text = "from figrecipe import utils"
-            result = branding.rebrand_text(text)
-            assert result == "from scitex.plt import utils"
+    def test_scitex_plt_rebrands_from_import_statement(self, _branding_env):
+        # Arrange
+        _branding_env("scitex.plt", "plt")
+        text = "from figrecipe import utils"
+        # Act
+        result = branding.rebrand_text(text)
+        # Assert
+        assert result == "from scitex.plt import utils"
 
     def test_none_input_returns_none(self):
-        """Test that None input returns None."""
+        # Arrange
         from figrecipe._branding import rebrand_text
+        # Act
+        result = rebrand_text(None)
+        # Assert
+        assert result is None
 
-        assert rebrand_text(None) is None
-
-    def test_preserves_urls(self):
-        """Test that URLs containing figrecipe are not mangled."""
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "scitex.plt", "FIGRECIPE_ALIAS": "plt"},
-            clear=False,
-        ):
-            import importlib
-
-            import figrecipe._branding as branding
-
-            importlib.reload(branding)
-
-            text = "https://github.com/user/figrecipe"
-            result = branding.rebrand_text(text)
-            # URL should be preserved
-            assert "github.com" in result
+    def test_preserves_url_domain_when_rebranding(self, _branding_env):
+        # Arrange
+        _branding_env("scitex.plt", "plt")
+        text = "https://github.com/user/figrecipe"
+        # Act
+        result = branding.rebrand_text(text)
+        # Assert
+        assert "github.com" in result
 
 
 class TestGetBrandedImportExample:
-    """Tests for get_branded_import_example function."""
+    """Tests for ``figrecipe._branding.get_branded_import_example``."""
 
-    def test_default_import(self):
-        """Test default import example."""
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "figrecipe", "FIGRECIPE_ALIAS": "fr"},
-            clear=False,
-        ):
-            import importlib
+    def test_default_brand_returns_import_figrecipe_as_fr(
+        self, _branding_env
+    ):
+        # Arrange
+        _branding_env("figrecipe", "fr")
+        # Act
+        result = branding.get_branded_import_example()
+        # Assert
+        assert result == "import figrecipe as fr"
 
-            import figrecipe._branding as branding
-
-            importlib.reload(branding)
-
-            result = branding.get_branded_import_example()
-            assert result == "import figrecipe as fr"
-
-    def test_submodule_import(self):
-        """Test submodule import example."""
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "scitex.plt", "FIGRECIPE_ALIAS": "plt"},
-            clear=False,
-        ):
-            import importlib
-
-            import figrecipe._branding as branding
-
-            importlib.reload(branding)
-
-            result = branding.get_branded_import_example()
-            assert result == "from scitex import plt as plt"
+    def test_submodule_brand_returns_from_scitex_import_plt(
+        self, _branding_env
+    ):
+        # Arrange
+        _branding_env("scitex.plt", "plt")
+        # Act
+        result = branding.get_branded_import_example()
+        # Assert
+        assert result == "from scitex import plt as plt"
 
 
 class TestGetMcpServerName:
-    """Tests for get_mcp_server_name function."""
+    """Tests for ``figrecipe._branding.get_mcp_server_name``."""
 
-    def test_default_name(self):
-        """Test default MCP server name."""
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "figrecipe", "FIGRECIPE_ALIAS": "fr"},
-            clear=False,
-        ):
-            import importlib
+    def test_default_brand_returns_figrecipe_server_name(
+        self, _branding_env
+    ):
+        # Arrange
+        _branding_env("figrecipe", "fr")
+        # Act
+        result = branding.get_mcp_server_name()
+        # Assert
+        assert result == "figrecipe"
 
-            import figrecipe._branding as branding
-
-            importlib.reload(branding)
-
-            result = branding.get_mcp_server_name()
-            assert result == "figrecipe"
-
-    def test_submodule_name_converts_dots(self):
-        """Test that dots are converted to dashes in MCP name."""
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "scitex.plt", "FIGRECIPE_ALIAS": "plt"},
-            clear=False,
-        ):
-            import importlib
-
-            import figrecipe._branding as branding
-
-            importlib.reload(branding)
-
-            result = branding.get_mcp_server_name()
-            assert result == "scitex-plt"
+    def test_dotted_brand_converts_dots_to_dashes(self, _branding_env):
+        # Arrange
+        _branding_env("scitex.plt", "plt")
+        # Act
+        result = branding.get_mcp_server_name()
+        # Assert
+        assert result == "scitex-plt"
 
 
 class TestGetMcpInstructions:
-    """Tests for get_mcp_instructions function."""
+    """Tests for ``figrecipe._branding.get_mcp_instructions``."""
 
-    def test_instructions_contain_brand_name(self):
-        """Test that instructions contain the brand name."""
-        with patch.dict(
-            os.environ,
-            {"FIGRECIPE_BRAND": "scitex.plt", "FIGRECIPE_ALIAS": "plt"},
-            clear=False,
-        ):
-            import importlib
-
-            import figrecipe._branding as branding
-
-            importlib.reload(branding)
-
-            result = branding.get_mcp_instructions()
-            assert "scitex.plt" in result
-            assert "MCP server" in result
-
-
-# Cleanup: restore default branding after tests
-@pytest.fixture(autouse=True)
-def restore_default_branding():
-    """Restore default branding after each test."""
-    yield
-    # Restore defaults
-    with patch.dict(
-        os.environ,
-        {"FIGRECIPE_BRAND": "figrecipe", "FIGRECIPE_ALIAS": "fr"},
-        clear=False,
+    def test_instructions_contain_configured_brand_name(
+        self, _branding_env
     ):
-        import importlib
+        # Arrange
+        _branding_env("scitex.plt", "plt")
+        # Act
+        result = branding.get_mcp_instructions()
+        # Assert
+        assert "scitex.plt" in result
 
-        import figrecipe._branding as branding
-
-        importlib.reload(branding)
+    def test_instructions_mention_mcp_server(self, _branding_env):
+        # Arrange
+        _branding_env("scitex.plt", "plt")
+        # Act
+        result = branding.get_mcp_instructions()
+        # Assert
+        assert "MCP server" in result
 
 
 # EOF


### PR DESCRIPTION
## Summary

Migrate the figrecipe test tree onto the NM + TQ contract (no mocks, AAA markers, ≥3-token descriptive names, one assert per test).

Canonical 4-pass migration per `~/.claude/skills/scitex/general/05_development_09_ecosystem-tq-migration.md`:
1. NM (no-mocks) — strip `unittest.mock` imports, replace `patch.dict`/`monkeypatch` with `yield`-based fixtures over real `os.environ`.
2. TQ003 — rename short test names to `test_<subject>_<condition>_<expected>` form.
3. TQ002 — insert `# Arrange` / `# Act` / `# Assert` marker comments at phase boundaries.
4. TQ007 — split multi-assertion tests into one-assertion-per-test, sharing setup via fixtures.

Baseline: `scitex-dev ecosystem audit-python-apis figrecipe` → ~1999 PA-306/PA-307 violations.
Goal: 0.

This PR is being assembled incrementally. Status updates will follow.

## Test plan
- [ ] `scitex-dev ecosystem audit-all figrecipe` → 0 PA-306/PA-307 violations
- [ ] `python -m pytest tests/ -q -p no:randomly` → green
- [ ] `python -m pytest tests/ -q` (pytest-randomly enabled) → green