### PR TITLE
feat(compose): panel_label_pt default 10pt (Nature-style)

### DIFF
--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -311,9 +311,10 @@ def _replay_axes_record_mm(
 def _panel_label_fontsize() -> float:
     """Resolve the panel-label font size from the active SCITEX_STYLE.
 
-    Falls back to title_pt, then to 8 if neither is configured.  Returning
-    the value lets compose stay consistent with axis/title typography
-    instead of forcing a hardcoded 10pt.
+    Default: 10pt bold (Nature-style panel labels).  Reads ``fonts.panel_label_pt``
+    from SCITEX_STYLE if set; otherwise falls back to 10pt.  ``title_pt`` is
+    *not* used as a fallback because panel labels (A, B, C, ...) follow a
+    different convention than axis titles.
     """
     try:
         from ..presets._scitex_style import SCITEX_STYLE
@@ -322,11 +323,9 @@ def _panel_label_fontsize() -> float:
             fonts = SCITEX_STYLE.get("fonts") or {}
             if "panel_label_pt" in fonts:
                 return float(fonts["panel_label_pt"])
-            if "title_pt" in fonts:
-                return float(fonts["title_pt"])
     except Exception:
         pass
-    return 8.0
+    return 10.0
 
 
 def _add_panel_labels_grid(axes, nrows: int, ncols: int, style: str) -> None:

--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -43,7 +43,7 @@ def compose(
     sources: Dict[Any, Any],
     layout: Optional[Tuple[int, int]] = None,
     canvas_size_mm: Optional[Tuple[float, float]] = None,
-    gap_mm: float = 5.0,
+    gap_mm: float = 2.0,
     dpi: int = DEFAULT_DPI,
     panel_labels: bool = False,
     label_style: str = "uppercase",
@@ -308,9 +308,31 @@ def _replay_axes_record_mm(
     fig_record.axes[ax_key] = ax_record_copy
 
 
+def _panel_label_fontsize() -> float:
+    """Resolve the panel-label font size from the active SCITEX_STYLE.
+
+    Falls back to title_pt, then to 8 if neither is configured.  Returning
+    the value lets compose stay consistent with axis/title typography
+    instead of forcing a hardcoded 10pt.
+    """
+    try:
+        from ..presets._scitex_style import SCITEX_STYLE
+
+        if isinstance(SCITEX_STYLE, dict):
+            fonts = SCITEX_STYLE.get("fonts") or {}
+            if "panel_label_pt" in fonts:
+                return float(fonts["panel_label_pt"])
+            if "title_pt" in fonts:
+                return float(fonts["title_pt"])
+    except Exception:
+        pass
+    return 8.0
+
+
 def _add_panel_labels_grid(axes, nrows: int, ncols: int, style: str) -> None:
     """Add panel labels to grid-based composition."""
     labels = _get_panel_labels(nrows * ncols, style)
+    fs = _panel_label_fontsize()
     idx = 0
     for row in range(nrows):
         for col in range(ncols):
@@ -321,7 +343,7 @@ def _add_panel_labels_grid(axes, nrows: int, ncols: int, style: str) -> None:
                 1.1,
                 labels[idx],
                 transform=mpl_ax.transAxes,
-                fontsize=10,
+                fontsize=fs,
                 fontweight="bold",
                 va="top",
                 ha="right",
@@ -332,6 +354,7 @@ def _add_panel_labels_grid(axes, nrows: int, ncols: int, style: str) -> None:
 def _add_panel_labels_mm(fig, sources: Dict, canvas_size_mm: Tuple, style: str) -> None:
     """Add panel labels to mm-based composition."""
     labels = _get_panel_labels(len(sources), style)
+    fs = _panel_label_fontsize()
     for idx, (_, spec) in enumerate(sources.items()):
         xy_mm = spec["xy_mm"]
         x_frac = xy_mm[0] / canvas_size_mm[0]
@@ -340,7 +363,7 @@ def _add_panel_labels_mm(fig, sources: Dict, canvas_size_mm: Tuple, style: str) 
             x_frac - 0.02,
             y_frac + 0.02,
             labels[idx],
-            fontsize=10,
+            fontsize=fs,
             fontweight="bold",
             va="bottom",
             ha="right",

--- a/src/figrecipe/presets/SCITEX_STYLE.yaml
+++ b/src/figrecipe/presets/SCITEX_STYLE.yaml
@@ -46,7 +46,7 @@ fonts:
   suptitle_pt: 8         # Super title font size
   legend_pt: 6           # Legend font size
   annotation_pt: 6       # Annotation text (stats, etc.)
-  panel_label_pt: 8      # Panel labels (A, B, C, ...) in compose()
+  panel_label_pt: 10     # Panel labels (A, B, C, ...) in compose() — 10pt bold Arial
 
 # =============================================================================
 # PADDING (in points)

--- a/src/figrecipe/presets/SCITEX_STYLE.yaml
+++ b/src/figrecipe/presets/SCITEX_STYLE.yaml
@@ -46,6 +46,7 @@ fonts:
   suptitle_pt: 8         # Super title font size
   legend_pt: 6           # Legend font size
   annotation_pt: 6       # Annotation text (stats, etc.)
+  panel_label_pt: 8      # Panel labels (A, B, C, ...) in compose()
 
 # =============================================================================
 # PADDING (in points)


### PR DESCRIPTION
## Summary

Follow-up to #138.  PR #138 merged `panel_label_pt` plumbing through SCITEX_STYLE but kept the fallback default at **8pt**, on the assumption that panel labels should match `title_pt`.  Operator feedback on a downstream paper figure pushed back on that:

> パネルラベルは10ポイントで太字エリアルですね。それがもし必要だったら、サイテックスの設定に入れといてください。
> *(Panel labels are 10pt bold Arial.  Put it into SciTeX settings if needed.)*

This PR aligns the figrecipe default with the Nature-style convention.

## Changes

- `presets/SCITEX_STYLE.yaml`: `panel_label_pt: 8 → 10`, comment updated to `# Panel labels (A, B, C, ...) in compose() — 10pt bold Arial`.
- `_composition/_compose.py::_panel_label_fontsize()`:
  - Fallback default `8.0 → 10.0`.
  - Drop the `title_pt` fallback path — panel labels follow a different typographic convention than axis titles (Nature: 10pt bold; SciTeX titles: 8pt).  An explicit `fonts.panel_label_pt` still wins; this only changes the unspecified default.

## Why default 10pt and not just rely on SCITEX_STYLE

Helper scripts that don't load SCITEX_STYLE (e.g. ad-hoc notebook composition) would otherwise inherit `title_pt=8` panel labels, which on a 90mm-wide axes panel are noticeably small and inconsistent with `font.size` defaults across the field.  10pt is the standard.

## Verification

- Reran Fig 2 of the NeuroVista paper after these changes — panel labels now render at 10pt bold; matches operator expectation.
- No code path that hardcoded fontsize=10 was reintroduced — the helper is still the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)