### PR TITLE
release: bump pyproject.toml to 0.28.16 (rides on #150)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.28.15"
+version = "0.28.16"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Pyproject.toml bump to pair with the #150 _validator import fix-forward. Combined, this becomes v0.28.16 and the tag will trigger a successful release (last attempt v0.28.15 was caught by the test gate so no broken wheel landed).

🤖 release driven by operator full-release-flow GO — proj-scitex-dev