### PR TITLE
release: v0.28.19 — scitex-compat-style module-rename aliases + entry-point regression guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.19] - 2026-06-04
+
+### Added
+- **Module-rename back-compat via `figrecipe._compat` (operator direct via
+  Telegram).** The #141 topical refactor moved four private modules into
+  `figrecipe._quality.*`. Per the YAGNI grep the ecosystem had zero
+  runtime consumers of the old paths, but the operator asked for uniform
+  scitex-compat-style deprecation messaging when *any* code touches a
+  moved path. New `figrecipe._compat._module_aliases` registers
+  transparent `sys.modules` aliases at the old paths so legacy imports
+  still resolve AND emit a single-fire `DeprecationWarning` pointing at
+  the new path. No flat shim files at the package root (PS-108b
+  threshold unaffected).
+
+  Aliases installed (eagerly, from `figrecipe.__init__`):
+  - `figrecipe._validator`              → `figrecipe._quality._validator`
+  - `figrecipe._linter_plugin`          → `figrecipe._quality._linter_plugin`
+  - `figrecipe._axis_alignment_checker` → `figrecipe._quality._axis_alignment_checker`
+  - `figrecipe._axis_range_alignment`   → `figrecipe._quality._axis_range_alignment`
+
+- **Entry-point regression guard (lead msg b4e3dc7e).** New parametrized
+  smoke test (`tests/figrecipe/test__entry_points.py`) parses every
+  `[project.entry-points.*]` group in `pyproject.toml` and asserts each
+  `<module>:<attr>` value resolves to a real importable attribute.
+  Catches the "moved module + stale entry-point string + aggregator
+  silent-skip" failure class generically — new entry points + future
+  moves are covered with zero extra test maintenance.
+
 ## [0.28.18] - 2026-06-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.28.18"
+version = "0.28.19"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -21,6 +21,15 @@ from ._branding import BRAND_NAME as _BRAND_NAME
 from ._branding import rebrand_text as _rebrand_text
 from ._qr import add_qr_to_figure
 
+# Register sys.modules aliases for modules moved by #141 (figrecipe._quality
+# topical refactor) so legacy `from figrecipe._validator import X` style
+# imports keep working with a single-fire DeprecationWarning pointing at the
+# new path. See figrecipe._compat for details.
+from ._compat import install_module_aliases as _install_module_aliases
+
+_install_module_aliases()
+del _install_module_aliases
+
 # Brand-triggered house style: when a parent package (e.g. scitex.plt) sets
 # FIGRECIPE_BRAND, auto-apply that brand's global plotting style on import so
 # the parent needs zero in-tree auto-config. No-op for the default brand, so

--- a/src/figrecipe/_compat/__init__.py
+++ b/src/figrecipe/_compat/__init__.py
@@ -1,0 +1,30 @@
+"""figrecipe._compat — module-rename back-compatibility layer.
+
+The #141 topical refactor moved four private modules into
+``figrecipe._quality.``::
+
+    figrecipe._validator                → figrecipe._quality._validator
+    figrecipe._linter_plugin            → figrecipe._quality._linter_plugin
+    figrecipe._axis_alignment_checker   → figrecipe._quality._axis_alignment_checker
+    figrecipe._axis_range_alignment     → figrecipe._quality._axis_range_alignment
+
+The YAGNI grep at lead-gate time showed zero external runtime consumers, so
+the move itself didn't break the ecosystem. But the operator asked for
+ecosystem-uniform deprecation messaging — when *anything* imports the old
+path, the resulting error/warning should be in the canonical scitex-compat
+style, not a bare ``ModuleNotFoundError``. That's what this subpackage
+provides.
+
+Implementation: ``install_module_aliases()`` registers ``sys.modules``
+entries at the old paths so the old imports succeed AND emit a
+``DeprecationWarning`` (single-fire per old path) pointing at the new path.
+No flat shim files at the package root — keeps the PS-108b flat-file
+threshold intact.
+
+This module is imported eagerly from ``figrecipe.__init__`` so the aliases
+are live before any consumer touches the old paths.
+"""
+
+from ._module_aliases import install_module_aliases
+
+__all__ = ["install_module_aliases"]

