### PR TITLE
feat: expose public figrecipe.diagram API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ outputs/
 !pyproject.toml
 !outputs/notebook/*.yaml
 !src/figrecipe/styles/presets/*.yaml
+!src/figrecipe/presets/*.yaml
 *.npy
 *.npz
 *.csv

--- a/src/figrecipe/diagram.py
+++ b/src/figrecipe/diagram.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Public diagram API for figrecipe.
+
+This module is the public face of figrecipe's diagram subsystem. The
+implementation lives in the private ``figrecipe._diagram`` package; this
+module re-exports the stable, public diagram API so consumers can write::
+
+    import figrecipe.diagram
+    from figrecipe.diagram import Diagram, compile_to_mermaid
+
+It mirrors how ``figrecipe.pyplot`` is exposed as a public submodule on top
+of the recording internals.
+
+Examples
+--------
+Box-and-arrow diagram (the primary ``Diagram`` builder)::
+
+    >>> from figrecipe.diagram import Diagram
+    >>> d = Diagram(title="Pipeline")
+    >>> d.add_box("Load", x_mm=10, y_mm=10)  # doctest: +SKIP
+
+Mermaid / Graphviz compilation from a semantic ``DiagramSpec``::
+
+    >>> from figrecipe.diagram import (
+    ...     DiagramSpec, DiagramType, NodeSpec, EdgeSpec, compile_to_mermaid
+    ... )
+    >>> spec = DiagramSpec(
+    ...     type=DiagramType.WORKFLOW,
+    ...     nodes=[NodeSpec(id="a", label="Start"),
+    ...            NodeSpec(id="b", label="End")],
+    ...     edges=[EdgeSpec(source="a", target="b")],
+    ... )
+    >>> mermaid = compile_to_mermaid(spec)
+"""
+
+from __future__ import annotations
+
+# Box-and-arrow Diagram builder + graph-compilation schema/presets/split.
+from ._diagram import (
+    DECISION_PRESET,
+    PIPELINE_PRESET,
+    SCIENTIFIC_PRESET,
+    WORKFLOW_PRESET,
+    ColumnLayout,
+    Diagram,
+    DiagramPreset,
+    DiagramSpec,
+    DiagramType,
+    EdgeSpec,
+    GraphDiagram,
+    LayoutHints,
+    NodeSpec,
+    PaperConstraints,
+    PaperMode,
+    SpacingLevel,
+    SplitConfig,
+    SplitResult,
+    SplitStrategy,
+    get_available_backends,
+    get_preset,
+    list_presets,
+)
+
+# Backend compilers (public entry points for Mermaid / Graphviz workflows).
+from ._diagram._graphviz._compile import compile_to_graphviz
+from ._diagram._mermaid._compile import compile_to_mermaid
+
+__all__ = [
+    # Box-and-arrow builder
+    "Diagram",
+    # Graph compilation
+    "GraphDiagram",
+    # Schema
+    "DiagramSpec",
+    "DiagramType",
+    "NodeSpec",
+    "EdgeSpec",
+    "PaperConstraints",
+    "LayoutHints",
+    "ColumnLayout",
+    "SpacingLevel",
+    "PaperMode",
+    # Backend compilers
+    "compile_to_mermaid",
+    "compile_to_graphviz",
+    # Presets
+    "DiagramPreset",
+    "get_preset",
+    "list_presets",
+    "WORKFLOW_PRESET",
+    "DECISION_PRESET",
+    "PIPELINE_PRESET",
+    "SCIENTIFIC_PRESET",
+    # Split
+    "SplitConfig",
+    "SplitResult",
+    "SplitStrategy",
+    # Render
+    "get_available_backends",
+]
+
+# EOF

--- a/src/figrecipe/presets/SCITEX_STYLE.yaml
+++ b/src/figrecipe/presets/SCITEX_STYLE.yaml
@@ -1,0 +1,129 @@
+# SciTeX Style Configuration
+# ===========================
+# Centralized style settings for publication-quality figures.
+# Users can modify this file or create their own YAML file.
+#
+# Units:
+#   - *_mm: millimeters (converted to points internally)
+#   - *_pt: points (1 pt = 1/72 inch)
+#
+# Usage:
+#   from scitex.plt import load_style
+#   style = load_style()  # Load default SCITEX_STYLE.yaml
+#   style = load_style("path/to/custom_style.yaml")  # Load custom style
+#   fig, ax = stx.plt.subplots(**style)
+
+# =============================================================================
+# AXES DIMENSIONS
+# =============================================================================
+# Can be scalar (applies to all) or list matching axes.flat size
+axes:
+  width_mm: 40           # Axes width in mm (scalar or list)
+  height_mm: 28          # Axes height in mm (scalar or list, 1:0.7 ratio)
+  thickness_mm: 0.2      # Spine line thickness in mm
+
+# =============================================================================
+# MARGINS AND SPACING (in mm)
+# =============================================================================
+margins:
+  left_mm: 20            # Left margin (large for labels, crop afterwards)
+  right_mm: 20           # Right margin (for colorbars)
+  bottom_mm: 20          # Bottom margin (for x-axis labels)
+  top_mm: 20             # Top margin (for titles)
+
+spacing:
+  horizontal_mm: 8       # Horizontal spacing between axes
+  vertical_mm: 10        # Vertical spacing between axes
+
+# =============================================================================
+# FONT SIZES (in points)
+# =============================================================================
+fonts:
+  family: "Arial"        # Font family (Arial for Nature-style)
+  axis_label_pt: 7       # X/Y axis label font size
+  tick_label_pt: 7       # Tick label font size
+  title_pt: 8            # Plot title font size
+  suptitle_pt: 8         # Super title font size
+  legend_pt: 6           # Legend font size
+  annotation_pt: 6       # Annotation text (stats, etc.)
+
+# =============================================================================
+# PADDING (in points)
+# =============================================================================
+padding:
+  label_pt: 0.5          # Axis label to axis distance (extremely tight)
+  tick_pt: 2.0           # Tick label to tick distance
+  title_pt: 1.0          # Title to axis top distance
+
+# =============================================================================
+# LINE THICKNESSES (in mm)
+# =============================================================================
+lines:
+  trace_mm: 0.2          # Plot line thickness
+  errorbar_mm: 0.2       # Error bar line thickness
+  errorbar_cap_mm: 0.8   # Error bar cap width
+  bar_edge_mm: 0.2       # Bar plot edge thickness
+  kde_mm: 0.2            # KDE line thickness
+  boxplot_mm: 0.2        # Boxplot line thickness
+  violin_mm: 0.2         # Violin plot line thickness
+  colorbar_mm: 0.2       # Colorbar outline thickness
+
+# =============================================================================
+# TICK MARKS (in mm)
+# =============================================================================
+ticks:
+  length_mm: 0.8         # Tick mark length
+  thickness_mm: 0.2      # Tick mark thickness
+  direction: "out"       # Tick direction: "in", "out", or "inout"
+  n_ticks: 4             # Target number of ticks per axis (3-4)
+
+# =============================================================================
+# MARKERS (in mm)
+# =============================================================================
+markers:
+  size_mm: 0.8           # Default marker size
+  scatter_mm: 0.8        # Scatter plot marker size
+  edge_width_mm: 0.1     # Marker edge width
+
+# =============================================================================
+# OUTPUT SETTINGS
+# =============================================================================
+output:
+  dpi: 300               # Resolution for saving
+  transparent: true      # Transparent background for cropping
+  format: "png"          # Default output format
+
+# =============================================================================
+# BEHAVIOR FLAGS
+# =============================================================================
+behavior:
+  auto_scale_axes: true  # Factor out powers of 10 from tick labels
+  hide_top_spine: true   # Hide top spine
+  hide_right_spine: true # Hide right spine
+  grid: false            # Show grid
+
+# =============================================================================
+# THEME / COLOR MODE
+# =============================================================================
+# Dark mode uses eye-friendly colors optimized for dark backgrounds
+# Light mode uses standard black on white (default matplotlib behavior)
+theme:
+  mode: "light"          # "light" or "dark"
+
+  # Dark mode color palette (eye-friendly, reduced strain)
+  dark:
+    background: "transparent"  # Figure background (transparent by default)
+    axes_bg: "#1a1a2e"         # Axes background (deep navy-black)
+    text: "#e8e8e8"            # Text, labels, titles (soft white)
+    spine: "#4a4a5a"           # Axis spines (muted gray)
+    tick: "#e8e8e8"            # Tick marks and labels
+    grid: "#3a3a4a"            # Grid lines (subtle)
+
+  # Light mode color palette (publication standard)
+  light:
+    background: "transparent"  # Figure background
+    axes_bg: "white"           # Axes background
+    text: "black"              # Text, labels, titles
+    spine: "black"             # Axis spines
+    tick: "black"              # Tick marks and labels
+    grid: "#cccccc"            # Grid lines

--- a/tests/figrecipe/test_diagram_public_api.py
+++ b/tests/figrecipe/test_diagram_public_api.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the public ``figrecipe.diagram`` API surface.
+
+``figrecipe.diagram`` is the public face of the private ``figrecipe._diagram``
+implementation, mirroring how ``figrecipe.pyplot`` exposes the recording
+internals. These tests pin the public contract the umbrella aliases to
+(``scitex.diagram`` -> ``figrecipe.diagram``).
+"""
+
+import importlib
+
+import pytest
+
+# The public diagram API the umbrella aliases against.
+PUBLIC_NAMES = [
+    "Diagram",
+    "GraphDiagram",
+    "DiagramSpec",
+    "DiagramType",
+    "NodeSpec",
+    "EdgeSpec",
+    "PaperConstraints",
+    "LayoutHints",
+    "ColumnLayout",
+    "SpacingLevel",
+    "PaperMode",
+    "compile_to_mermaid",
+    "compile_to_graphviz",
+    "DiagramPreset",
+    "get_preset",
+    "list_presets",
+    "WORKFLOW_PRESET",
+    "DECISION_PRESET",
+    "PIPELINE_PRESET",
+    "SCIENTIFIC_PRESET",
+    "SplitConfig",
+    "SplitResult",
+    "SplitStrategy",
+    "get_available_backends",
+]
+
+
+def test_import_figrecipe_diagram_module_succeeds():
+    # Arrange
+    module_name = "figrecipe.diagram"
+    # Act
+    module = importlib.import_module(module_name)
+    # Assert
+    assert module.__name__ == module_name
+
+
+@pytest.mark.parametrize("name", PUBLIC_NAMES)
+def test_public_name_is_attribute(name):
+    # Arrange
+    import figrecipe.diagram as diagram
+
+    # Act
+    has_attr = hasattr(diagram, name)
+    # Assert
+    assert has_attr, f"figrecipe.diagram.{name} missing"
+
+
+@pytest.mark.parametrize("name", PUBLIC_NAMES)
+def test_public_name_is_in_all(name):
+    # Arrange
+    import figrecipe.diagram as diagram
+
+    # Act
+    in_all = name in diagram.__all__
+    # Assert
+    assert in_all, f"figrecipe.diagram.{name} not in __all__"
+
+
+def test_from_import_exposes_callable_diagram():
+    # Arrange
+    import figrecipe.diagram  # noqa: F401
+
+    # Act
+    from figrecipe.diagram import Diagram
+
+    # Assert
+    assert callable(Diagram)
+
+
+def test_from_import_exposes_callable_compile_to_mermaid():
+    # Arrange
+    import figrecipe.diagram  # noqa: F401
+
+    # Act
+    from figrecipe.diagram import compile_to_mermaid
+
+    # Assert
+    assert callable(compile_to_mermaid)
+
+
+def _build_workflow_spec():
+    """Build a minimal two-node workflow DiagramSpec."""
+    from figrecipe.diagram import (
+        DiagramSpec,
+        DiagramType,
+        EdgeSpec,
+        NodeSpec,
+    )
+
+    return DiagramSpec(
+        type=DiagramType.WORKFLOW,
+        nodes=[
+            NodeSpec(id="a", label="Start"),
+            NodeSpec(id="b", label="End"),
+        ],
+        edges=[EdgeSpec(source="a", target="b")],
+    )
+
+
+def test_compile_spec_to_mermaid_declares_graph():
+    # Arrange
+    from figrecipe.diagram import compile_to_mermaid
+
+    spec = _build_workflow_spec()
+    # Act
+    mermaid = compile_to_mermaid(spec)
+    # Assert
+    assert "graph" in mermaid
+
+
+def test_compile_spec_to_mermaid_renders_edge():
+    # Arrange
+    from figrecipe.diagram import compile_to_mermaid
+
+    spec = _build_workflow_spec()
+    # Act
+    mermaid = compile_to_mermaid(spec)
+    # Assert
+    assert "a --> b" in mermaid
+
+
+def test_diagram_builder_records_box_text():
+    # Arrange
+    from figrecipe.diagram import Diagram
+
+    diagram = Diagram(title="Public API")
+    # Act
+    diagram.add_box("step", "Step", x_mm=10, y_mm=10)
+    # Assert
+    spec = diagram.to_dict()
+    assert any(box.get("title") == "Step" for box in spec.get("boxes", []))
+
+
+# EOF


### PR DESCRIPTION
## Summary

Adds `figrecipe/diagram.py` as the **public** face of the private `figrecipe._diagram` implementation, mirroring how `figrecipe.pyplot` exposes the recording internals.

This lets the scitex umbrella alias `scitex.diagram` -> `figrecipe.diagram` (the same pattern as `scitex.plt` -> `figrecipe.pyplot`) without reaching into private modules.

## Public API surface (`figrecipe.diagram.__all__`)

- Builders: `Diagram`, `GraphDiagram`
- Schema: `DiagramSpec`, `DiagramType`, `NodeSpec`, `EdgeSpec`, `PaperConstraints`, `LayoutHints`, `ColumnLayout`, `SpacingLevel`, `PaperMode`
- Compilers: `compile_to_mermaid`, `compile_to_graphviz`
- Presets: `DiagramPreset`, `get_preset`, `list_presets`, `WORKFLOW_PRESET`, `DECISION_PRESET`, `PIPELINE_PRESET`, `SCIENTIFIC_PRESET`
- Split: `SplitConfig`, `SplitResult`, `SplitStrategy`
- Render: `get_available_backends`

`figrecipe._diagram` stays as the implementation; existing imports are unchanged.

## Tests

`tests/figrecipe/test_diagram_public_api.py` — verifies `import figrecipe.diagram`, every public name present + in `__all__`, `from figrecipe.diagram import ...`, and a `DiagramSpec` -> `compile_to_mermaid` build. AAA + one-assert-per-test conventions.

## Audit

`scitex-dev ecosystem audit-all figrecipe` fully green (audit-cli, audit-mcp-tools, audit-skills, audit-python-apis, audit-project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)