### PR TITLE
fix(caption): stop double-render + reserve real room for caption (PR #162 follow-up)

### DIFF
--- a/src/figrecipe/_captions/_caption.py
+++ b/src/figrecipe/_captions/_caption.py
@@ -50,6 +50,7 @@ class ScientificCaption:
         wrap_width: int = 80,
         save_to_file: bool = False,
         file_path: Optional[str] = None,
+        render: bool = True,
     ) -> str:
         """Add a scientific caption to a figure.
 
@@ -76,6 +77,14 @@ class ScientificCaption:
             Whether to save caption to separate file. Default: False.
         file_path : str, optional
             Path for caption file. Default: None.
+        render : bool, optional
+            If True (default), draw the caption onto the figure and
+            adjust the layout to reserve room for it.  Set to False to
+            register/number the caption only — the public
+            ``figrecipe.add_figure_caption`` API uses ``render=False`` so
+            that ONE rendering pipeline (its own ``mpl_fig.text`` call)
+            owns the visual output; otherwise the caption is drawn twice
+            and the two stacked copies overlap each other.
 
         Returns
         -------
@@ -95,10 +104,13 @@ class ScientificCaption:
             caption, figure_label, style, wrap_width
         )
 
-        # Add caption to figure
-        self._add_caption_to_figure(
-            mpl_fig, formatted_caption, position, width_ratio, font_size
-        )
+        # Add caption to figure — only when the caller asks us to render.
+        # The public figrecipe.add_figure_caption draws the caption itself
+        # and passes render=False here so we don't double-render.
+        if render:
+            self._add_caption_to_figure(
+                mpl_fig, formatted_caption, position, width_ratio, font_size
+            )
 
         # Register caption
         self.caption_registry[figure_label] = {
@@ -236,7 +248,13 @@ class ScientificCaption:
         width_ratio: float,
         font_size: Union[str, int],
     ):
-        """Add caption text to figure."""
+        """Add caption text to figure.
+
+        Markdown markers (``**``, ``*``) introduced by ``_format_caption``'s
+        style templates (e.g. ``**Figure 1.**``) are stripped here.
+        matplotlib renders text literally — leaving the markers in would
+        show ``**Figure 1.**`` as four asterisks instead of a bold label.
+        """
         if position == "bottom":
             y_pos = 0.02
             va = "bottom"
@@ -244,10 +262,11 @@ class ScientificCaption:
             y_pos = 0.98
             va = "top"
 
+        clean = caption.replace("**", "").replace("*", "")
         fig.text(
             0.5,
             y_pos,
-            caption,
+            clean,
             ha="center",
             va=va,
             fontsize=font_size,

--- a/src/figrecipe/_captions/_public.py
+++ b/src/figrecipe/_captions/_public.py
@@ -68,43 +68,86 @@ def add_figure_caption(
     str
         The rendered caption text (Markdown-stripped).
     """
+    # Resolve the underlying matplotlib Figure (RecordingFigure wraps it).
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+
+    # Reserve room for the caption BEFORE rendering, by adjusting axes
+    # positions when they encroach on the caption strip.  The previous
+    # implementation called ``mpl_fig.subplots_adjust(bottom=0.15)`` and
+    # trusted that to move the panels, but on figrecipe's mm-laid figures
+    # (the paper-figure default) the bottom-row axes stayed near y0≈0.05
+    # and the caption text at y=0.02 landed on top of them.  We now
+    # nudge each axes via ``set_position`` so the fix is robust to the
+    # mm-layout path AND the plain subplots_adjust path.
+    reserved = 0.15  # caption strip height in figure-fraction
+    pad = 0.02  # gap between caption and nearest axes
+    if position == "bottom":
+        mpl_fig.subplots_adjust(bottom=reserved)
+        mpl_fig.canvas.draw()
+        mpl_axes = [ax for ax in mpl_fig.axes if ax.get_visible()]
+        if mpl_axes:
+            lowest = min(ax.get_position().y0 for ax in mpl_axes)
+            if lowest < reserved + pad:
+                delta = (reserved + pad) - lowest
+                for ax in mpl_axes:
+                    pos = ax.get_position()
+                    new_height = max(0.05, pos.height - delta)
+                    ax.set_position([pos.x0, pos.y0 + delta, pos.width, new_height])
+        y_pos, va = 0.02, "bottom"
+    else:
+        mpl_fig.subplots_adjust(top=1.0 - reserved)
+        mpl_fig.canvas.draw()
+        mpl_axes = [ax for ax in mpl_fig.axes if ax.get_visible()]
+        if mpl_axes:
+            highest = max(ax.get_position().y1 for ax in mpl_axes)
+            if highest > 1.0 - reserved - pad:
+                delta = highest - (1.0 - reserved - pad)
+                for ax in mpl_axes:
+                    pos = ax.get_position()
+                    new_height = max(0.05, pos.height - delta)
+                    ax.set_position([pos.x0, pos.y0, pos.width, new_height])
+        y_pos, va = 0.98, "top"
+
+    clean_caption = _strip_markdown(caption)
+
     # Persist caption in the recipe record for round-trip.
     if hasattr(fig, "record"):
         fig.record.caption = caption
         fig.record.figure_texts.append(
             {
                 "x": 0.5,
-                "y": 0.02 if position == "bottom" else 0.98,
-                "s": _strip_markdown(caption),
+                "y": y_pos,
+                "s": clean_caption,
                 "kwargs": {
                     "ha": "center",
-                    "va": "bottom" if position == "bottom" else "top",
+                    "va": va,
                     "fontsize": font_size,
                     "wrap": True,
-                    "bbox": dict(boxstyle="round,pad=0.5", facecolor="white", alpha=0.8),
+                    "bbox": dict(
+                        boxstyle="round,pad=0.5", facecolor="white", alpha=0.8
+                    ),
                 },
             }
         )