--- a/src/figrecipe/_compat/_module_aliases.py
+++ b/src/figrecipe/_compat/_module_aliases.py
@@ -1,0 +1,90 @@
+"""sys.modules aliases for modules moved by #141.
+
+The (a) layout option from lead msg b4e3dc7e: register transparent
+aliases at the old import paths so legacy code keeps working AND gets
+a single-fire ``DeprecationWarning`` directing it to the new path. No
+flat shim files at the package root (the PS-108b threshold reason).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+from types import ModuleType
+from typing import Mapping
+
+# Old path → new path. Defined here so a single point of update covers
+# any future moves of the same shape.
+_MOVED: Mapping[str, str] = {
+    "figrecipe._validator": "figrecipe._quality._validator",
+    "figrecipe._linter_plugin": "figrecipe._quality._linter_plugin",
+    "figrecipe._axis_alignment_checker": "figrecipe._quality._axis_alignment_checker",
+    "figrecipe._axis_range_alignment": "figrecipe._quality._axis_range_alignment",
+}
+
+
+class _DeprecatedAliasModule(ModuleType):
+    """A live ModuleType that proxies attribute access to the new module.
+
+    Emits a single ``DeprecationWarning`` the first time anything is
+    accessed via the old path. We use a real ``ModuleType`` subclass (not
+    a bare proxy object) so ``from figrecipe._validator import X``,
+    ``import figrecipe._validator as v``, and ``hasattr(v, ...)`` all
+    behave like normal module access.
+    """
+
+    def __init__(self, old_name: str, new_name: str) -> None:
+        super().__init__(old_name)
+        # Don't use self.__dict__ for these so they don't pollute the
+        # attribute lookup of the proxied module. Stash on the instance
+        # via object-level slots-like attrs.
+        object.__setattr__(self, "_alias_old_name", old_name)
+        object.__setattr__(self, "_alias_new_name", new_name)
+        object.__setattr__(self, "_alias_warned", False)
+        object.__setattr__(self, "_alias_real", None)
+
+    def _resolve(self) -> ModuleType:
+        real = object.__getattribute__(self, "_alias_real")
+        if real is None:
+            real = importlib.import_module(
+                object.__getattribute__(self, "_alias_new_name")
+            )
+            object.__setattr__(self, "_alias_real", real)
+        return real
+
+    def _warn_once(self) -> None:
+        if object.__getattribute__(self, "_alias_warned"):
+            return
+        old = object.__getattribute__(self, "_alias_old_name")
+        new = object.__getattribute__(self, "_alias_new_name")
+        warnings.warn(
+            f"figrecipe: {old} has moved to {new} (figrecipe #141 _quality "
+            f"topical refactor). The old path is preserved for compatibility "
+            f"and will be removed in figrecipe 1.0. Update your imports.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        object.__setattr__(self, "_alias_warned", True)
+
+    def __getattr__(self, name: str):
+        # Module-level dunders (__name__, __doc__, __loader__, ...) are
+        # handled by ModuleType already; __getattr__ only fires for
+        # otherwise-missing attrs, which is exactly what we want to
+        # forward to the new module.
+        self._warn_once()
+        return getattr(self._resolve(), name)
+
+
+def install_module_aliases() -> None:
+    """Register every old-path alias in ``sys.modules``.
+
+    Idempotent: re-running is safe (existing aliases are skipped).
+    No-op if the new module isn't importable yet (lets ``figrecipe``'s
+    own bootstrap finish without circular-import surprises; the next
+    explicit alias access will re-attempt resolution via ``_resolve``).
+    """
+    for old, new in _MOVED.items():
+        if old in sys.modules:
+            continue
+        sys.modules[old] = _DeprecatedAliasModule(old, new)

--- a/tests/figrecipe/_compat/test__module_aliases.py
+++ b/tests/figrecipe/_compat/test__module_aliases.py
@@ -1,0 +1,92 @@
+"""Behavioural tests for figrecipe._compat._module_aliases.
+
+Each test is AAA-marked, single-assertion (STX-TQ002 / STX-TQ007). The
+seam under test is the sys.modules registration installed by figrecipe's
+top-level __init__; tests assert observable properties (resolution +
+warning emission) rather than internal state.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+
+import pytest
+
+pytest.importorskip("figrecipe")
+
+
+def test_old_validator_path_resolves_to_a_module():
+    # Arrange
+    import figrecipe  # noqa: F401 — ensure aliases are installed
+    # Act
+    mod = importlib.import_module("figrecipe._validator")
+    # Assert
+    assert mod is not None
+
+
+def test_old_validator_path_exposes_same_validation_result_as_new_path():
+    # Arrange
+    import figrecipe  # noqa: F401
+    new_mod = importlib.import_module("figrecipe._quality._validator")
+    # Act
+    old_mod = importlib.import_module("figrecipe._validator")
+    # Assert
+    assert old_mod.ValidationResult is new_mod.ValidationResult
+
+
+def test_old_linter_plugin_path_exposes_get_plugin_function():
+    # Arrange
+    import figrecipe  # noqa: F401
+    # Act
+    from figrecipe._linter_plugin import get_plugin
+    # Assert
+    assert callable(get_plugin)
+
+
+def test_old_axis_range_alignment_path_exposes_check_function():
+    # Arrange
+    import figrecipe  # noqa: F401
+    # Act
+    from figrecipe._axis_range_alignment import check_axis_range_alignment
+    # Assert
+    assert callable(check_axis_range_alignment)
+
+
+def test_old_axis_alignment_checker_path_exposes_checker_class():
+    # Arrange
+    import figrecipe  # noqa: F401
+    # Act
+    from figrecipe._axis_alignment_checker import AxisAlignmentChecker
+    # Assert
+    assert AxisAlignmentChecker is not None
+
+
+def test_first_access_to_old_path_emits_deprecation_warning():
+    # Arrange — drop the cached alias so the proxy's first-fire branch runs.
+    # Use a SEPARATE module path that test_*_resolves_to_a_module
+    # doesn't touch (so each test stays single-assertion / isolated).
+    import figrecipe  # noqa: F401
+    sys.modules.pop("figrecipe._linter_plugin", None)
+    from figrecipe._compat import install_module_aliases
+    install_module_aliases()
+    proxy = sys.modules["figrecipe._linter_plugin"]
+    # Act
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = proxy.get_plugin  # trigger __getattr__
+    # Assert
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_install_module_aliases_is_idempotent():
+    # Arrange
+    import figrecipe  # noqa: F401
+    from figrecipe._compat import install_module_aliases
+    first = sys.modules.get("figrecipe._validator")
+    # Act
+    install_module_aliases()
+    second = sys.modules.get("figrecipe._validator")
+    # Assert
+    assert first is second

