### PR TITLE
chore(audit): finish section 6 cleanup — config.yaml exemption knob, bump scitex-dev to 0.12.0

### DIFF
--- a/.github/workflows/figrecipe-quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/figrecipe-quality-audit-on-ubuntu-latest.yml
@@ -42,7 +42,19 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-          pip install "scitex-dev[cli-audit]"
+          pip install "scitex-dev[cli-audit]>=0.12.1"
+
+      - name: Install fd (Rust file finder; preferred fast path for audit discovery)
+        run: |
+          # scitex-dev's audit-project orphan-hinter prefers fd/fdfind for
+          # file discovery. Absent fd it warns + falls back to a stdlib walk,
+          # but this repo sets audit.require-fd: true (.scitex/dev/config.yaml)
+          # so the audit ERRORS if fd is missing — install it here so the fast
+          # path always runs. Debian/Ubuntu ships the binary as `fdfind`;
+          # symlink it to `fd` so scitex-dev's `fd` lookup resolves too.
+          sudo apt-get update && sudo apt-get install -y fd-find
+          sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+          fd --version
 
       - name: Run scitex-dev ecosystem audit-all
         run: scitex-dev ecosystem audit-all figrecipe --no-version-check

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -30,6 +30,17 @@ jobs:
           # (yaml, fastmcp, textual) get exercised. Falls back to [dev] then
           # plain editable so a packaging hiccup doesn't strand CI.
           pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
+      - name: Install fd (Rust file finder; preferred fast path for audit discovery)
+        run: |
+          # tests/develop/test_audit.py runs scitex-dev's audit-project, whose
+          # orphan-hinter prefers fd/fdfind for file discovery. This repo sets
+          # audit.require-fd: true (.scitex/dev/config.yaml), so fd-absence
+          # ERRORS rather than falling back — install it here. Debian/Ubuntu
+          # ships the binary as `fdfind`; symlink to `fd` so the `fd` lookup
+          # resolves too.
+          sudo apt-get update && sudo apt-get install -y fd-find
+          sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+          fd --version
       - name: Run tests
         run: |
           pytest tests/ --cov=src/figrecipe --cov-report=xml --cov-report=term

--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -5,6 +5,14 @@
 project-type:
   - pip
 
+# figrecipe's MCP surface mirrors matplotlib Axes methods (plot / scatter /
+# bar / hist / …); those ~74 tools have no standalone Python-function
+# counterpart by design, so the §6 MCP<->Python-API parity rule is a false
+# positive for this package. Opt out of the §6 parity/orphan-tool check.
+# Read by scitex-dev >= 0.12.0's audit-mcp-tools / audit-all.
+audit:
+  mcp-parity-exempt: true
+
 # audit:
 #   skip:
 #     - PS-108

--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -12,6 +12,12 @@ project-type:
 # Read by scitex-dev >= 0.12.0's audit-mcp-tools / audit-all.
 audit:
   mcp-parity-exempt: true
+  # Belt-and-suspenders with the CI fd-install step: scitex-dev's
+  # audit-project orphan-hinter prefers fd and, when absent, warns + falls
+  # back to a slower stdlib walk. We install fd in CI; require-fd makes the
+  # audit ERROR if fd is somehow still missing, so our CI always runs the
+  # fast path rather than silently degrading. Read by scitex-dev >= 0.12.1.
+  require-fd: true
 
 # audit:
 #   skip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "rich>=13.0.0",
     "scitex-app>=0.2.0",
     "scitex-config>=0.3.0",
-    "scitex-dev>=0.12.0",
+    "scitex-dev>=0.12.1",
 ]
 
 [project.optional-dependencies]
@@ -56,7 +56,7 @@ dev = [
     "pytest-xdist>=3.0.0",
     "pre-commit>=3.5.0",
     "pyyaml>=6.0.0",
-    "scitex-dev>=0.12.0",
+    "scitex-dev>=0.12.1",
     # Mirror runtime extras so `pip install -e .[dev]` runs the full suite.
     # Tests import these unguarded; PS210 audit invariants.
     "scitex-app>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "rich>=13.0.0",
     "scitex-app>=0.2.0",
     "scitex-config>=0.3.0",
-    "scitex-dev>=0.11.7",
+    "scitex-dev>=0.12.0",
 ]
 
 [project.optional-dependencies]
