### PR TITLE
ci: normalize codecov.yml to canonical shape

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,29 @@
+codecov:
+  require_ci_to_pass: false
+  # Treat develop as the de-facto default branch — main is a stable
+  # release mirror that only fast-forwards from develop, so develop
+  # is where coverage uploads land. This makes the unbranched badge
+  # endpoint (/graph/badge.svg) follow develop's value.
+  branch: develop
+
 coverage:
   status:
     project:
       default:
-        # Coverage is still ramping up; switch to a hard 90% target once
-        # the long-tail unit tests (_cli/, _mcp/_handlers/, _plot_*) land.
-        # See 05_development_08_coverage-push-playbook.md for the recipe.
         target: auto
         threshold: 1%
     patch:
       default:
-        target: auto
-        threshold: 1%
+        target: 80%
 
-comment: false
+ignore:
+  - "src/figrecipe/_sphinx_html/**"
+  - "src/figrecipe/_skills/**"
+  - "src/figrecipe/_completion.py"
+  - "src/figrecipe/_cli/_completion.py"
+  - "tests/**"
+  - "examples/**"
+
+comment:
+  layout: "diff, files"
+  require_changes: true


### PR DESCRIPTION
Normalizes Codecov config to the canonical ecosystem shape (general/02_package_11_ci-and-codecov.md):

- codecov.branch: develop — unbranched badge follows develop, not the stale main release-mirror
- ignore: _sphinx_html, _skills, _completion, _cli/_completion, tests, examples
- patch target 80%; project target auto/1%
- canonical comment block

The pytest-matrix workflow's codecov-action@v5 upload step is already correct. UNMERGED for review.