--- a/tests/integration/test_entry_points.py
+++ b/tests/integration/test_entry_points.py
@@ -1,0 +1,80 @@
+"""Entry-point regression guard for figrecipe.
+
+Lead msg b4e3dc7e: when `_quality/` moved 4 private modules in #141, the
+pyproject.toml entry-point string had to be updated in lockstep (because
+rename-symbols doesn't rewrite TOML). It was, but the silent-skip failure
+mode (where the aggregator imports a moved module via the entry point and
+the dotted path now points nowhere) is the worst-class bug — no error
+surfaces, the linter rules just silently stop firing ecosystem-wide.
+
+This test parses every ``[project.entry-points.*]`` table in figrecipe's
+pyproject.toml and asserts each ``<module>:<attr>`` value resolves to a
+real importable attribute. New entry points + future moves are covered
+automatically without extra test maintenance.
+
+AAA-marked, single-assertion per test (STX-TQ002 / STX-TQ007).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import tomllib  # Python 3.11+
+except ImportError:  # pragma: no cover
+    tomllib = pytest.importorskip("tomli")  # type: ignore[assignment]
+
+
+def _read_entry_points() -> dict[str, dict[str, str]]:
+    """Return ``{group: {name: value}}`` from figrecipe's pyproject.toml.
+
+    Discovered by walking up from this test file to the repo root.
+    """
+    here = Path(__file__).resolve()
+    for parent in [here, *here.parents]:
+        candidate = parent / "pyproject.toml"
+        if candidate.exists() and candidate.read_text(encoding="utf-8").startswith(
+            "[build-system]"
+        ) or (
+            candidate.exists() and 'name = "figrecipe"' in candidate.read_text(encoding="utf-8")
+        ):
+            with candidate.open("rb") as fh:
+                data = tomllib.load(fh)
+            return (
+                data.get("project", {})
+                .get("entry-points", {})
+            )
+    return {}
+
+
+def _value_pairs() -> list[tuple[str, str, str]]:
+    """Yield (group, name, value) tuples for every entry point declared."""
+    out = []
+    for group, entries in _read_entry_points().items():
+        for name, value in entries.items():
+            out.append((group, name, value))
+    return out
+
+
+@pytest.mark.parametrize(
+    "group,name,value",
+    _value_pairs(),
+    ids=[f"{g}::{n}" for g, n, _ in _value_pairs()] or ["no-entry-points"],
+)
+def test_every_entry_point_resolves_to_real_attribute(group, name, value):
+    # Arrange
+    if not value:
+        pytest.skip("no entry points declared")
+    if ":" in value:
+        module_path, attr = value.split(":", 1)
+    else:
+        module_path, attr = value, None
+    # Act
+    mod = importlib.import_module(module_path)
+    resolved = getattr(mod, attr) if attr else mod
+    # Assert
+    assert resolved is not None


### PR DESCRIPTION
Two related back-compat / regression-guard additions, requested directly by operator + lead.

## 1. `figrecipe._compat` module-rename aliases (operator-direct via Telegram)

#141 moved 4 private modules into `figrecipe._quality.*`. YAGNI grep at the time showed zero ecosystem consumers of the old paths, so no shim was added. Operator then asked for **uniform scitex-compat-style deprecation messaging** when *any* code (now or in the future) touches a moved path — so the error format matches the rest of the ecosystem instead of being a bare `ModuleNotFoundError`.

New `figrecipe._compat._module_aliases.install_module_aliases()` registers transparent `sys.modules` aliases at the old paths. Each alias is a live `ModuleType` subclass that proxies attribute access to the new module + emits a single-fire `DeprecationWarning` the first time it's touched.

| Old path | New path |
|----------|----------|
| `figrecipe._validator` | `figrecipe._quality._validator` |
| `figrecipe._linter_plugin` | `figrecipe._quality._linter_plugin` |
| `figrecipe._axis_alignment_checker` | `figrecipe._quality._axis_alignment_checker` |
| `figrecipe._axis_range_alignment` | `figrecipe._quality._axis_range_alignment` |

**No flat shim files at the package root** — PS-108b flat-file threshold unaffected. Hooked into `figrecipe.__init__` so aliases are live before any consumer touches the old paths.

## 2. Entry-point regression guard (lead msg b4e3dc7e)

The #141 silent-break scenario lead worried about (TOML entry-point string still naming the OLD module path → aggregator can't import it → STX lint rules silently stop firing) didn't materialise — the pyproject.toml was updated in lockstep. But the failure class is real and ugly. New parametrized smoke test (`tests/integration/test_entry_points.py`) parses every `[project.entry-points.*]` group in pyproject.toml and asserts each `<module>:<attr>` value resolves to a real importable attribute.

New entry points + future moves are covered automatically.

## Tests

- `tests/figrecipe/_compat/test__module_aliases.py` — 7 AAA + single-assert tests (old path resolves, exposes same objects as new path, idempotent, single-fire warning, etc).
- `tests/integration/test_entry_points.py` — parametrized over every `[project.entry-points.*]` entry; today's matrix is one (the `scitex_dev.linter.plugins:figure` line), grows automatically.

## Pre-flight

- [x] py_compile clean on every touched file
- [x] `scitex-dev ecosystem audit-project figrecipe --repo /tmp/<wt> --severity error` → CLEAN
- [ ] CI pytest-matrix GREEN
- [ ] CI `quality` workflow GREEN
- [ ] release wheel publishes for v0.28.19

🤖 operator-direct + lead-coordinated — proj-scitex-dev