### PR TITLE
fix(tests): split nice_lim raises tests AAA markers (STX-TQ002 fix-forward)

### DIFF
--- a/tests/figrecipe/_utils/test__nice_lim.py
+++ b/tests/figrecipe/_utils/test__nice_lim.py
@@ -104,7 +104,8 @@ def test_data_max_equals_zero_returns_one_round_to_step_high():
 def test_negative_round_to_raises_value_error():
     # Arrange
     fr = pytest.importorskip("figrecipe")
-    # Act / Assert
+    # Act
+    # Assert
     with pytest.raises(ValueError):
         fr.nice_lim([1, 2, 3], round_to=-5)
 
@@ -112,7 +113,8 @@ def test_negative_round_to_raises_value_error():
 def test_zero_round_to_raises_value_error():
     # Arrange
     fr = pytest.importorskip("figrecipe")
-    # Act / Assert
+    # Act
+    # Assert
     with pytest.raises(ValueError):
         fr.nice_lim([1, 2, 3], round_to=0)
 


### PR DESCRIPTION
Fix-forward for #146.

PR #146 used combined `# Act / Assert` markers on the two `pytest.raises` tests in `tests/figrecipe/_utils/test__nice_lim.py`. STX-TQ002 requires each AAA marker on its own line in order — combined markers don't count.

Split into adjacent `# Act` + `# Assert` lines above each `with pytest.raises(...)` block; semantics unchanged.

Local pre-push pytest can't catch this because the rule lives under `audit-python-apis` which doesn't accept `--repo` today; manual review is the only safety net for now. Filing a follow-up to give `audit-python-apis` a `--repo` override mirroring `audit-project`'s.

🤖 figrecipe maintainer fix-forward — proj-scitex-dev