### PR TITLE
docs: refresh version, python req, and branding references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 !-- File: /home/ywatanabe/proj/figrecipe/README.md
 !-- --- -->
 
-# FigRecipe (<code>scitex-plt</code>)
+# FigRecipe
 
 <p align="center">
   <a href="https://scitex.ai">
@@ -33,8 +33,8 @@
 
 | # | Problem | Solution |
 |---|---------|----------|
-| 1 | **Figures drift from data** -- `plt.savefig(...)` produces a PNG whose source data disappears the moment the notebook closes | **Recipe + data + PNG atomic** -- each `ax.stx_*()` call records inputs; `stx.io.save(fig)` writes `.png + .csv + .yaml` so figures are replayable from the recipe |
-| 2 | **Restyling requires re-running analysis** -- changing fonts/colors/layout means rebuilding the figure from scratch | **Reproduce from recipe** -- `stx.plt.reproduce("fig.yaml", style="nature")` restyles without touching data; hashes stay valid for Clew |
+| 1 | **Figures drift from data** -- `plt.savefig(...)` produces a PNG whose source data disappears the moment the notebook closes | **Recipe + data + PNG atomic** -- each `ax.plot()` call records inputs; `fr.save(fig)` writes `.png + .csv + .yaml` so figures are replayable from the recipe |
+| 2 | **Restyling requires re-running analysis** -- changing fonts/colors/layout means rebuilding the figure from scratch | **Reproduce from recipe** -- `fr.reproduce("fig.yaml", style="nature")` restyles without touching data; hashes stay valid for Clew |
 | 3 | **mm-precision layout hard** -- matplotlib uses inches/pixels; journals demand mm | **Native mm layout** -- `figure_mm()` + `figure_from_axes_mm()` give journal-grade column widths without conversion math |
 
 ## Installation

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath("../../src"))
 project = "FigRecipe"
 copyright = "2026, Yusuke Watanabe"
 author = "Yusuke Watanabe"
-release = "0.27.0"
+release = "0.28.12"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,6 +1,6 @@
 .. FigRecipe documentation master file
 
-FigRecipe (``scitex-plt``) - Reproducible Scientific Figures
+FigRecipe - Reproducible Scientific Figures
 =============================================================
 
 **FigRecipe** is a framework for creating reproducible, style-editable scientific figures via YAML recipes. It wraps matplotlib with automatic recording, enabling figures to be reproduced, modified, and shared. Part of `SciTeX <https://scitex.ai>`_.

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -55,7 +55,7 @@ For development:
 Requirements
 ------------
 
-- Python 3.9+
+- Python 3.10+
 - matplotlib >= 3.5
 - numpy
 - PyYAML


### PR DESCRIPTION
## Summary
- Bump sphinx conf.py release from 0.27.0 → 0.28.12 (matching pyproject.toml)
- Fix installation.rst minimum Python from 3.9+ → 3.10+ (matching pyproject.toml)
- Drop legacy `scitex-plt` label from sphinx index.rst title
- Replace stale `stx.*` API references in README.md with current `fr.*` API

## Test plan
- [ ] `sphinx-build -W` passes
- [ ] All generated doc pages render correctly