### PR TITLE
feat(_utils): add fr.nice_lim — tick-friendly axis limits from data extent (closes #140)

### DIFF
--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -157,6 +157,8 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "KIND_ALIASES": ("._spec_builders", "KIND_ALIASES"),
     # ._render
     "render_spec_to_bytes": ("._render", "render_spec_to_bytes"),
+    # ._utils._nice_lim  (issue #140)
+    "nice_lim": ("._utils._nice_lim", "nice_lim"),
     # ._utils._termplot
     "termplot": ("._utils._termplot", "termplot"),
     # ._api._style_manager (style helpers)

--- a/src/figrecipe/_utils/__init__.py
+++ b/src/figrecipe/_utils/__init__.py
@@ -24,6 +24,7 @@ from ._im2grid import im2grid  # noqa: F401
 from ._is_valid_axis import assert_valid_axis, is_valid_axis  # noqa: F401
 from ._mk_colorbar import mk_colorbar  # noqa: F401
 from ._mk_patches import mk_patches  # noqa: F401
+from ._nice_lim import nice_lim
 from ._numpy_io import load_array, save_array
 from ._units import inch_to_mm, mm_to_inch, mm_to_pt, pt_to_mm
 
@@ -52,6 +53,7 @@ __all__ = [
     "mk_patches",
     "mm_to_inch",
     "mm_to_pt",
+    "nice_lim",
     "parse_csv_column_name",
     "parse_grid_id",
     "print_dimension_info",

--- a/src/figrecipe/_utils/_nice_lim.py
+++ b/src/figrecipe/_utils/_nice_lim.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tick-friendly axis-limit helper (issue #140).
+
+Provides :func:`nice_lim` — snap an axis limit to a "round" boundary above
+(and optionally below) the data extent, so the right (or top) spine doesn't
+get its own tick label and the axis range remains tick-friendly.
+
+Recurring need across scientific figures (timelines, count histograms,
+day-since-baseline x-axes, etc.). Sits alongside the existing
+:func:`figrecipe._utils._calc_nice_ticks.calc_nice_ticks` — the two solve
+adjacent problems (tick locations vs. axis limits) using the same "snap to
+order-of-magnitude" heuristic.
+
+Examples
+--------
+Day-since-start x-axis where ``data.max() == 367``::
+
+    >>> from figrecipe import nice_lim
+    >>> nice_lim([0, 367], round_to=10)
+    (0.0, 370.0)
+    >>> nice_lim([0, 367])                   # auto round step
+    (0.0, 400.0)
+
+Count histogram ``y`` axis where the tallest bar must not touch the top
+spine::
+
+    >>> nice_lim([0, 0, 1, 4, 19], round_to=5)
+    (0.0, 20.0)
+
+Negative data with ``lower=None`` rounds both edges outward::
+
+    >>> nice_lim([-3, 27], lower=None, round_to=10)
+    (-10.0, 30.0)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional, Tuple
+
+
+def nice_lim(
+    data: Any,
+    lower: Optional[float] = 0.0,
+    round_to: Optional[float] = None,
+) -> Tuple[float, float]:
+    """Return ``(lo, hi)`` axis limits snapped to tick-friendly boundaries.
+
+    Parameters
+    ----------
+    data : array-like
+        Data values to enclose. ``numpy`` arrays, lists, tuples, and any
+        iterable of floats are accepted. ``NaN`` is ignored. Empty input
+        returns ``(lower or 0, lower or 0 + round_to_or_1)`` instead of
+        crashing.
+    lower : float or None, optional
+        Lower bound. ``0.0`` (default) is the common case for time-since-start
+        / count axes — leaves the left edge anchored at zero. ``None`` snaps
+        the left edge *down* to the nearest multiple of ``round_to`` below
+        ``data.min()``.
+    round_to : float or None, optional
+        Snap step. ``None`` (default) picks an auto step equal to
+        ``10 ** floor(log10(max(|data|, 1)))`` — i.e. the order of magnitude
+        of the data range. Pass an explicit value (e.g. ``5``, ``10``) to
+        control tick spacing.
+
+    Returns
+    -------
+    (lo, hi) : tuple of float
+        Where ``lo <= data.min()`` and ``hi >= data.max() + epsilon`` and
+        both endpoints are exact multiples of ``round_to`` (when ``round_to``
+        is set explicitly or auto-chosen). If ``data.max()`` already sits on
+        a round boundary, ``hi`` is bumped by one ``round_to`` so the value
+        doesn't sit directly on the right spine.
+
+    Notes
+    -----
+    This helper is intentionally separate from
+    :func:`figrecipe._utils._calc_nice_ticks.calc_nice_ticks` — that one
+    returns tick *locations* given a fixed range, this one returns the
+    *range* given the data extent. Pair them by calling ``nice_lim`` first
+    and feeding the result into ``ax.set_xlim`` / ``ax.set_ylim`` (or any
+    locator that wants a sensible upper bound).
+    """
+    try:
+        import numpy as _np
+
+        arr = _np.asarray(list(data), dtype=float).ravel()
+        if arr.size == 0:
+            return _empty_lim(lower, round_to)
+        mask = ~_np.isnan(arr)
+        if not mask.any():
+            return _empty_lim(lower, round_to)
+        dmin = float(arr[mask].min())
+        dmax = float(arr[mask].max())
+    except (ImportError, ValueError, TypeError):
+        # Fallback for non-array iterables (no numpy available).
+        seq = [float(v) for v in data if v == v]  # skip NaN via self-equality
+        if not seq:
+            return _empty_lim(lower, round_to)
+        dmin, dmax = min(seq), max(seq)
+
+    if round_to is None:
+        span = max(abs(dmax), abs(dmin), 1.0)
+        step = 10 ** math.floor(math.log10(span)) if span > 0 else 1.0
+    else:
+        step = float(round_to)
+    if step <= 0:
+        raise ValueError(f"round_to must be positive, got {round_to!r}")
+
+    hi = math.ceil(dmax / step) * step
+    if hi <= dmax:
+        # data already sits on a round boundary; push one step so the value
+        # isn't pinned to the right spine.
+        hi += step
+
+    if lower is None:
+        lo = math.floor(dmin / step) * step
+        if lo >= dmin:
+            lo -= step
+    else:
+        lo = float(lower)
+
+    return (lo, hi)
+
+
+def _empty_lim(
+    lower: Optional[float],
+    round_to: Optional[float],
+) -> Tuple[float, float]:
+    """Sane fallback for empty / all-NaN data."""
+    lo = 0.0 if lower is None else float(lower)
+    step = 1.0 if round_to is None else float(round_to)
+    return (lo, lo + step)

--- a/tests/figrecipe/_utils/test__nice_lim.py
+++ b/tests/figrecipe/_utils/test__nice_lim.py
@@ -1,0 +1,126 @@
+"""GH #140: tick-friendly axis-limit helper ``figrecipe.nice_lim``.
+
+Each test focuses on one observable property of ``nice_lim`` and is
+AAA-structured (``# Arrange`` / ``# Act`` / ``# Assert`` markers) to
+satisfy STX-TQ002 / STX-TQ007 (PA-307 §3 test-quality).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_timeline_day_max_snaps_up_to_next_round_to():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    data = [0, 367]
+    # Act
+    lo, hi = fr.nice_lim(data, lower=0, round_to=10)
+    # Assert
+    assert (lo, hi) == (0.0, 370.0)
+
+
+def test_auto_round_to_picks_data_order_of_magnitude():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    data = [0, 367]
+    # Act
+    lo, hi = fr.nice_lim(data)
+    # Assert
+    assert (lo, hi) == (0.0, 400.0)
+
+
+def test_count_histogram_max_does_not_touch_top_spine():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    counts = [0, 0, 1, 4, 19]
+    # Act
+    _, hi = fr.nice_lim(counts, round_to=5)
+    # Assert
+    assert hi == 20.0
+
+
+def test_explicit_lower_zero_is_honoured_for_negative_friendly_data():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    data = [3, 27]
+    # Act
+    lo, _ = fr.nice_lim(data, lower=0, round_to=10)
+    # Assert
+    assert lo == 0.0
+
+
+def test_lower_none_snaps_left_edge_below_negative_data_min():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    data = [-3, 27]
+    # Act
+    lo, _ = fr.nice_lim(data, lower=None, round_to=10)
+    # Assert
+    assert lo == -10.0
+
+
+def test_exact_round_max_is_pushed_one_step_off_the_spine():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    data = [0, 20]
+    # Act
+    _, hi = fr.nice_lim(data, lower=0, round_to=10)
+    # Assert
+    assert hi == 30.0
+
+
+def test_empty_data_returns_unit_step_window_without_crashing():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    # Act
+    lo, hi = fr.nice_lim([], lower=0, round_to=10)
+    # Assert
+    assert (lo, hi) == (0.0, 10.0)
+
+
+def test_all_nan_data_returns_unit_step_window_without_crashing():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    import math
+
+    data = [math.nan, math.nan]
+    # Act
+    lo, hi = fr.nice_lim(data, lower=0, round_to=5)
+    # Assert
+    assert (lo, hi) == (0.0, 5.0)
+
+
+def test_data_max_equals_zero_returns_one_round_to_step_high():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    data = [0, 0, 0]
+    # Act
+    _, hi = fr.nice_lim(data, lower=0, round_to=10)
+    # Assert
+    assert hi == 10.0
+
+
+def test_negative_round_to_raises_value_error():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    # Act / Assert
+    with pytest.raises(ValueError):
+        fr.nice_lim([1, 2, 3], round_to=-5)
+
+
+def test_zero_round_to_raises_value_error():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    # Act / Assert
+    with pytest.raises(ValueError):
+        fr.nice_lim([1, 2, 3], round_to=0)
+
+
+def test_nice_lim_is_exposed_at_top_level_per_pep_562():
+    # Arrange
+    fr = pytest.importorskip("figrecipe")
+    # Act
+    nl = fr.nice_lim
+    # Assert
+    assert callable(nl)


### PR DESCRIPTION
Closes #140.

## Summary

Snap an axis limit to a "round" boundary above (and optionally below) the data extent, so the right (or top) spine doesn't get its own tick label and the axis range remains tick-friendly. Recurring need across scientific figures — surfaced from a paper Fig 2 build for `days since recording start`-style x-axes.

## API

```python
from figrecipe import nice_lim
xmin, xmax = nice_lim(data, lower=0.0, round_to=10.0)
ax.set_xlim(xmin, xmax)
```

Or as the PEP-562-exposed top-level alias (matches `fr.subplots` etc.):

```python
import figrecipe as fr
ax.set_xlim(*fr.nice_lim(data))
```

## Defaults

| param | default | meaning |
|-------|---------|---------|
| `lower` | `0.0` | common case for time-since-start / count axes |
| `round_to` | `None` | auto: `10 ** floor(log10(max(|data|, 1)))` (data order of magnitude) |
| `lower=None` | — | snap left edge *down* to nearest multiple of `round_to` below `data.min()` |

## Edge cases

- empty / all-NaN data → `(lower or 0, lower or 0 + step)`
- `data.max() == 0` → `hi` lifted to one `step` (not pinned to spine)
- exact round-boundary `data.max()` → `hi` lifted by one `step`
- negative or zero `round_to` → `ValueError`

## Pairing with `calc_nice_ticks`

`figrecipe._utils.calc_nice_ticks` returns tick *locations* given a range; `nice_lim` returns the *range* given the data extent. Use `nice_lim` first, then `calc_nice_ticks` if you want explicit tick control.

## Files

- `src/figrecipe/_utils/_nice_lim.py` — **NEW** (135 lines)
- `src/figrecipe/_utils/__init__.py` — re-export + `__all__` entry
- `src/figrecipe/__init__.py` — PEP-562 `_LAZY_ATTRS` map entry
- `tests/figrecipe/_utils/test__nice_lim.py` — **NEW** (12 AAA + one-assert tests)

## Pre-flight (lesson learned from the #144 → #145 fix-forward cycle)

- [x] `py_compile` clean on every touched file
- [x] `scitex-dev ecosystem audit-project figrecipe --repo <worktree> --severity error` → "no project-structure violations"
- [x] Each test follows **STX-TQ002** (AAA markers `# Arrange` / `# Act` / `# Assert`) and **STX-TQ007** (exactly one assertion per test — `with pytest.raises` counts as one)
- [ ] CI pytest-matrix GREEN on py3.11 / 3.12 / 3.13
- [ ] CI `quality` workflow GREEN

🤖 figrecipe maintainer — proj-scitex-dev