-        # Adjust layout to reserve space.
-        mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
-        if position == "bottom":
-            mpl_fig.subplots_adjust(bottom=0.15)
-        else:
-            mpl_fig.subplots_adjust(top=0.85)
 
-        # Also render the text onto the figure.
-        mpl_fig.text(
-            0.5,
-            0.02 if position == "bottom" else 0.98,
-            _strip_markdown(caption),
-            ha="center",
-            va="bottom" if position == "bottom" else "top",
-            fontsize=font_size,
-            wrap=True,
-            bbox=dict(boxstyle="round,pad=0.5", facecolor="white", alpha=0.8),
-        )
+    # Render the caption text — ONCE.  This is the single source of
+    # visual truth; ``caption_manager.add_figure_caption`` below is
+    # called with ``render=False`` so it only registers metadata
+    # (numbering, registry, optional file save) and does NOT draw a
+    # second copy of the caption (the previous double-render bug stacked
+    # two captions on the same y-anchor and they overlapped each other).
+    mpl_fig.text(
+        0.5,
+        y_pos,
+        clean_caption,
+        ha="center",
+        va=va,
+        fontsize=font_size,
+        wrap=True,
+        bbox=dict(boxstyle="round,pad=0.5", facecolor="white", alpha=0.8),
+    )
 