@@ -56,7 +56,7 @@ dev = [
     "pytest-xdist>=3.0.0",
     "pre-commit>=3.5.0",
     "pyyaml>=6.0.0",
-    "scitex-dev>=0.11.7",
+    "scitex-dev>=0.12.0",
     # Mirror runtime extras so `pip install -e .[dev]` runs the full suite.
     # Tests import these unguarded; PS210 audit invariants.
     "scitex-app>=0.1.0",
@@ -158,16 +158,6 @@ Homepage = "https://github.com/ywatanabe1989/figrecipe"
 Documentation = "https://figrecipe.readthedocs.io"
 Repository = "https://github.com/ywatanabe1989/figrecipe.git"
 Issues = "https://github.com/ywatanabe1989/figrecipe/issues"
-
-[tool.scitex_dev]
-# figrecipe's MCP surface mirrors matplotlib Axes methods (plot / scatter /
-# bar / hist / …); those ~74 tools have no standalone Python-function
-# counterpart by design, so the §6 MCP↔Python-API parity rule is a false
-# positive for this package. Declare the exemption here (read by
-# scitex-dev's audit-mcp-tools / audit-all). Requires scitex-dev with the
-# mcp_parity_exempt knob; until that release lands, tests/develop/test_audit.py
-# keeps skip_rules=("§6",) as the active mechanism.
-mcp_parity_exempt = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/figrecipe"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "rich>=13.0.0",
     "scitex-app>=0.2.0",
     "scitex-config>=0.3.0",
-    "scitex-dev>=0.12.1",
+    "scitex-dev>=0.12.2",
 ]
 
 [project.optional-dependencies]
@@ -56,7 +56,7 @@ dev = [
     "pytest-xdist>=3.0.0",
     "pre-commit>=3.5.0",
     "pyyaml>=6.0.0",
-    "scitex-dev>=0.12.1",
+    "scitex-dev>=0.12.2",
     # Mirror runtime extras so `pip install -e .[dev]` runs the full suite.
     # Tests import these unguarded; PS210 audit invariants.
     "scitex-app>=0.1.0",

--- a/tests/develop/test_audit.py
+++ b/tests/develop/test_audit.py
@@ -22,28 +22,9 @@ def test_audit_all_for_package_reports_clean():
 
     # Act
     # `audit_all_for_package` raises (pytest.fail) on any violation;
-    # a clean return is the assertion proxy.
-    audit_all_for_package(
-        "figrecipe",
-        skip_rules=(
-            # MCP <-> Python-API parity gap: 74 MCP tools (mostly
-            # diagram_*, e.g. diagram_compile_graphviz / diagram_create)
-            # are thin wrappers around external CLIs (graphviz / mermaid /
-            # plantuml) with no Python-API counterpart by design. The
-            # auditor's pairing rule (§6) flags every one as architectural
-            # debt.
-            #
-            # The DECLARED exemption now lives in pyproject.toml as
-            # `[tool.scitex_dev] mcp_parity_exempt = true`. This skip_rules
-            # entry is the TRANSITIONAL fallback: CI installs scitex-dev
-            # from PyPI (`scitex-dev>=0.11.7`), and the mcp_parity_exempt
-            # knob only suppresses §6 once a scitex-dev release carrying it
-            # is published and the pin is bumped. Until then, the knob is a
-            # forward-compatible no-op and this entry keeps pytest-matrix
-            # green. Remove this entry (keeping the pyproject declaration)
-            # after bumping scitex-dev to the version with the knob.
-            "§6",
-        ),
-    )
+    # a clean return is the assertion proxy. The §6 MCP<->Python-API
+    # parity rule is exempted via `.scitex/dev/config.yaml`
+    # (audit.mcp-parity-exempt: true), read by scitex-dev >= 0.12.0.
+    audit_all_for_package("figrecipe")
     # Assert
     assert True  # `audit_all_for_package` raises on failure


### PR DESCRIPTION
Back-half of the section-6 (MCP <-> Python-API parity) release cleanup, now
that scitex-dev 0.12.0 is published to PyPI.

## What changed
- **Bump pin**: `scitex-dev>=0.11.7` -> `>=0.12.0` (both runtime deps and
  `[dev]` extras). 0.12.0 ships the `mcp_parity_exempt` audit knob.
- **Proper exemption knob**: declared in `.scitex/dev/config.yaml` as
  `audit.mcp-parity-exempt: true` (project-type-agnostic; read by
  scitex-dev >= 0.12.0's `is_mcp_parity_exempt`). The transitional
  `[tool.scitex_dev] mcp_parity_exempt = true` block is removed from
  pyproject.toml to keep a single source of truth.
- **Drop transitional hack**: removed `skip_rules=("section-6",)` from
  `tests/develop/test_audit.py`; the test now calls
  `audit_all_for_package("figrecipe")` with the exemption coming purely
  from the config knob. AAA structure, descriptive name, single assertion
  preserved.

## Verification (released scitex-dev 0.12.0, figrecipe importable)
`scitex-dev ecosystem audit-all figrecipe` -> all five auditors SUCC, exit 0.
The mcp-parity check reports:

```
INFO: figrecipe: section-6 MCP-parity exempt by config (...) — plotting/diagram-rich tool surface mirrors external methods with no Python-API counterpart
```

`pytest tests/develop/test_audit.py` -> 1 passed.

## Notes
- Local pre-commit hooks (ruff, ruff-format, yaml, pytest-testmon) all
  passed on commit.
- Branched off origin/develop; the section-6 exemption itself (PR #122)
  is already merged — this finishes the pin bump + knob relocation + hack
  removal that the prior pass left for the post-0.12.0-release window.