### PR TITLE
feat(caption): first-class caption= on fr.compose + fr.subplots, public caption API, round-trip persistence

### DIFF
--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -129,6 +129,9 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "save_bundle": ("._bundle", "save_bundle"),
     "load_bundle": ("._bundle", "load_bundle"),
     "reproduce_bundle": ("._bundle", "reproduce_bundle"),
+    # ._captions (public caption API)
+    "add_figure_caption": ("._captions._public", "add_figure_caption"),
+    "add_panel_captions": ("._captions._public", "add_panel_captions"),
     # ._composition
     "align_panels": ("._composition", "align_panels"),
     "align_smart": ("._composition", "align_smart"),
@@ -170,6 +173,8 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "edit": ("._api._public", "gui"),
     # ._editable
     "export_editable": ("._editable", "export_editable"),
+    # ._wrappers
+    "panel_label": ("._wrappers._panel_labels", "panel_label"),
     # ._composition (alias)
     "smart_align": ("._composition", "align_smart"),
 }
@@ -248,6 +253,10 @@ __all__ = [
     "validate",
     "extract_data",
     "add_qr_to_figure",
+    # Caption API
+    "add_figure_caption",
+    "add_panel_captions",
+    "panel_label",
     # Bundle format
     "Figz",
     "Pltz",

--- a/src/figrecipe/_api/_subplots.py
+++ b/src/figrecipe/_api/_subplots.py
@@ -237,6 +237,7 @@ def create_subplots(
     style: Optional[Dict[str, Any]] = None,
     apply_style_mm: bool = True,
     panel_labels: Optional[bool] = None,
+    caption: Optional[str] = None,
     **kwargs,
 ) -> Tuple[RecordingFigure, Union[RecordingAxes, NDArray]]:
     """Core subplots implementation."""
@@ -349,6 +350,13 @@ def create_subplots(
     # Add panel labels if enabled (for multi-panel figures)
     if use_panel_labels and (nrows > 1 or ncols > 1):
         fig.add_panel_labels()
+
+    # Render caption if provided
+    if caption is not None:
+        fig.record.caption = caption
+        from .._captions._public import add_figure_caption
+
+        add_figure_caption(fig, caption, position="bottom")
 
     return fig, axes
 

--- a/src/figrecipe/_captions/_public.py
+++ b/src/figrecipe/_captions/_public.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Public caption API — clean, simple, no Markdown noise.
+
+This module provides the figrecipe public caption surface:
+- ``add_figure_caption(fig, text, position="bottom")``
+- ``add_panel_captions(fig, axes, texts, position="top_left")``
+
+The internal ``ScientificCaption`` class adds Markdown formatting
+(e.g. ``**Figure 1.**``) which matplotlib cannot render.  This wrapper
+strips it so users get what they typed.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from ._caption import caption_manager
+
+
+def _strip_markdown(text: str) -> str:
+    """Remove Markdown bold/italic markers from text."""
+    return text.replace("**", "").replace("*", "")
+
+
+def add_figure_caption(
+    fig: Any,
+    caption: str,
+    *,
+    figure_label: Optional[str] = None,
+    style: str = "scientific",
+    position: str = "bottom",
+    width_ratio: float = 0.9,
+    font_size: Union[str, int] = "small",
+    wrap_width: int = 80,
+    save_to_file: bool = False,
+    file_path: Optional[str] = None,
+) -> str:
+    """Add a figure caption.
+
+    The caption text is stripped of Markdown formatting (bold/italic)
+    so it renders cleanly in matplotlib.  The caption is also recorded
+    on ``fig.record.caption`` so it survives save→reproduce round-trip.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure or RecordingFigure
+        The figure to add caption to.
+    caption : str
+        The caption text (Markdown formatting is automatically stripped).
+    figure_label : str, optional
+        Custom figure label (e.g. "Figure 1").  Auto-generated if None.
+    style : str
+        Caption style: "scientific", "nature", "ieee", "apa".
+    position : str
+        Caption position: "bottom" (default) or "top".
+    width_ratio : float
+        Width of caption relative to figure width.
+    font_size : str or int
+        Font size for caption text.
+    wrap_width : int
+        Character width for text wrapping.
+    save_to_file : bool
+        Whether to also save caption to a separate file.
+    file_path : str, optional
+        Path for caption file.
+
+    Returns
+    -------
+    str
+        The rendered caption text (Markdown-stripped).
+    """
+    # Persist caption in the recipe record for round-trip.
+    if hasattr(fig, "record"):
+        fig.record.caption = caption
+        fig.record.figure_texts.append(
+            {
+                "x": 0.5,
+                "y": 0.02 if position == "bottom" else 0.98,
+                "s": _strip_markdown(caption),
+                "kwargs": {
+                    "ha": "center",
+                    "va": "bottom" if position == "bottom" else "top",
+                    "fontsize": font_size,
+                    "wrap": True,
+                    "bbox": dict(boxstyle="round,pad=0.5", facecolor="white", alpha=0.8),
+                },
+            }
+        )
+        # Adjust layout to reserve space.
+        mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+        if position == "bottom":
+            mpl_fig.subplots_adjust(bottom=0.15)
+        else:
+            mpl_fig.subplots_adjust(top=0.85)
+
+        # Also render the text onto the figure.
+        mpl_fig.text(
+            0.5,
+            0.02 if position == "bottom" else 0.98,
+            _strip_markdown(caption),
+            ha="center",
+            va="bottom" if position == "bottom" else "top",
+            fontsize=font_size,
+            wrap=True,
+            bbox=dict(boxstyle="round,pad=0.5", facecolor="white", alpha=0.8),
+        )
+
+    # Also register with internal manager for numbering/export.
+    caption_manager.add_figure_caption(
+        fig,
+        caption,
+        figure_label=figure_label,
+        style=style,
+        position=position,
+        width_ratio=width_ratio,
+        font_size=font_size,
+        wrap_width=wrap_width,
+        save_to_file=save_to_file,
+        file_path=file_path,
+    )
+
+    return _strip_markdown(caption)
+
+
+def add_panel_captions(
+    fig: Any,
+    axes: Any,
+    panel_captions: Union[List[str], Dict[str, str]],
+    *,
+    main_caption: str = "",
+    figure_label: Optional[str] = None,
+    panel_style: str = "letter_bold",
+    position: str = "top_left",
+    font_size: Union[str, int] = "medium",
+    offset: Tuple[float, float] = (0.02, 0.98),
+) -> Dict[str, str]:
+    """Add panel captions (A, B, C, etc.) to subplot panels.
+
+    Panel labels are rendered with Markdown-stripped text so they
+    display cleanly in matplotlib.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure or RecordingFigure
+        The figure containing panels.
+    axes : Axes, list, or ndarray
+        Axes objects for each panel.
+    panel_captions : list or dict
+        Caption text for each panel.
+    main_caption : str
+        Main figure caption (optional, auto-attached).
+    figure_label : str, optional
+        Figure label for the main caption.
+    panel_style : str
+        Panel label style: "letter_bold", "letter_italic", "number".
+    position : str
+        Panel label position: "top_left", "top_right", etc.
+    font_size : str or int
+        Font size for panel labels.
+    offset : tuple
+        Position offset for panel labels.
+
+    Returns
+    -------
+    dict
+        Dictionary mapping panel labels to full caption text.
+    """
+    return caption_manager.add_panel_captions(
+        fig,
+        axes,
+        panel_captions,
+        main_caption=main_caption,
+        figure_label=figure_label,
+        panel_style=panel_style,
+        position=position,
+        font_size=font_size,
+        offset=offset,
+    )
+
+
+__all__ = [
+    "add_figure_caption",
+    "add_panel_captions",
+]

--- a/src/figrecipe/_composition/_caption_render.py
+++ b/src/figrecipe/_composition/_caption_render.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Render caption text for figrecipe compose figures.
+
+Wires fr.compose(caption=..., panel_captions=...) into the
+add_figure_caption / add_panel_captions public API.
+"""
+
+from typing import List, Optional, Union
+
+import numpy as np
+
+from .._wrappers import RecordingAxes, RecordingFigure
+
+
+def _strip_markdown(text: str) -> str:
+    return text.replace("**", "").replace("*", "")
+
+
+def _flatten_axes(
+    axes: Union[RecordingAxes, np.ndarray, List[RecordingAxes]],
+) -> List[RecordingAxes]:
+    """Flatten axes into 1D list."""
+    if isinstance(axes, RecordingAxes):
+        return [axes]
+    if isinstance(axes, np.ndarray):
+        return list(axes.flat)
+    if isinstance(axes, list):
+        result = []
+        for row in axes:
+            if isinstance(row, RecordingAxes):
+                result.append(row)
+            elif isinstance(row, list):
+                result.extend(row)
+        return result
+    return [axes]
+
+
+def render_compose_captions(
+    fig: RecordingFigure,
+    axes: Union[RecordingAxes, np.ndarray, List[RecordingAxes]],
+    caption: Optional[str],
+    panel_captions: Optional[List[str]],
+) -> None:
+    """Render caption text onto a composed figure.
+
+    Persist caption in fig.record and render as fig.text.
+    """
+    flat = _flatten_axes(axes)
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+
+    # Persist in record for round-trip
+    if caption is not None:
+        fig.record.caption = caption
+    if panel_captions:
+        fig.record.figure_panel_captions = panel_captions
+
+    # --- Per-panel captions: render label + text above each panel ---
+    if panel_captions:
+        import string
+
+        n = len(flat)
+        labels = list(string.ascii_uppercase[:n])
+
+        for i, (ax, label, cap_text) in enumerate(zip(flat, labels, panel_captions)):
+            raw = ax._ax if hasattr(ax, "_ax") else ax
+            pos = raw.get_position()
+            x_center = pos.x0 + pos.width / 2.0
+            y_top = pos.y1
+            mpl_fig.text(
+                x_center,
+                y_top + 0.02,
+                f"({label}) {cap_text}",
+                transform=mpl_fig.transFigure,
+                fontsize=8,
+                ha="center",
+                va="bottom",
+            )
+
+    # --- Figure-level caption ---
+    if caption:
+        from .._captions._public import add_figure_caption
+
+        add_figure_caption(fig, caption, position="bottom")
+
+
+__all__ = [
+    "render_compose_captions",
+]

--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -47,6 +47,8 @@ def compose(
     dpi: int = DEFAULT_DPI,
     panel_labels: bool = False,
     label_style: str = "uppercase",
+    caption: Optional[str] = None,
+    panel_captions: Optional[List[str]] = None,
     **kwargs,
 ) -> Tuple[RecordingFigure, Union[RecordingAxes, NDArray, List[RecordingAxes]]]:
     """Compose a new figure from multiple sources (recipes or raw images).
@@ -77,6 +79,12 @@ def compose(
         If True, add panel labels (A, B, C...) to each panel.
     label_style : str
         'uppercase', 'lowercase', or 'numeric'.
+    caption : str, optional
+        Figure-level caption text.  Rendered on the figure and persisted
+        in the recipe so it survives save→reproduce.
+    panel_captions : list of str, optional
+        Per-panel caption texts.  When provided, panel labels (A, B, C...)
+        are placed with the corresponding caption text on each panel.
     **kwargs
         Additional arguments passed to figure creation.
 
@@ -99,6 +107,17 @@ def compose(
     ...     }
     ... )
 
+    Composition with figure-level caption:
+
+    >>> fig, axes = fr.compose(
+    ...     layout=(2, 2),
+    ...     sources={
+    ...         (0, 0): "a.yaml", (0, 1): "b.yaml",
+    ...         (1, 0): "c.yaml", (1, 1): "d.yaml",
+    ...     },
+    ...     caption="Figure 1. Four-condition comparison (n=3).",
+    ... )
+
     Mm-based free-form composition:
 
     >>> fig, axes = fr.compose(
@@ -112,10 +131,14 @@ def compose(
     """
     if _is_mm_based_sources(sources):
         return _compose_mm_based(
-            sources, canvas_size_mm, dpi, panel_labels, label_style, **kwargs
+            sources, canvas_size_mm, dpi, panel_labels, label_style,
+            caption=caption, panel_captions=panel_captions, **kwargs,
         )
     else:
-        return _compose_grid_based(sources, layout, panel_labels, label_style, **kwargs)
+        return _compose_grid_based(
+            sources, layout, panel_labels, label_style,
+            caption=caption, panel_captions=panel_captions, **kwargs,
+        )
 
 
 def _compose_grid_based(
@@ -123,10 +146,13 @@ def _compose_grid_based(
     layout: Optional[Tuple[int, int]],
     panel_labels: bool,
     label_style: str,
+    caption: Optional[str],
+    panel_captions: Optional[List[str]],
     **kwargs,
 ) -> Tuple[RecordingFigure, Union[RecordingAxes, NDArray]]:
     """Grid-based composition using subplots."""
     from .. import subplots
+    from ._caption_render import render_compose_captions
 
     # Auto-detect layout from source positions
     if layout is None:
@@ -189,6 +215,9 @@ def _compose_grid_based(
     if panel_labels:
         _add_panel_labels_grid(axes, nrows, ncols, label_style)
 
+    # Render caption and panel captions
+    render_compose_captions(fig, axes, caption, panel_captions)
+
     return fig, axes
 
 
@@ -198,6 +227,8 @@ def _compose_mm_based(
     dpi: int,
     panel_labels: bool,
     label_style: str,
+    caption: Optional[str],
+    panel_captions: Optional[List[str]],
     **kwargs,
 ) -> Tuple[RecordingFigure, List[RecordingAxes]]:
     """Mm-based composition using fig.add_axes() for precise positioning."""
@@ -276,6 +307,9 @@ def _compose_mm_based(
 
     if panel_labels:
         _add_panel_labels_mm(mpl_fig, sources, canvas_size_mm, label_style)
+
+    # Render caption and panel captions for mm-based
+    render_compose_captions(fig, axes_list, caption, panel_captions)
 
     return fig, axes_list
 

--- a/src/figrecipe/_recorder/_core.py
+++ b/src/figrecipe/_recorder/_core.py
@@ -141,6 +141,8 @@ class FigureRecord:
     source_data_dirs: Optional[Dict[str, Path]] = None
     # Colorbar calls: list of {mappable_id, ax_key, kwargs}
     colorbars: List[Dict[str, Any]] = field(default_factory=list)
+    # Per-panel caption texts (set via fr.compose(panel_captions=...))
+    figure_panel_captions: Optional[List[str]] = None
 
     def get_axes_key(self, row: int, col: int) -> str:
         """Get dictionary key for axes at position."""
@@ -209,6 +211,9 @@ class FigureRecord:
         # Add colorbars if set
         if self.colorbars:
             result["figure"]["colorbars"] = self.colorbars
+        # Add per-panel caption texts if set
+        if self.figure_panel_captions is not None:
+            result["figure"]["panel_captions"] = self.figure_panel_captions
         return result
 
     @classmethod
@@ -236,6 +241,7 @@ class FigureRecord:
             crop_info=fig_data.get("crop_info"),
             mm_layout=fig_data.get("mm_layout"),
             colorbars=fig_data.get("colorbars", []),
+            figure_panel_captions=fig_data.get("panel_captions"),
         )
 
         # Reconstruct axes

--- a/src/figrecipe/_wrappers/_panel_labels.py
+++ b/src/figrecipe/_wrappers/_panel_labels.py
@@ -122,6 +122,58 @@ def _calculate_position(
     return x, y, ha, va
 
 
-__all__ = ["add_panel_labels"]
+__all__ = ["add_panel_labels", "panel_label"]
+
+
+def panel_label(
+    ax: Any,
+    label: str,
+    loc: str = "upper left",
+    offset: Tuple[float, float] = (-0.1, 1.05),
+    fontsize: float = 10,
+    fontweight: str = "bold",
+    text_color: str = "black",
+    **kwargs,
+) -> Any:
+    """Place a single panel label (A, B, C, etc.) on one axes.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The axes to annotate.
+    label : str
+        The panel label text (e.g. 'A', 'B', '(1)').
+    loc : str
+        Location hint: 'upper left' (default), 'upper right',
+        'lower left', 'lower right'.
+    offset : tuple of float
+        (x, y) offset in axes coordinates. Default (-0.1, 1.05).
+    fontsize : float
+        Font size in points (default 10).
+    fontweight : str
+        Font weight (default 'bold').
+    text_color : str
+        Text color (default 'black').
+    **kwargs
+        Additional arguments passed to ``ax.text()``.
+
+    Returns
+    -------
+    matplotlib.text.Text
+        The created text annotation.
+    """
+    x, y, ha, va = _calculate_position(loc, offset)
+    return ax.ax.text(
+        x,
+        y,
+        label,
+        transform=ax.ax.transAxes,
+        fontsize=fontsize,
+        fontweight=fontweight,
+        color=text_color,
+        ha=ha,
+        va=va,
+        **kwargs,
+    )
 
 # EOF

--- a/tests/figrecipe/_wrappers/test__panel_labels.py
+++ b/tests/figrecipe/_wrappers/test__panel_labels.py
@@ -5,7 +5,11 @@ as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
 
+import matplotlib
+import matplotlib.pyplot as plt
 import pytest
+
+import figrecipe._wrappers._panel_labels as _panel_labels
 
 
 def test_import__wrappers__panel_labels_module():
@@ -18,3 +22,14 @@ def test_import__wrappers__panel_labels_module():
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+def test_panel_label_returns_text():
+    """Test that panel_label places a single label on an axes and returns the Text object."""
+    fig, ax = plt.subplots()
+    # Act
+    result = _panel_labels.panel_label(ax, "A")
+    # Assert
+    assert isinstance(result, matplotlib.text.Text)
+    assert result.get_text() == "A"
+    plt.close(fig)

--- a/tests/figrecipe/_wrappers/test__panel_labels.py
+++ b/tests/figrecipe/_wrappers/test__panel_labels.py
@@ -4,9 +4,7 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-
 import matplotlib
-import matplotlib.pyplot as plt
 import pytest
 
 import figrecipe._wrappers._panel_labels as _panel_labels
@@ -14,22 +12,34 @@ import figrecipe._wrappers._panel_labels as _panel_labels
 
 def test_import__wrappers__panel_labels_module():
     # Arrange
-    # Arrange
-    # Act
-    # Assert
-    module_path = 'figrecipe._wrappers._panel_labels'
+    module_path = "figrecipe._wrappers._panel_labels"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
 
 
-def test_panel_label_returns_text():
-    """Test that panel_label places a single label on an axes and returns the Text object."""
-    fig, ax = plt.subplots()
+def test_panel_label_renders_given_label_text_on_recording_axes():
+    # Arrange
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+
     # Act
     result = _panel_labels.panel_label(ax, "A")
+
+    # Assert
+    assert result.get_text() == "A"
+
+
+def test_panel_label_returns_matplotlib_text_artist_instance():
+    # Arrange
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+
+    # Act
+    result = _panel_labels.panel_label(ax, "A")
+
     # Assert
     assert isinstance(result, matplotlib.text.Text)
-    assert result.get_text() == "A"
-    plt.close(fig)


### PR DESCRIPTION
Makes figure captions a first-class, obvious API instead of a hidden internal call (operator request: わかりやすい API, on both Plotter and Composer, no hidden commands).

- `fr.compose(caption=..., panel_captions=...)` — figure-level + per-panel captions
- `fr.subplots(caption=...)` — caption param added
- `add_figure_caption` / `add_panel_captions` / `panel_label` — now public API (promoted out of `_captions`)
- `FigureRecord.figure_panel_captions` — persists per-panel captions for save/reproduce round-trip

Unblocks neurovista's in-figure comodulogram captions (drops the internal _captions workaround).