-    # Also register with internal manager for numbering/export.
+    # Register with internal manager for numbering/export ONLY.
     caption_manager.add_figure_caption(
         fig,
         caption,
@@ -116,9 +159,10 @@ def add_figure_caption(
         wrap_width=wrap_width,
         save_to_file=save_to_file,
         file_path=file_path,
+        render=False,
     )
 
-    return _strip_markdown(caption)
+    return clean_caption
 
 
 def add_panel_captions(

--- a/tests/figrecipe/_captions/test__public_overlap.py
+++ b/tests/figrecipe/_captions/test__public_overlap.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression tests for caption-overlap bugs (PR #162 follow-up).
+
+The first iteration of ``fr.subplots(caption=...)`` / ``fr.compose(caption=...)``
+shipped three layered bugs:
+
+  1) DOUBLE-RENDER: ``add_figure_caption`` drew the caption twice — once
+     directly via ``mpl_fig.text(...)`` and once via
+     ``caption_manager.add_figure_caption(...)``. Two ``fig.texts``
+     entries stacked at the same y-anchor and overlapped each other.
+  2) PANEL OVERLAP: ``mpl_fig.subplots_adjust(bottom=0.15)`` failed to
+     move the bottom-row panels on mm-laid figures (the paper-figure
+     default), so the caption text at y=0.02 landed on top of panels
+     whose ``y0`` was still ≈0.05.
+  3) MARKDOWN LEAKAGE: ``caption_manager`` rendered the formatted caption
+     with raw ``**Figure N.**`` markers, which matplotlib renders
+     literally as four asterisks rather than as bold text.
+
+Tests are AAA-structured (STX-TQ002) with one assertion each
+(STX-TQ007), one behaviour per test.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+
+def _bbox_intersects(text_bbox, axes_bbox) -> bool:
+    """Return True iff two figure-fraction Bboxes overlap."""
+    return not (
+        text_bbox.x1 <= axes_bbox.x0
+        or axes_bbox.x1 <= text_bbox.x0
+        or text_bbox.y1 <= axes_bbox.y0
+        or axes_bbox.y1 <= text_bbox.y0
+    )
+
+
+def _text_bbox_in_fig_frac(mpl_fig, txt_artist):
+    """Return text's bounding box in figure-fraction coords."""
+    mpl_fig.canvas.draw()
+    bb = txt_artist.get_window_extent(renderer=mpl_fig.canvas.get_renderer())
+    return bb.transformed(mpl_fig.transFigure.inverted())
+
+
+@pytest.fixture
+def fig_with_long_caption():
+    """A 2x2 fr.subplots with a long caption + one line per panel.
+
+    Yields (mpl_fig, mpl_axes_list). Closes the figure on teardown.
+    """
+    import figrecipe as fr
+
+    fig, axes = fr.subplots(
+        nrows=2,
+        ncols=2,
+        figsize=(7, 5),
+        caption=(
+            "Figure Y. Long-ish caption that tests whether a multi-line "
+            "wrapped caption with bbox can overlap the bottom row of panels "
+            "in a small figure. PAC z-score comparison; n=15 patients."
+        ),
+    )
+    axes_flat = np.asarray(axes).flatten().tolist()
+    for i, ax in enumerate(axes_flat):
+        raw = ax._ax if hasattr(ax, "_ax") else ax
+        raw.plot(np.linspace(0, 1, 50), np.sin(np.linspace(0, 6, 50) + i))
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    mpl_axes = [ax._ax if hasattr(ax, "_ax") else ax for ax in axes_flat]
+    yield mpl_fig, mpl_axes
+    plt.close(mpl_fig)
+
+
+def test_caption_renders_exactly_one_figure_text():
+    """Bug 1: caption must not be rendered twice on the same figure."""
+    # Arrange
+    import figrecipe as fr
+
+    fig, _axes = fr.subplots(
+        nrows=2,
+        ncols=2,
+        figsize=(7, 5),
+        caption="Figure X. Single caption rendered exactly once.",
+    )
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+
+    # Act
+    n_texts = len(mpl_fig.texts)
+
+    # Assert
+    assert n_texts == 1, (
+        f"expected exactly 1 figure-level text artist, got {n_texts}: "
+        f"{[t.get_text()[:40] for t in mpl_fig.texts]}"
+    )
+    plt.close(mpl_fig)
+
+
+def test_caption_bbox_does_not_overlap_top_left_panel(fig_with_long_caption):
+    """Bug 2: caption must not overlap top-left panel (axes index 0)."""
+    # Arrange
+    mpl_fig, mpl_axes = fig_with_long_caption
+
+    # Act
+    tbb = _text_bbox_in_fig_frac(mpl_fig, mpl_fig.texts[0])
+    abb = mpl_axes[0].get_position()
+
+    # Assert
+    assert not _bbox_intersects(tbb, abb), (
+        f"caption y=[{tbb.y0:.3f}..{tbb.y1:.3f}] overlaps "
+        f"axes[0] y=[{abb.y0:.3f}..{abb.y1:.3f}]"
+    )
+
+
+def test_caption_bbox_does_not_overlap_top_right_panel(fig_with_long_caption):
+    """Bug 2: caption must not overlap top-right panel (axes index 1)."""
+    # Arrange
+    mpl_fig, mpl_axes = fig_with_long_caption
+
+    # Act
+    tbb = _text_bbox_in_fig_frac(mpl_fig, mpl_fig.texts[0])
+    abb = mpl_axes[1].get_position()
+
+    # Assert
+    assert not _bbox_intersects(tbb, abb), (
+        f"caption y=[{tbb.y0:.3f}..{tbb.y1:.3f}] overlaps "
+        f"axes[1] y=[{abb.y0:.3f}..{abb.y1:.3f}]"
+    )
+
+
+def test_caption_bbox_does_not_overlap_bottom_left_panel(
+    fig_with_long_caption,
+):
+    """Bug 2 (the originally-failing case): caption must not overlap
+    bottom-left panel (axes index 2). This is where the pre-fix bug
+    landed — bottom-row axes y0≈0.04, caption y=0.02..0.08.
+    """
+    # Arrange
+    mpl_fig, mpl_axes = fig_with_long_caption
+
+    # Act
+    tbb = _text_bbox_in_fig_frac(mpl_fig, mpl_fig.texts[0])
+    abb = mpl_axes[2].get_position()
+
+    # Assert
+    assert not _bbox_intersects(tbb, abb), (
+        f"caption y=[{tbb.y0:.3f}..{tbb.y1:.3f}] overlaps "
+        f"axes[2] (bottom-left) y=[{abb.y0:.3f}..{abb.y1:.3f}]"
+    )
+
+
+def test_caption_bbox_does_not_overlap_bottom_right_panel(
+    fig_with_long_caption,
+):
+    """Bug 2 (the originally-failing case): caption must not overlap
+    bottom-right panel (axes index 3).
+    """
+    # Arrange
+    mpl_fig, mpl_axes = fig_with_long_caption
+
+    # Act
+    tbb = _text_bbox_in_fig_frac(mpl_fig, mpl_fig.texts[0])
+    abb = mpl_axes[3].get_position()
+
+    # Assert
+    assert not _bbox_intersects(tbb, abb), (
+        f"caption y=[{tbb.y0:.3f}..{tbb.y1:.3f}] overlaps "
+        f"axes[3] (bottom-right) y=[{abb.y0:.3f}..{abb.y1:.3f}]"
+    )
+
+
+def test_rendered_caption_strips_double_asterisks():
+    """Bug 3: ``**`` bold markers must not appear in rendered caption."""
+    # Arrange
+    import figrecipe as fr
+
+    fig, _axes = fr.subplots(
+        nrows=2,
+        ncols=2,
+        figsize=(7, 5),
+        caption="Figure Z. Caption with **bold** markers.",
+    )
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+
+    # Act
+    rendered = mpl_fig.texts[0].get_text()
+
+    # Assert
+    assert (
+        "**" not in rendered
+    ), f"raw '**' markdown leaked into rendered caption: {rendered!r}"
+    plt.close(mpl_fig)
+
+
+def test_rendered_caption_strips_single_asterisks():
+    """Bug 3: single-``*`` italic markers must not appear in rendered caption."""
+    # Arrange
+    import figrecipe as fr
+
+    fig, _axes = fr.subplots(
+        nrows=2,
+        ncols=2,
+        figsize=(7, 5),
+        caption="Figure Z. Caption with *italic* markers.",
+    )
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+
+    # Act
+    rendered = mpl_fig.texts[0].get_text()
+
+    # Assert
+    assert (
+        "*" not in rendered
+    ), f"raw '*' markdown leaked into rendered caption: {rendered!r}"
+    plt.close(mpl_fig)
+
+
+def test_caption_manager_does_not_render_when_render_false():
+    """``caption_manager.add_figure_caption(render=False)`` must not draw."""
+    # Arrange
+    import matplotlib.pyplot as _plt
+
+    from figrecipe._captions._caption import ScientificCaption
+
+    mgr = ScientificCaption()
+    fig, _ax = _plt.subplots()
+    n_before = len(fig.texts)
+
+    # Act
+    mgr.add_figure_caption(fig, "Test caption — should not draw.", render=False)
+
+    # Assert
+    assert len(fig.texts) == n_before, (
+        f"render=False must not add any fig.text; "
+        f"texts grew from {n_before} to {len(fig.texts)}"
+    )
+    _plt.close(fig)
+
+
+def test_caption_manager_renders_by_default():
+    """``caption_manager.add_figure_caption`` (default render=True) DOES draw."""
+    # Arrange
+    import matplotlib.pyplot as _plt
+
+    from figrecipe._captions._caption import ScientificCaption
+
+    mgr = ScientificCaption()
+    fig, _ax = _plt.subplots()
+    n_before = len(fig.texts)
+
+    # Act
+    mgr.add_figure_caption(fig, "Test caption — should draw exactly one.")
+
+    # Assert
+    assert len(fig.texts) == n_before + 1, (
+        f"default render=True must add exactly one fig.text; "
+        f"texts grew from {n_before} to {len(fig.texts)}"
+    )
+    _plt.close(fig)


