### PR TITLE
fix(_diagram): Diagram.render(ax) emits recipe CallRecord (closes #139)

### DIFF
--- a/src/figrecipe/_diagram/_diagram/_core.py
+++ b/src/figrecipe/_diagram/_diagram/_core.py
@@ -381,6 +381,29 @@ class Diagram:
                 logger.warning(str(e))
             fig._figrecipe_diagram = self
 
+        # GH #139: record this render as a single high-level "diagram" call so
+        # the recipe's reproducer can replay it via replay_diagram_native_call
+        # (already wired to function="diagram" in _reproducer/_core.py via
+        # _replay_diagram.py). Without this hook, users who call
+        # `Diagram.render(ax)` directly on a figrecipe-recording axes get a
+        # recipe with NO record of the diagram render, so
+        # `fr.save(fig, validate=True)` round-trips into a blank panel and
+        # fails the MSE check (figrecipe-concept violation per #139). The
+        # `ax.diagram(...)` wrapper path already records via
+        # _wrappers/_axes_diagram::_record_diagram_call; this mirrors that
+        # for the direct-render path so the two entry points stay in sync.
+        if (
+            ax is not None
+            and getattr(ax, "_recorder", None) is not None
+            and getattr(ax, "_position", None) is not None
+        ):
+            try:
+                from .._wrappers._axes_diagram import _record_diagram_call
+
+                _record_diagram_call(ax._recorder, ax._position, None, self)
+            except Exception as _e:  # noqa: BLE001 - defensive: never break render
+                logger.warning(f"Failed to record diagram for recipe replay: {_e}")
+
         # Auto-crop SVG on any savefig call (stx.io.save, direct, etc.)
         # Pixel-analysis approach: renders temp PNG → find_content_area → adjust viewBox
         _original_savefig = fig.savefig

--- a/tests/figrecipe/_diagram/_diagram/test__core_render_records.py
+++ b/tests/figrecipe/_diagram/_diagram/test__core_render_records.py
@@ -1,0 +1,94 @@
+"""GH #139: verify Diagram.render(ax) records a "diagram" CallRecord.
+
+The bug: when a user calls ``Diagram.render(ax)`` directly on a
+figrecipe-recording axes (the common path — most figrecipe paper figures
+do this), the recipe ends up with NO record of the diagram render. On
+``fr.save(fig, validate=True)`` the reproducer renders an empty panel
+where the diagram should be, blows past the MSE threshold, and the
+validator raises. This violates the figrecipe round-trip concept.
+
+The fix lives in ``figrecipe._diagram._diagram._core.Diagram.render``:
+after the matplotlib primitives are drawn, fire
+``_wrappers/_axes_diagram::_record_diagram_call`` so the figure_record
+gets a single high-level ``CallRecord(function="diagram",
+kwargs={"diagram_data": diagram.to_dict()})`` that the reproducer's
+existing ``replay_diagram_native_call`` already knows how to replay.
+
+These tests assert the recording side only. The replay side has its own
+coverage under ``tests/figrecipe/_reproducer/test__replay_diagram.py``;
+together they close the round-trip.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _make_recording_axes():
+    """Return a real fr-wrapped figure + axes wired to a fresh Recorder."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import figrecipe as fr
+
+    fig, ax = fr.subplots(figsize_mm=(80, 60))
+    return fig, ax
+
+
+def test_render_on_recording_axes_appends_diagram_call_record():
+    """Direct ``Diagram.render(ax)`` records the diagram for replay."""
+    fr = pytest.importorskip("figrecipe")
+    _make_recording_axes_fn = _make_recording_axes  # local alias for readability
+    fig, ax = _make_recording_axes_fn()
+
+    from figrecipe.diagram import Diagram
+
+    diag = Diagram(title="GH139 smoke", width_mm=80, height_mm=60)
+    diag.add_box("a", "A", x_mm=5, y_mm=5)
+    diag.add_box("b", "B", x_mm=40, y_mm=5)
+    diag.add_arrow("a", "b")
+    diag.render(ax)
+
+    # The recording axes carries a back-pointer to the Recorder; pluck it.
+    recorder = getattr(ax, "_recorder", None)
+    assert recorder is not None, "fr.subplots axes should expose ._recorder"
+
+    fig_record = recorder.figure_record
+    assert fig_record is not None
+    ax_record = fig_record.get_or_create_axes(*ax._position)
+
+    diagram_calls = [c for c in ax_record.calls if c.function == "diagram"]
+    assert len(diagram_calls) == 1, (
+        f"expected exactly one recorded diagram call, got {len(diagram_calls)}"
+    )
+
+    rec = diagram_calls[0]
+    assert "diagram_data" in rec.kwargs, (
+        "recorded diagram call must carry diagram_data for replay"
+    )
+    diagram_data = rec.kwargs["diagram_data"]
+    assert isinstance(diagram_data, dict)
+    # diagram_data must round-trip through Diagram.from_dict so the reproducer
+    # can rebuild the renderer at replay time.
+    rebuilt = Diagram.from_dict(diagram_data)
+    assert rebuilt.title == "GH139 smoke"
+
+
+def test_render_without_recording_axes_is_a_silent_noop():
+    """``Diagram.render(ax)`` on a plain matplotlib axes must not raise."""
+    pytest.importorskip("figrecipe")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    from figrecipe.diagram import Diagram
+
+    fig, ax = plt.subplots(figsize=(3, 2))
+    # Plain axes has no ._recorder / ._position; the recording branch
+    # should short-circuit without raising and without polluting the
+    # bare matplotlib axes object.
+    diag = Diagram(title="GH139 noop", width_mm=80, height_mm=60)
+    diag.add_box("only", "Only", x_mm=5, y_mm=5)
+    diag.render(ax)  # must not raise
+    assert not hasattr(ax, "_recorder")


### PR DESCRIPTION
Closes #139.

## Summary

`fr.save(fig, validate=True)` was failing with **MSE>100** whenever the figure contained a `figrecipe.diagram.Diagram` panel built via the common direct-render path:

```python
fig, ax = fr.subplots(figsize_mm=(80, 60))
diag = Diagram(...); diag.add_box(...); diag.add_arrow(...)
diag.render(ax)            # ← THIS PATH WAS UNRECORDED
fr.save(fig, "/tmp/x.png") # → RuntimeError: Reproducible Validation FAILED
```

Round-trip is figrecipe's **core concept**. The validator renders the figure, saves a PNG, reproduces the figure from the recipe, re-renders, and compares pixel-MSE. The reproduce step builds an empty panel where the diagram should be (no record of the render → reproducer renders nothing) → MSE blows the threshold → the entire `fr.save` chain raises. Users had to set `validate=False` everywhere a figure included a Diagram, which **defeats the validator**.

## Root cause

The `ax.diagram(...)` wrapper path in `_wrappers/_axes_diagram.py::diagram_plot` already records the call via `_record_diagram_call(recorder, position, call_id, info)`. The **direct** `Diagram.render(ax)` path bypasses the wrapper and so emits no record.

The reproducer side is already wired:
- `_reproducer/_core.py:346` routes `method_name in ("diagram", "schematic")` → `_reproducer/_replay_diagram.py::replay_diagram_native_call`
- `replay_diagram_native_call` rebuilds the renderer via `Diagram.from_dict(diagram_data)` and replays

So the only missing piece was the recording-side emission for the direct render path.

## Fix

After the matplotlib primitives are drawn in `Diagram.render(ax)`, detect whether `ax` is a figrecipe-recording axes (has `._recorder` + `._position`) and, if so, fire `_record_diagram_call(...)` so the direct-render path mirrors the wrapper path.

```python
if (
    ax is not None
    and getattr(ax, "_recorder", None) is not None
    and getattr(ax, "_position", None) is not None
):
    try:
        from .._wrappers._axes_diagram import _record_diagram_call
        _record_diagram_call(ax._recorder, ax._position, None, self)
    except Exception as _e:
        logger.warning(f"Failed to record diagram for recipe replay: {_e}")
```

Defensive: wrapped in try/except — any failure logs at warning level and never breaks the render, so users on vanilla matplotlib axes (no recorder) keep working.

## Files

- `src/figrecipe/_diagram/_diagram/_core.py` — +23 lines: the recording hook in `Diagram.render(ax)`.
- `tests/figrecipe/_diagram/_diagram/test__core_render_records.py` — **NEW** focused test for the recording behavior:
  - `test_render_on_recording_axes_appends_diagram_call_record` — builds a Diagram, calls `.render(ax)` on a `fr.subplots()`-wrapped axes, asserts exactly one `CallRecord` with `function="diagram"` and a `kwargs.diagram_data` dict that round-trips through `Diagram.from_dict`.
  - `test_render_without_recording_axes_is_a_silent_noop` — verifies the defensive short-circuit on plain matplotlib axes.

## Out of scope (separate follow-up, per the issue's options b/c/d)

- **(b)** Generic `Rectangle`/`Text`/`FancyArrowPatch` recording — would also help matplotlib `ax.table(...)` round-trips.
- **(c)** Wrap `ax.table(...)` so post-creation `set_facecolor` / `set_text_props` mutations get recorded.
- **(d)** Raise the default MSE threshold — escape hatch only, doesn't address the actual recording gap.

This PR ships **option (a)** — the issue's recommended easiest unblocker — because `Diagram` is the single biggest source of `validate=True` failures in current paper builds. Other cases (notably matplotlib `ax.table`) deserve their own follow-up issues so we can scope each properly.

## Test plan

- [x] `py_compile` clean on both touched files
- [ ] CI: new tests pass on py3.11 / 3.12 / 3.13
- [ ] CI: full pytest-matrix GREEN
- [ ] Manual (operator-side): `fr.save(fig, validate=True)` on a Diagram-containing figure no longer raises MSE>100; round-trip succeeds

🤖 figrecipe maintainer — direct fix for operator-flagged figrecipe-concept violation (proj-scitex-dev)