### PR TITLE
feat(validators): axis_range_alignment runtime check + tests

### DIFF
--- a/src/figrecipe/_api/_public.py
+++ b/src/figrecipe/_api/_public.py
@@ -103,6 +103,8 @@ def save(
     validate: bool = True,
     validate_mse_threshold: float = 100.0,
     validate_error_level: str = "error",
+    validate_axis_range_alignment: bool = True,
+    validate_axis_range_alignment_error_level: str = "warning",
     verbose: bool = True,
     dpi: Optional[int] = None,
     image_format: Optional[str] = None,
@@ -132,6 +134,13 @@ def save(
         Maximum acceptable MSE for validation (default: 100).
     validate_error_level : str
         How to handle failures: 'error', 'warning', or 'debug'.
+    validate_axis_range_alignment : bool
+        If True (default), run the runtime ``axis_range_alignment``
+        check on the rendered figure. Catches the autoscale-with-
+        different-data case that the static STX-FIG001 lint misses.
+    validate_axis_range_alignment_error_level : str
+        Dispatch level for the axis-range-alignment check:
+        'warning' (default), 'error', or 'debug' (silent).
     verbose : bool
         If True (default), print save status.
     dpi : int, optional
@@ -165,6 +174,10 @@ def save(
         validate=validate,
         validate_mse_threshold=validate_mse_threshold,
         validate_error_level=validate_error_level,
+        validate_axis_range_alignment=validate_axis_range_alignment,
+        validate_axis_range_alignment_error_level=(
+            validate_axis_range_alignment_error_level
+        ),
         verbose=verbose,
         dpi=dpi,
         image_format=image_format,

--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -152,6 +152,8 @@ def save_figure(
     validate: bool = True,
     validate_mse_threshold: float = 100.0,
     validate_error_level: str = "error",
+    validate_axis_range_alignment: bool = True,
+    validate_axis_range_alignment_error_level: str = "warning",
     verbose: bool = True,
     dpi: Optional[int] = None,
     image_format: Optional[str] = None,
@@ -190,6 +192,15 @@ def save_figure(
         Maximum acceptable MSE for validation (default: 100).
     validate_error_level : str
         How to handle validation failures: 'error', 'warning', or 'debug'.
+    validate_axis_range_alignment : bool
+        If True (default), run the runtime ``axis_range_alignment``
+        check on the rendered figure before saving. Complements the
+        static ``STX-FIG001`` lint rule by catching the autoscale-
+        with-different-data case.
+    validate_axis_range_alignment_error_level : str
+        Dispatch level for the axis-range-alignment check:
+        'warning' (default — never kills the script), 'error', or
+        'debug' (silent).
     verbose : bool
         If True (default), print save status.
     dpi : int, optional
@@ -235,6 +246,17 @@ def save_figure(
     for ax in fig.fig.get_axes():
         finalize_ticks(ax)
         finalize_special_plots(ax, style_dict)
+
+    # Runtime axis-range-alignment check (complements static STX-FIG001).
+    # Default warning-level — per operator preference (figrecipe #134), never
+    # kill the script after the PNG has been written.
+    if validate_axis_range_alignment:
+        from .._axis_range_alignment import run_axis_range_alignment
+
+        run_axis_range_alignment(
+            fig.fig,
+            validate_error_level=validate_axis_range_alignment_error_level,
+        )
 
     # Check for .fig.zip (multi-panel Figz bundle) or .plt.zip (single-plot Pltz bundle)
     suffixes = [s.lower() for s in path.suffixes]

--- a/src/figrecipe/_axis_range_alignment.py
+++ b/src/figrecipe/_axis_range_alignment.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Runtime validator: ``axis_range_alignment``.
+
+Complements the static ``STX-FIG001`` lint rule (which catches explicit
+literal ``ax.set_ylim(0, 1)`` vs ``ax.set_ylim(0, 5)`` mismatches in
+source). Most real matplotlib code uses autoscale or variable limits —
+the displayed range only exists at runtime. This validator inspects
+the actual rendered ``fig.axes`` at savefig time and warns when axes
+that appear to plot the *same* quantity have mismatched displayed
+ranges.
+
+Rule reference: scientific-figure standards rule #4 — "Same axis
+range on x and y, even if one condition has less data — the visual
+comparison is destroyed by mismatched ranges".
+
+Severity: WARNING by default — per the operator's preference
+(figrecipe issue #134) the validator never raises after the PNG has
+already been written. The caller may upgrade the severity via the
+existing ``validate_error_level`` knob in ``save_figure``.
+
+Opt-out: set ``fig._figrecipe_allow_axis_mismatch = True`` to skip.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+__all__ = [
+    "AxisAlignmentResult",
+    "check_axis_range_alignment",
+    "WARNING_MESSAGE",
+]
+
+
+WARNING_MESSAGE = (
+    "figrecipe.axis_range_alignment: subplots that appear to share a "
+    "quantity (matching {xlabel|ylabel} or same gridspec {row|col}) "
+    "have mismatched displayed ranges. This destroys visual comparison "
+    "(scientific-figure standards rule #4)."
+)
+
+
+# Axis kind tags — internal to grouping.
+_X_AXIS = "x"
+_Y_AXIS = "y"
+
+
+class AxisAlignmentResult:
+    """Result of the ``axis_range_alignment`` runtime check.
+
+    Attributes
+    ----------
+    triggered : bool
+        True if at least one peer group has mismatched displayed
+        ranges.
+    message : str
+        Human-readable explanation (constant ``WARNING_MESSAGE`` when
+        triggered, empty string otherwise).
+    mismatches : list of dict
+        One entry per offending peer group. Each entry has keys
+        ``axis`` ("x" or "y"), ``key`` (the grouping key — label
+        string or gridspec row/col index), and ``ranges`` (list of
+        (low, high) tuples in axis-iteration order).
+    """
+
+    __slots__ = ("triggered", "message", "mismatches")
+
+    def __init__(
+        self,
+        triggered: bool,
+        message: str = "",
+        mismatches: Optional[List[dict]] = None,
+    ) -> None:
+        self.triggered = triggered
+        self.message = message
+        self.mismatches = list(mismatches) if mismatches else []
+
+    def __repr__(self) -> str:  # pragma: no cover — trivial
+        status = "MISMATCH" if self.triggered else "OK"
+        return f"AxisAlignmentResult({status}, " f"groups={len(self.mismatches)})"
+
+
+# ---------------------------------------------------------------------------
+# Tolerance comparison
+# ---------------------------------------------------------------------------
+
+
+def _limits_close(
+    a: Tuple[float, float],
+    b: Tuple[float, float],
+    rel_tol: float = 1e-3,
+    abs_tol: float = 1e-9,
+) -> bool:
+    """Return True if both endpoints of (low, high) tuples match within
+    tolerance, per the spec (``math.isclose(rel_tol=1e-3, abs_tol=1e-9)``).
+    """
+    return math.isclose(a[0], b[0], rel_tol=rel_tol, abs_tol=abs_tol) and math.isclose(
+        a[1], b[1], rel_tol=rel_tol, abs_tol=abs_tol
+    )
+
+
+def _all_limits_close(limits: Sequence[Tuple[float, float]]) -> bool:
+    """Return True if every (low, high) limit matches the first within
+    tolerance.
+    """
+    if len(limits) < 2:
+        return True
+    pivot = limits[0]
+    return all(_limits_close(pivot, lim) for lim in limits[1:])
+
+
+# ---------------------------------------------------------------------------
+# Per-axis skip predicates (be conservative)
+# ---------------------------------------------------------------------------
+
+
+def _is_twin_axis(ax) -> bool:
+    """True if ``ax`` is a twin axis (``twinx`` / ``twiny``).
+
+    Twins share one axis (x or y) AND occupy the same bounding box as
+    their parent. Across matplotlib versions the ``_twinned_axes``
+    registry on the parent figure may or may not be populated, so we
+    fall back to the geometric/sibling test:
+
+    1. ``ax`` shares either its x- or y-axis with at least one peer.
+    2. That peer has an identical ``get_position()`` bbox — meaning
+       both axes overlay the same physical region, which is the
+       defining property of a twin.
+    """
+    fig = ax.figure
+
+    # First try the modern registry (when present).
+    twinned = getattr(fig, "_twinned_axes", None)
+    if twinned is not None:
+        try:
+            siblings = list(twinned.get_siblings(ax))
+            if len(siblings) > 1:
+                return True
+        except Exception:
+            pass
+
+    # Fallback: geometric / sibling overlap test. Robust across
+    # matplotlib >= 3.4 (Grouper API) and >= 3.10 (registry absent).
+    try:
+        my_bbox = tuple(ax.get_position().bounds)
+    except Exception:
+        return False
+
+    def _shared_siblings(getter_name: str):
+        try:
+            return list(getattr(ax, getter_name)().get_siblings(ax))
+        except Exception:
+            return [ax]
+
+    for getter in ("get_shared_x_axes", "get_shared_y_axes"):
+        for peer in _shared_siblings(getter):
+            if peer is ax:
+                continue
+            try:
+                peer_bbox = tuple(peer.get_position().bounds)
+            except Exception:
+                continue
+            if all(
+                math.isclose(a, b, rel_tol=1e-6, abs_tol=1e-9)
+                for a, b in zip(my_bbox, peer_bbox)
+            ):
+                return True
+    return False
+
+
+def _is_non_rect_projection(ax) -> bool:
+    """True for 3D / polar / non-rectilinear projections — skip them.
+
+    These cannot reasonably be compared by ``get_xlim``/``get_ylim``
+    tuples against rectilinear peers.
+    """
+    name = getattr(ax, "name", "rectilinear")
+    if name and name != "rectilinear":
+        return True
+    # 3D check (mpl_toolkits.mplot3d sets name="3d" but defend anyway)
+    if hasattr(ax, "get_zlim"):
+        return True
+    return False
+
+
+def _has_shared_x(ax) -> bool:
+    """True if matplotlib already shares the x-axis with any sibling."""
+    try:
+        siblings = list(ax.get_shared_x_axes().get_siblings(ax))
+    except Exception:
+        return False
+    return len(siblings) > 1
+
+
+def _has_shared_y(ax) -> bool:
+    """True if matplotlib already shares the y-axis with any sibling."""
+    try:
+        siblings = list(ax.get_shared_y_axes().get_siblings(ax))
+    except Exception:
+        return False
+    return len(siblings) > 1
+
+
+def _gridspec_row_col(ax) -> Tuple[Optional[int], Optional[int]]:
+    """Return (row, col) start indices from the SubplotSpec, or
+    (None, None) if the axis was not placed via gridspec.
+    """
+    get_spec = getattr(ax, "get_subplotspec", None)
+    if get_spec is None:
+        return None, None
+    try:
+        spec = get_spec()
+    except Exception:
+        return None, None
+    if spec is None:
+        return None, None
+    try:
+        row_start, _row_stop, col_start, _col_stop = (
+            spec.rowspan.start,
+            spec.rowspan.stop,
+            spec.colspan.start,
+            spec.colspan.stop,
+        )
+    except AttributeError:
+        return None, None
+    return row_start, col_start
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+
+def _eligible(ax, axis_kind: str) -> bool:
+    """Return True if ``ax`` should participate in the comparison for
+    the given axis_kind ("x" or "y").
+
+    Conservative skips:
+      - twin axes (twinx/twiny deliberately differ),
+      - non-rectilinear projections (3D, polar, …),
+      - axes whose matching matplotlib-side sharex/sharey is already on
+        (mismatch impossible by construction).
+    """
+    if _is_twin_axis(ax):
+        return False
+    if _is_non_rect_projection(ax):
+        return False
+    if axis_kind == _X_AXIS and _has_shared_x(ax):
+        return False
+    if axis_kind == _Y_AXIS and _has_shared_y(ax):
+        return False
+    return True
+
+
+def _group_by_label(axes: Iterable, axis_kind: str) -> dict:
+    """Group axes by non-empty x/y label."""
+    groups: dict = {}
+    for ax in axes:
+        if not _eligible(ax, axis_kind):
+            continue
+        label = ax.get_xlabel() if axis_kind == _X_AXIS else ax.get_ylabel()
+        if not label:
+            continue
+        groups.setdefault(label, []).append(ax)
+    return groups
+
+
+def _group_by_gridspec(axes: Iterable, axis_kind: str) -> dict:
+    """Group axes by gridspec row (x-axis quantity peer group) or
+    column (y-axis quantity peer group).
+
+    Convention (matches matplotlib ``sharex='row'`` / ``sharey='col'``):
+
+    * Axes sharing the same row → candidates for shared x-quantity.
+    * Axes sharing the same column → candidates for shared y-quantity.
+
+    Only emit a group if the gridspec has more than one row (for x) or
+    more than one column (for y); otherwise the grouping degenerates
+    into "all axes" and conflicts with label-based grouping.
+    """
+    rows_cols: List[Tuple[int, int, object]] = []
+    for ax in axes:
+        if not _eligible(ax, axis_kind):
+            continue
+        row, col = _gridspec_row_col(ax)
+        if row is None or col is None:
+            continue
+        rows_cols.append((row, col, ax))
+
+    if not rows_cols:
+        return {}
+
+    distinct_rows = {r for r, _, _ in rows_cols}
+    distinct_cols = {c for _, c, _ in rows_cols}
+
+    groups: dict = {}
+    if axis_kind == _X_AXIS:
+        if len(distinct_rows) <= 1:
+            return {}
+        for row, _col, ax in rows_cols:
+            groups.setdefault(row, []).append(ax)
+    else:  # _Y_AXIS
+        if len(distinct_cols) <= 1:
+            return {}
+        for _row, col, ax in rows_cols:
+            groups.setdefault(col, []).append(ax)
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Public check
+# ---------------------------------------------------------------------------
+
+
+def _opted_out(fig) -> bool:
+    """Honor the per-figure opt-out sentinel."""
+    return bool(getattr(fig, "_figrecipe_allow_axis_mismatch", False))
+
+
+def _has_any_inferable_peer(ax) -> bool:
+    """True if at least one signal (xlabel, ylabel, gridspec) lets us
+    place this axis into a peer group. Used only to decide whether to
+    skip an axis when it carries no information at all.
+    """
+    if ax.get_xlabel() or ax.get_ylabel():
+        return True
+    row, col = _gridspec_row_col(ax)
+    return row is not None and col is not None
+
+
+def _collect_mismatches(fig, axis_kind: str) -> List[dict]:
+    """Return one mismatch record per offending peer group along the
+    given axis.
+    """
+    axes = [ax for ax in fig.axes if _has_any_inferable_peer(ax)]
+    if len(axes) < 2:
+        return []
+
+    mismatches: List[dict] = []
+    seen_pairs = set()
+
+    label_groups = _group_by_label(axes, axis_kind)
+    gridspec_groups = _group_by_gridspec(axes, axis_kind)
+
+    def _emit(key, group_axes):
+        if len(group_axes) < 2:
+            return
+        getter = "get_xlim" if axis_kind == _X_AXIS else "get_ylim"
+        limits = [tuple(getattr(a, getter)()) for a in group_axes]
+        if _all_limits_close(limits):
+            return
+        ax_ids = tuple(sorted(id(a) for a in group_axes))
+        pair_key = (axis_kind, ax_ids)
+        if pair_key in seen_pairs:
+            return
+        seen_pairs.add(pair_key)
+        mismatches.append({"axis": axis_kind, "key": key, "ranges": limits})
+
+    for key, group in label_groups.items():
+        _emit(key, group)
+    for key, group in gridspec_groups.items():
+        _emit(key, group)
+    return mismatches
+
+
+def check_axis_range_alignment(fig) -> AxisAlignmentResult:
+    """Runtime check that axes plotting the same quantity share their
+    displayed range.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The fully-rendered figure (after all plotting / autoscale).
+        ``RecordingFigure`` callers should pass ``fig.fig`` (the
+        underlying matplotlib ``Figure``).
+
+    Returns
+    -------
+    AxisAlignmentResult
+        ``triggered=False`` when no mismatches are detected, when the
+        check is opted out, or when fewer than two axes are present.
+    """
+    if fig is None:
+        return AxisAlignmentResult(False)
+    if _opted_out(fig):
+        return AxisAlignmentResult(False)
+
+    axes = list(getattr(fig, "axes", []) or [])
+    if len(axes) < 2:
+        return AxisAlignmentResult(False)
+
+    mismatches: List[dict] = []
+    mismatches.extend(_collect_mismatches(fig, _X_AXIS))
+    mismatches.extend(_collect_mismatches(fig, _Y_AXIS))
+
+    if not mismatches:
+        return AxisAlignmentResult(False)
+
+    return AxisAlignmentResult(
+        triggered=True,
+        message=WARNING_MESSAGE,
+        mismatches=mismatches,
+    )
+
+
+def run_axis_range_alignment(
+    fig,
+    validate_error_level: str = "warning",
+) -> AxisAlignmentResult:
+    """Run the check and dispatch the result according to
+    ``validate_error_level``.
+
+    Defaults to ``"warning"`` per the operator preference (figrecipe
+    issue #134): never kill the script after the PNG has already been
+    written. Callers can opt up to ``"error"`` or down to ``"debug"``.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The matplotlib figure to inspect.
+    validate_error_level : {"warning", "error", "debug"}
+        Dispatch level. ``"warning"`` emits ``warnings.warn`` (default),
+        ``"error"`` raises ``ValueError``, ``"debug"`` is silent.
+    """
+    result = check_axis_range_alignment(fig)
+    if not result.triggered:
+        return result
+
+    level = (validate_error_level or "warning").lower()
+    if level == "error":
+        raise ValueError(result.message)
+    if level == "warning":
+        warnings.warn(result.message, UserWarning, stacklevel=2)
+    # "debug" → silent
+    return result
+
+
+# EOF

--- a/tests/figrecipe/test__axis_range_alignment.py
+++ b/tests/figrecipe/test__axis_range_alignment.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the runtime ``axis_range_alignment`` validator.
+
+These tests build real matplotlib ``Figure`` objects (no mocks) and
+call the validator directly. ``matplotlib.use("Agg")`` is already set
+by the root ``conftest.py``; we still set it here defensively in case
+this file is run in isolation.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+from figrecipe._axis_range_alignment import (  # noqa: E402
+    WARNING_MESSAGE,
+    check_axis_range_alignment,
+    run_axis_range_alignment,
+)
+
+# ---------------------------------------------------------------------------
+# POSITIVE — fires
+# ---------------------------------------------------------------------------
+
+
+def test_mismatched_ylim_with_shared_ylabel_triggers():
+    # Arrange
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("voltage")
+    ax0.set_ylim(0, 1)
+    ax1.set_ylim(0, 5)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is True
+
+    plt.close(fig)
+
+
+def test_mismatched_ylim_emits_warning_at_default_level():
+    # Arrange
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("voltage")
+    ax0.set_ylim(0, 1)
+    ax1.set_ylim(0, 5)
+
+    # Act
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        run_axis_range_alignment(fig)
+    triggering_messages = [
+        str(w.message) for w in caught if WARNING_MESSAGE in str(w.message)
+    ]
+
+    # Assert
+    assert len(triggering_messages) == 1
+
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE — does not fire when ranges agree
+# ---------------------------------------------------------------------------
+
+
+def test_matching_ylim_with_shared_ylabel_does_not_trigger():
+    # Arrange
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("voltage")
+    ax0.set_ylim(0, 1)
+    ax1.set_ylim(0, 1)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is False
+
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE — matplotlib sharey=True
+# ---------------------------------------------------------------------------
+
+
+def test_sharey_true_skips_the_check_for_y_axis():
+    # Arrange
+    fig, (ax0, ax1) = plt.subplots(1, 2, sharey=True)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("voltage")
+    # With sharey=True, both calls effectively pin the same limit, so
+    # by construction get_ylim() agrees on both axes — but more
+    # importantly the validator must skip y-axis comparison entirely.
+    ax0.set_ylim(0, 1)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is False
+
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE — different ylabels (peers don't share a quantity)
+# ---------------------------------------------------------------------------
+
+
+def test_different_ylabels_are_not_grouped_as_peers():
+    # Arrange
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("current")
+    ax0.set_ylim(0, 1)
+    ax1.set_ylim(0, 5)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is False
+
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE — twinx
+# ---------------------------------------------------------------------------
+
+
+def test_twinx_axes_are_skipped_by_design():
+    # Arrange
+    fig, ax = plt.subplots()
+    ax.set_ylabel("voltage")
+    ax2 = ax.twinx()
+    ax2.set_ylabel("voltage")
+    ax.set_ylim(0, 1)
+    ax2.set_ylim(0, 5)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is False
+
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE — opt-out sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_opt_out_sentinel_skips_the_check_entirely():
+    # Arrange
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("voltage")
+    ax0.set_ylim(0, 1)
+    ax1.set_ylim(0, 5)
+    fig._figrecipe_allow_axis_mismatch = True
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is False
+
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE — single axis (no comparison possible)
+# ---------------------------------------------------------------------------
+
+
+def test_single_axis_figure_is_a_noop():
+    # Arrange
+    fig, ax = plt.subplots(1, 1)
+    ax.set_ylabel("voltage")
+    ax.set_ylim(0, 1)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is False
+
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Extra edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_mismatched_xlim_with_shared_xlabel_triggers():
+    # Arrange
+    fig, (ax0, ax1) = plt.subplots(2, 1)
+    ax0.set_xlabel("time (s)")
+    ax1.set_xlabel("time (s)")
+    ax0.set_xlim(0, 1)
+    ax1.set_xlim(0, 10)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is True
+
+    plt.close(fig)
+
+
+def test_error_level_raises_value_error_when_mismatched():
+    # Arrange
+
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("voltage")
+    ax0.set_ylim(0, 1)
+    ax1.set_ylim(0, 5)
+    raised = False
+
+    # Act
+    try:
+        run_axis_range_alignment(fig, validate_error_level="error")
+    except ValueError:
+        raised = True
+
+    # Assert
+    assert raised is True
+
+    plt.close(fig)
+
+
+def test_debug_level_is_silent_when_mismatched():
+    # Arrange
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("voltage")
+    ax0.set_ylim(0, 1)
+    ax1.set_ylim(0, 5)
+
+    # Act
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        run_axis_range_alignment(fig, validate_error_level="debug")
+    triggering = [w for w in caught if WARNING_MESSAGE in str(w.message)]
+
+    # Assert
+    assert triggering == []
+
+    plt.close(fig)
+
+
+def test_empty_labels_without_gridspec_skip_the_axis():
+    # Arrange — create two bare axes with no labels and no shared
+    # gridspec. The validator must NOT warn (cannot infer peers).
+    fig = plt.figure()
+    ax0 = fig.add_axes([0.1, 0.1, 0.35, 0.8])
+    ax1 = fig.add_axes([0.55, 0.1, 0.35, 0.8])
+    ax0.set_ylim(0, 1)
+    ax1.set_ylim(0, 5)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is False
+
+    plt.close(fig)
+
+
+def test_two_dot_five_percent_tolerance_does_trigger():
+    # Arrange — well outside the 1e-3 rel_tol tolerance.
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("voltage")
+    ax0.set_ylim(0.0, 1.0)
+    ax1.set_ylim(0.0, 1.025)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is True
+
+    plt.close(fig)
+
+
+def test_within_tolerance_does_not_trigger():
+    # Arrange — inside the 1e-3 rel_tol tolerance.
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    ax0.set_ylabel("voltage")
+    ax1.set_ylabel("voltage")
+    ax0.set_ylim(0.0, 1.0)
+    ax1.set_ylim(0.0, 1.0 + 1e-6)
+
+    # Act
+    result = check_axis_range_alignment(fig)
+
+    # Assert
+    assert result.triggered is False
+
+    plt.close(fig)
+
+
+# EOF


### PR DESCRIPTION
## Summary
Adds a **runtime** validator `axis_range_alignment` that fires at savefig time and warns when axes that appear to plot the same quantity have mismatched displayed ranges. Complements the static **STX-FIG001** AST rule (#136) by covering the dominant autoscale-with-different-data case that static analysis provably cannot detect.

## Why both layers?
- **Static (#136)**: catches the small minority where the author writes literal `set_xlim(0, 1)` / `set_xlim(0, 5)` calls with explicit different ranges. Useful as code review feedback, before the script even runs.
- **Runtime (this PR)**: catches everything the author didn't pin explicitly — autoscaled axes whose displayed ranges differ because the data differs. This is the realistic majority case.

## Detection (runtime, on the real `matplotlib.figure.Figure`)
- Group axes by **inferred shared quantity**:
  - same non-empty `xlabel` → x-quantity peer group
  - same non-empty `ylabel` → y-quantity peer group
  - same gridspec row → x-axis peer (mirrors `sharex='row'` convention)
  - same gridspec col → y-axis peer (mirrors `sharey='col'` convention)
- For each peer group with ≥2 axes, compare `get_xlim()` / `get_ylim()`. Mismatch tested with `math.isclose(rel_tol=1e-3, abs_tol=1e-9)`.
- **Skip**:
  - matplotlib's own `sharex` / `sharey` already wired (mismatch impossible)
  - twin axes (`ax.twinx` / `ax.twiny`) — deliberately different
  - axes with empty xlabel AND empty ylabel AND no gridspec membership (can't infer peer-group)
- **Opt-out**: `fig._figrecipe_allow_axis_mismatch = True` before savefig.

## Severity default
`validate_error_level="warning"` per the operator's earlier ask on figrecipe issue #134 (script kills after the PNG was already saved are bad UX). Operator can still set `"error"` to raise `ValueError`, or `"debug"` for silence.

## Test plan
- [x] 14 new tests, all green (`pytest tests/figrecipe/test__axis_range_alignment.py` → 14/14 PASS).
- [x] Positives: mismatched ylim/xlim with shared labels, 2.5% gap above tolerance, error-level raises.
- [x] Negatives: matching limits, sharey=True, different labels, twinx, opt-out sentinel, single-axis figure, debug-level silent, empty labels without gridspec, within-tolerance.
- [ ] CI on the PR.

## Pre-commit note
The local `pytest-testmon` hook fails to collect because the environment is missing `libgthread-2.0.so.0` (cv2 fails to load via `scitex_cv` during testmon collection). Pre-existing environment issue unrelated to this change; committed with `SKIP=pytest-testmon`. The `ruff` and `ruff-format` hooks both pass cleanly.