### PR DESCRIPTION
## Summary

Fixes three layered caption bugs in the `fr.subplots(caption=...)` / `fr.compose(caption=...)` API introduced by PR #162. With this patch the caption is rendered exactly once, with markdown stripped, and the bottom-row panels are nudged up via `set_position` when `subplots_adjust` fails to take effect.

## What was broken

1. **DOUBLE-RENDER** — `_captions/_public.py::add_figure_caption` drew the caption twice: once directly via `mpl_fig.text(...)` and once via `caption_manager.add_figure_caption(...)`. Two `fig.texts` entries stacked at the same y-anchor and overlapped each other.
2. **PANEL OVERLAP** — `mpl_fig.subplots_adjust(bottom=0.15)` failed to move the bottom-row panels on figrecipe's mm-laid figures (the paper-figure default). The caption text at y=0.02 landed on top of panels whose `y0` was still ≈0.05.
3. **MARKDOWN LEAKAGE** — `caption_manager` rendered `**Figure N.**` with raw markers because matplotlib does not interpret Markdown. Users saw four asterisks instead of a bold label.

## What this PR changes

### `src/figrecipe/_captions/_public.py::add_figure_caption`

Now the **sole rendering path**.

- Reserves room via `subplots_adjust`.
- Detects via `canvas.draw()` whether the axes actually moved; if not (constrained_layout / mm-layout / explicit `set_position` already in effect), nudges each `ax.set_position(...)` up by the required delta. This is what made the fix robust across both code paths.
- Renders the caption text via `mpl_fig.text(...)` with markdown stripped — once.
- Calls `caption_manager.add_figure_caption(..., render=False)` so the manager continues to handle numbering / registry / optional file save, but does NOT draw a second copy.

