### PR TITLE
release: v0.28.17 — fix test fr.subplots(figsize_mm) → axes_width_mm/axes_height_mm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.17] - 2026-06-03
+
+### Fixed
+- **`tests/figrecipe/_diagram/_diagram/test__core_render_records.py` used
+  a fictional `figsize_mm` kwarg on `fr.subplots`.** The #144 / #145 test
+  scaffolding copied the API shape from the issue #139 reproduction body
+  literally, but `fr.subplots` takes per-axes sizing as
+  `axes_width_mm` / `axes_height_mm` — there is no `figsize_mm`
+  parameter. v0.28.16's release CI test-matrix surfaced this
+  (`AttributeError: Figure.set() got an unexpected keyword argument
+  'figsize_mm'`), correctly skipped build/publish/release, so **no
+  broken wheel reached PyPI**. Fixed the test helper; behaviour
+  unchanged everywhere else.
+
 ## [0.28.16] - 2026-06-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.28.16"
+version = "0.28.17"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/tests/figrecipe/_diagram/_diagram/test__core_render_records.py
+++ b/tests/figrecipe/_diagram/_diagram/test__core_render_records.py
@@ -25,13 +25,18 @@ import pytest
 
 
 def _make_recording_fig_ax():
-    """Real fr-wrapped figure + axes wired to a fresh Recorder."""
+    """Real fr-wrapped figure + axes wired to a fresh Recorder.
+
+    `fr.subplots` takes per-axes sizing in mm (`axes_width_mm` /
+    `axes_height_mm`), NOT a Matplotlib-style `figsize_mm` tuple — the
+    earlier copy-paste from the issue body used a fictional kwarg.
+    """
     import matplotlib
 
     matplotlib.use("Agg")
     import figrecipe as fr
 
-    return fr.subplots(figsize_mm=(80, 60))
+    return fr.subplots(axes_width_mm=80, axes_height_mm=60)
 
 
 def _build_and_render_diagram(ax):


### PR DESCRIPTION
## Summary

#144 / #145's new test file used `fr.subplots(figsize_mm=(80, 60))` — a fictional kwarg that the issue body used as illustrative pseudocode. The real `fr.subplots` signature takes per-axes sizing as `axes_width_mm` / `axes_height_mm` (no figsize_mm).

v0.28.16's release CI test-matrix surfaced this (`AttributeError: Figure.set() got an unexpected keyword argument 'figsize_mm'`) and correctly skipped build/publish/release — **no broken wheel reached PyPI**. Same defensive behaviour as v0.28.15 caught the `_validator` sibling-import bug.

## Fix

Single-call change in the test's `_make_recording_fig_ax` helper:
```python
- return fr.subplots(figsize_mm=(80, 60))
+ return fr.subplots(axes_width_mm=80, axes_height_mm=60)
```

Both pyproject.toml and CHANGELOG bumped to 0.28.17 in the same commit (lesson from #148/#149 / #150/#151 cycles where I split version metadata across two PRs).

## Pre-flight

- [x] py_compile clean
- [x] `scitex-dev ecosystem audit-project figrecipe --repo /tmp/<worktree> --severity error` → CLEAN
- [x] CHANGELOG + pyproject in same commit (no follow-up bump PR)
- [ ] Release CI test-matrix (the gate that caught v0.28.15 and v0.28.16) goes GREEN

🤖 release driven by operator full-release-flow GO — proj-scitex-dev