### PR TITLE
release: bump pyproject.toml to 0.28.15 (follow-up to #148)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.28.14"
+version = "0.28.15"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Follow-up to #148 — the CHANGELOG was bumped but pyproject.toml was not. This catches it up.

🤖 release driven by operator full-release-flow GO — proj-scitex-dev