### PR TITLE
feat(compose): default gap_mm=2 + panel labels read fontsize from SCITEX_STYLE

### DIFF
--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -311,9 +311,10 @@ def _replay_axes_record_mm(
 def _panel_label_fontsize() -> float:
     """Resolve the panel-label font size from the active SCITEX_STYLE.
 
-    Falls back to title_pt, then to 8 if neither is configured.  Returning
-    the value lets compose stay consistent with axis/title typography
-    instead of forcing a hardcoded 10pt.
+    Default: 10pt bold (Nature-style panel labels).  Reads ``fonts.panel_label_pt``
+    from SCITEX_STYLE if set; otherwise falls back to 10pt.  ``title_pt`` is
+    *not* used as a fallback because panel labels (A, B, C, ...) follow a
+    different convention than axis titles.
     """
     try:
         from ..presets._scitex_style import SCITEX_STYLE
@@ -322,11 +323,9 @@ def _panel_label_fontsize() -> float:
             fonts = SCITEX_STYLE.get("fonts") or {}
             if "panel_label_pt" in fonts:
                 return float(fonts["panel_label_pt"])
-            if "title_pt" in fonts:
-                return float(fonts["title_pt"])
     except Exception:
         pass
-    return 8.0
+    return 10.0
 
 
 def _add_panel_labels_grid(axes, nrows: int, ncols: int, style: str) -> None:

--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -43,7 +43,7 @@ def compose(
     sources: Dict[Any, Any],
     layout: Optional[Tuple[int, int]] = None,
     canvas_size_mm: Optional[Tuple[float, float]] = None,
-    gap_mm: float = 5.0,
+    gap_mm: float = 2.0,
     dpi: int = DEFAULT_DPI,
     panel_labels: bool = False,
     label_style: str = "uppercase",
@@ -308,9 +308,31 @@ def _replay_axes_record_mm(
     fig_record.axes[ax_key] = ax_record_copy
 
 
+def _panel_label_fontsize() -> float:
+    """Resolve the panel-label font size from the active SCITEX_STYLE.
+
+    Falls back to title_pt, then to 8 if neither is configured.  Returning
+    the value lets compose stay consistent with axis/title typography
+    instead of forcing a hardcoded 10pt.
+    """
+    try:
+        from ..presets._scitex_style import SCITEX_STYLE
+
+        if isinstance(SCITEX_STYLE, dict):
+            fonts = SCITEX_STYLE.get("fonts") or {}
+            if "panel_label_pt" in fonts:
+                return float(fonts["panel_label_pt"])
+            if "title_pt" in fonts:
+                return float(fonts["title_pt"])
+    except Exception:
+        pass
+    return 8.0
+
+
 def _add_panel_labels_grid(axes, nrows: int, ncols: int, style: str) -> None:
     """Add panel labels to grid-based composition."""
     labels = _get_panel_labels(nrows * ncols, style)
+    fs = _panel_label_fontsize()
     idx = 0
     for row in range(nrows):
         for col in range(ncols):
@@ -321,7 +343,7 @@ def _add_panel_labels_grid(axes, nrows: int, ncols: int, style: str) -> None:
                 1.1,
                 labels[idx],
                 transform=mpl_ax.transAxes,
-                fontsize=10,
+                fontsize=fs,
                 fontweight="bold",
                 va="top",
                 ha="right",
@@ -332,6 +354,7 @@ def _add_panel_labels_grid(axes, nrows: int, ncols: int, style: str) -> None:
 def _add_panel_labels_mm(fig, sources: Dict, canvas_size_mm: Tuple, style: str) -> None:
     """Add panel labels to mm-based composition."""
     labels = _get_panel_labels(len(sources), style)
+    fs = _panel_label_fontsize()
     for idx, (_, spec) in enumerate(sources.items()):
         xy_mm = spec["xy_mm"]
         x_frac = xy_mm[0] / canvas_size_mm[0]
@@ -340,7 +363,7 @@ def _add_panel_labels_mm(fig, sources: Dict, canvas_size_mm: Tuple, style: str) 
             x_frac - 0.02,
             y_frac + 0.02,
             labels[idx],
-            fontsize=10,
+            fontsize=fs,
             fontweight="bold",
             va="bottom",
             ha="right",

--- a/src/figrecipe/presets/SCITEX_STYLE.yaml
+++ b/src/figrecipe/presets/SCITEX_STYLE.yaml
@@ -46,7 +46,7 @@ fonts:
   suptitle_pt: 8         # Super title font size
   legend_pt: 6           # Legend font size
   annotation_pt: 6       # Annotation text (stats, etc.)
-  panel_label_pt: 8      # Panel labels (A, B, C, ...) in compose()
+  panel_label_pt: 10     # Panel labels (A, B, C, ...) in compose() — 10pt bold Arial
 
 # =============================================================================
 # PADDING (in points)

--- a/src/figrecipe/presets/SCITEX_STYLE.yaml
+++ b/src/figrecipe/presets/SCITEX_STYLE.yaml
@@ -46,6 +46,7 @@ fonts:
   suptitle_pt: 8         # Super title font size
   legend_pt: 6           # Legend font size
   annotation_pt: 6       # Annotation text (stats, etc.)
+  panel_label_pt: 8      # Panel labels (A, B, C, ...) in compose()
 
 # =============================================================================
 # PADDING (in points)


### PR DESCRIPTION
## Summary

Two small ergonomic fixes to `fr.compose`:

1. **Default `gap_mm=2` (was 5)** — multi-panel mm-based layouts looked too sparse at 5 mm; 2 mm gives the tighter close-pack default users expect. Explicit callers (`gap_mm=...`) unaffected.

2. **Panel-label font size now reads from `SCITEX_STYLE`** — both `_add_panel_labels_grid` and `_add_panel_labels_mm` were hard-coding `fontsize=10`, which clashed with `tick_label_pt=7` / `title_pt=8` in the canonical style. New `_panel_label_fontsize()` helper resolves in this order:
   - `fonts.panel_label_pt` (new explicit override key)
   - `10.0` (hard fallback — Nature-style panel-label convention)
   - `SCITEX_STYLE.yaml` now ships with `panel_label_pt: 10` as the documented override key (the in-code default mirrors the YAML default, so they stay in sync).

## Files

- `src/figrecipe/_composition/_compose.py` — default change + `_panel_label_fontsize()` helper; both label functions use it.
- `src/figrecipe/presets/SCITEX_STYLE.yaml` — new `panel_label_pt: 10` under `fonts`.

## CI note

The pre-existing `audit-all` red on `develop` (16 flat `.py` files at `figrecipe/` root, threshold 15) was unrelated to this PR but was failing every PR's `tests/develop/test_audit.py::test_audit_all_for_package_reports_clean`. That gate is cleared by **#141 (refactor: `_quality/` subpackage)**, which landed on develop just before this re-run. CI on this branch should now go green.

## Test plan

- [ ] `gap_mm` default reads as 2 from `fr.compose` signature.
- [ ] Calling `fr.compose(..., panel_labels=True)` on an MM-based layout produces labels at fontsize 10.
- [ ] Adding `panel_label_pt: 14` to a custom style YAML overrides the default.
- [ ] Existing tests that explicitly pass `gap_mm` or rely on default fontsize continue to pass.