### `src/figrecipe/_captions/_caption.py::ScientificCaption.add_figure_caption`

Grows a new keyword: `render: bool = True`.

- `render=True` (default) preserves the old behaviour for any direct caller of `caption_manager.add_figure_caption(...)`.
- The public API now passes `render=False`.

### `src/figrecipe/_captions/_caption.py::_add_caption_to_figure`

Strips `**` / `*` markdown before handing the text to `fig.text(...)`. Direct callers of `caption_manager` also get clean rendering — matplotlib renders text literally.

## Regression test

`tests/figrecipe/_captions/test__public_overlap.py` — 9 tests, AAA-structured per STX-TQ002, one assertion each per STX-TQ007:

- `test_caption_renders_exactly_one_figure_text` — asserts `len(fig.texts) == 1`.
- `test_caption_bbox_does_not_overlap_{top_left,top_right,bottom_left,bottom_right}_panel` — asserts the caption text bbox does not intersect any of the four panels.
- `test_rendered_caption_strips_{double,single}_asterisks` — asserts no leaked markdown.
- `test_caption_manager_does_not_render_when_render_false` — asserts `render=False` adds no `fig.text`.
- `test_caption_manager_renders_by_default` — asserts `render=True` adds exactly one `fig.text`.

## Verification

| Suite | Result |
| --- | --- |
| New regression suite (9 tests) | 9 PASS |
| Existing `tests/figrecipe/_captions/` (56 tests) | 56 PASS |
| Focused `_captions + _composition + _api` suite (214 tests) | 214 PASS |
| Reproducer (`/tmp/figrecipe_caption_overlap_repro.py`, 3 cases) | All 3 → `fig.texts count: 1` + `NO OVERLAP DETECTED` |

Before this PR, the same reproducer reported `fig.texts count: 2` and 4 `OVERLAP` findings per case (caption overlapping both bottom-row panels + a TEXT-vs-TEXT overlap between the two captions).

## Test plan

- [ ] CI green on the fix branch.
- [ ] Eyeball the 3 reproducer PNGs (`/tmp/figrecipe_caption_repro_out/case[123]_*.png`) — caption sits cleanly below all panels with no overlap.
- [ ] Manual smoke: `fr.subplots(caption=..., figsize=(7,5))` and `fr.subplots(caption=...)` (mm-default) on a 2×2 with long captions; confirm one `fig.text` and no panel overlap.

## Context

Surfaced by proj-neurovista preparing to use `fr.compose(caption=...)` for the paper figures under `scripts/for_paper/build_fig_0N_*.py`. The operator asked to verify whether captions still overlap on the new API. They did; this PR fixes that.

## Note on `--no-verify`

The commit was created with `--no-verify` after an explicit operator go-ahead. The `pytest-testmon` pre-commit hook fails during test collection on `tests/figrecipe/_quality/test__axis_alignment_checker.py` (`ModuleNotFoundError: No module named 'figrecipe._quality'`) inside testmon's environment, although `from figrecipe._quality._axis_alignment_checker import AxisAlignmentChecker` succeeds when invoked directly and `pytest tests/figrecipe/_quality/test__axis_alignment_checker.py` passes 7/7 on `develop`. The blockage is a pre-commit infrastructure question on `develop`; happy to follow up in a separate PR that either fixes testmon's import path or adds the file to the existing `--ignore` list (precedent: 4 existing ignores).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
