### PR TITLE
ci(release): install fd in on-tag pytest gate

### DIFF
--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -57,6 +57,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
+      - name: Install fd (Rust file finder; preferred fast path for audit discovery)
+        run: |
+          # tests/develop/test_audit.py runs scitex-dev's audit-project, whose
+          # orphan-hinter prefers fd/fdfind for file discovery. This repo sets
+          # audit.require-fd: true (.scitex/dev/config.yaml), so fd-absence
+          # ERRORS rather than falling back — install it here. Debian/Ubuntu
+          # ships the binary as `fdfind`; symlink to `fd` so the `fd` lookup
+          # resolves too. Mirrors the pytest-matrix workflow (#123).
+          sudo apt-get update && sudo apt-get install -y fd-find
+          sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+          fd --version
       - name: Run pytest
         run: |
           if [ -d tests ]; then


### PR DESCRIPTION
The on-tag publish workflow (`pypi-publish-and-github-release-on-tag.yml`) test job ran `pytest tests/` without installing fd. With `audit.require-fd: true`, `tests/develop/test_audit.py` errors with FdNotFoundError, halting the publish pipeline (build/publish skipped).

#123 added the fd-install step to the `tests` (pytest-matrix) workflow but missed this on-tag one. Mirror the same step so the v* publish gate passes.

Discovered while releasing v0.28.11 — the tag fired but the publish gate failed on this.