### PR TITLE
release: figrecipe v0.28.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.28.10"
+version = "0.28.11"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump 0.28.10 → 0.28.11 (PATCH).

Ships the section-6 audit cleanup finish (#123): config.yaml exemption knob, dropped the transitional skip, MCP-parity exemption declared, plus the fd-install CI gate fix and sphinx -W docstring fixes. No public API change — patch-level.

Bump-only PR (pyproject.toml).