### PR TITLE
fix(linter): defer scitex_dev import + spine-list-arg + FM010/FM011 rules (per neurovista 2026-06-14)

### DIFF
--- a/src/figrecipe/_quality/_linter_checkers.py
+++ b/src/figrecipe/_quality/_linter_checkers.py
@@ -1,0 +1,181 @@
+"""AST NodeVisitor factories for the figrecipe linter plugin.
+
+Extracted from ``_linter_plugin.py`` to keep that orchestrator module
+under the project line-cap and to make the checker logic independently
+testable.
+
+Two factories live here:
+
+- ``_make_style_kwarg_checker(P006, P007, P008, P009)`` — flags
+  style-override kwargs (``s=`` on scatter, ``fontsize=``, ``figsize=``,
+  ``linewidth=``/``lw=``).
+- ``_make_figure_method_checker(FM010, FM011)`` — flags
+  ``set_xlabel`` / ``set_ylabel`` / ``set_title`` (recommend ``set_xyt``)
+  and ``ax.spines[...].set_visible(False)`` (recommend ``hide_spines``).
+
+Circular-import discipline (per neurovista 2026-06-14): both factories
+defer the ``scitex_dev.linter.checker`` import into ``_emit()`` rather
+than at factory-build time. figrecipe's plugin factories are called by
+``load_plugins()`` *during* the scitex_dev.linter module's own import;
+importing ``scitex_dev.linter.checker`` here at build time raises
+ImportError, the old factory swallowed it with ``return None``, and the
+checker was silently dropped from the registered checkers list.
+"""
+
+from __future__ import annotations
+
+import ast
+
+
+def _make_style_kwarg_checker(P006, P007, P008, P009):
+    """Build an AST NodeVisitor class that flags style-override kwargs.
+
+    - ``scatter(..., s=...)`` → P006
+    - any call with ``fontsize=...`` → P007
+    - any call with ``figsize=...``  → P008
+    - any call with ``linewidth=`` / ``lw=`` → P009
+
+    Returned class follows the scitex-linter checker contract:
+    ``__init__(source_lines, config)`` + ``.issues`` list + ``.category``.
+    """
+
+    class StyleKwargChecker(ast.NodeVisitor):
+        category = "plot"
+
+        def __init__(self, source_lines, config):
+            self.source_lines = source_lines
+            self.config = config
+            self.issues: list = []
+
+        def _src(self, ln):
+            if 1 <= ln <= len(self.source_lines):
+                return self.source_lines[ln - 1].rstrip()
+            return ""
+
+        def _emit(self, rule, node):
+            from dataclasses import replace as _replace
+
+            # Deferred import — avoids the circular-import that previously
+            # caused the factory to silently return None.
+            from scitex_dev.linter.checker import Issue, _is_allowed_by_comment
+
+            line = self._src(node.lineno)
+            if rule.id in self.config.disable:
+                return
+            if _is_allowed_by_comment(line, rule.id):
+                return
+            sev = self.config.per_rule_severity.get(rule.id)
+            if sev:
+                rule = _replace(rule, severity=sev)
+            self.issues.append(
+                Issue(
+                    rule=rule,
+                    line=node.lineno,
+                    col=node.col_offset,
+                    source_line=line,
+                )
+            )
+
+        def visit_Call(self, node):
+            func = node.func
+            if isinstance(func, ast.Attribute):
+                fname = func.attr
+            elif isinstance(func, ast.Name):
+                fname = func.id
+            else:
+                fname = ""
+            kwargs = {kw.arg for kw in node.keywords if kw.arg}
+            if fname in ("scatter", "stx_scatter") and "s" in kwargs:
+                self._emit(P006, node)
+            if "fontsize" in kwargs:
+                self._emit(P007, node)
+            if "figsize" in kwargs:
+                self._emit(P008, node)
+            if "linewidth" in kwargs or "lw" in kwargs:
+                self._emit(P009, node)
+            self.generic_visit(node)
+
+    return StyleKwargChecker
+
+
+def _make_figure_method_checker(FM010, FM011):
+    """Build an AST NodeVisitor class for figure-method style rules.
+
+    - ``ax.set_xlabel(...)`` / ``ax.set_ylabel(...)`` / ``ax.set_title(...)``
+        → STX-FM010 (recommend ``ax.set_xyt(x, y, t)`` instead).
+    - ``ax.spines[...].set_visible(False)``
+        → STX-FM011 (recommend ``ax.hide_spines(top=True, right=True, ...)``).
+
+    Same deferred-import discipline as ``_make_style_kwarg_checker``.
+    """
+
+    class FigureMethodChecker(ast.NodeVisitor):
+        category = "figure"
+
+        def __init__(self, source_lines, config):
+            self.source_lines = source_lines
+            self.config = config
+            self.issues: list = []
+
+        def _src(self, ln):
+            if 1 <= ln <= len(self.source_lines):
+                return self.source_lines[ln - 1].rstrip()
+            return ""
+
+        def _emit(self, rule, node):
+            from dataclasses import replace as _replace
+
+            # Deferred import — see _make_style_kwarg_checker.
+            from scitex_dev.linter.checker import Issue, _is_allowed_by_comment
+
+            line = self._src(node.lineno)
+            if rule.id in self.config.disable:
+                return
+            if _is_allowed_by_comment(line, rule.id):
+                return
+            sev = self.config.per_rule_severity.get(rule.id)
+            if sev:
+                rule = _replace(rule, severity=sev)
+            self.issues.append(
+                Issue(
+                    rule=rule,
+                    line=node.lineno,
+                    col=node.col_offset,
+                    source_line=line,
+                )
+            )
+
+        def visit_Call(self, node):
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                self.generic_visit(node)
+                return
+
+            fname = func.attr
+            receiver = func.value
+
+            # STX-FM010: set_xlabel / set_ylabel / set_title.
+            if fname in ("set_xlabel", "set_ylabel", "set_title"):
+                self._emit(FM010, node)
+
+            # STX-FM011: ax.spines[...].set_visible(False).
+            # Match shape: Call(func=Attribute(attr='set_visible',
+            #     value=Subscript(value=Attribute(attr='spines'))))
+            if fname == "set_visible" and isinstance(receiver, ast.Subscript):
+                sub_val = receiver.value
+                if isinstance(sub_val, ast.Attribute) and sub_val.attr == "spines":
+                    # Only fire when the argument is literally False (the
+                    # antipattern). set_visible(True) is restoration and is
+                    # legitimate.
+                    first_arg = node.args[0] if node.args else None
+                    if isinstance(first_arg, ast.Constant) and first_arg.value is False:
+                        self._emit(FM011, node)
+
+            self.generic_visit(node)
+
+    return FigureMethodChecker
+
+
+__all__ = ["_make_style_kwarg_checker", "_make_figure_method_checker"]
+
+# EOF

--- a/src/figrecipe/_quality/_linter_plugin.py
+++ b/src/figrecipe/_quality/_linter_plugin.py
@@ -2,83 +2,23 @@
 
 Rule families:
 - FM001-FM009  — inch-based matplotlib patterns; suggest mm-based alternatives.
+- FM010-FM011  — figure-method style rules (set_xlabel/set_ylabel/set_title
+                 → set_xyt; ax.spines[...].set_visible(False) → hide_spines).
 - FIG001       — scientific-figure hygiene (axis-range alignment across subplots).
 - P001-P009    — bare matplotlib calls; suggest scitex/figrecipe tracked variants
                  and flag style-override kwargs.
 
 Registered via entry point 'scitex_dev.linter.plugins' so scitex-linter
 discovers these rules automatically when figrecipe is installed.
+
+The AST NodeVisitor factories live in ``_linter_checkers.py`` so this
+file stays focused on the rule-object definitions + plugin wiring.
 """
 
-
-def _make_style_kwarg_checker(P006, P007, P008, P009):
-    """Build an AST NodeVisitor class that flags style-override kwargs:
-
-    - ``scatter(..., s=...)``  → P006
-    - any call with ``fontsize=...``  → P007
-    - any call with ``figsize=...``   → P008
-    - any call with ``linewidth=`` / ``lw=``  → P009
-
-    Returned class follows the scitex-linter checker contract:
-    ``__init__(source_lines, config)`` + ``.issues`` list + ``.category``.
-    """
-    import ast
-
-    try:
-        from scitex_dev.linter.checker import Issue, _is_allowed_by_comment
-    except ImportError:
-        return None
-
-    class StyleKwargChecker(ast.NodeVisitor):
-        category = "plot"
-
-        def __init__(self, source_lines, config):
-            self.source_lines = source_lines
-            self.config = config
-            self.issues: list = []
-
-        def _src(self, ln):
-            if 1 <= ln <= len(self.source_lines):
-                return self.source_lines[ln - 1].rstrip()
-            return ""
-
-        def _emit(self, rule, node):
-            from dataclasses import replace as _replace
-
-            line = self._src(node.lineno)
-            if rule.id in self.config.disable:
-                return
-            if _is_allowed_by_comment(line, rule.id):
-                return
-            sev = self.config.per_rule_severity.get(rule.id)
-            if sev:
-                rule = _replace(rule, severity=sev)
-            self.issues.append(
-                Issue(
-                    rule=rule, line=node.lineno, col=node.col_offset, source_line=line
-                )
-            )
-
-        def visit_Call(self, node):
-            func = node.func
-            if isinstance(func, ast.Attribute):
-                fname = func.attr
-            elif isinstance(func, ast.Name):
-                fname = func.id
-            else:
-                fname = ""
-            kwargs = {kw.arg for kw in node.keywords if kw.arg}
-            if fname in ("scatter", "stx_scatter") and "s" in kwargs:
-                self._emit(P006, node)
-            if "fontsize" in kwargs:
-                self._emit(P007, node)
-            if "figsize" in kwargs:
-                self._emit(P008, node)
-            if "linewidth" in kwargs or "lw" in kwargs:
-                self._emit(P009, node)
-            self.generic_visit(node)
-
-    return StyleKwargChecker
+from ._linter_checkers import (  # noqa: F401
+    _make_figure_method_checker,
+    _make_style_kwarg_checker,
+)
 
 
 def get_plugin():
@@ -188,6 +128,47 @@ def get_plugin():
             "or `stx.plt.subplots(margin_left_mm=15, margin_bottom_mm=12)` for deterministic layout."
         ),
         requires="figrecipe",
+    )
+
+    # FM010 — figrecipe axes wrapper provides `set_xyt(x, y, t)` which
+    # sets xlabel/ylabel/title in one call and records the metadata in
+    # the recipe (used by `figrecipe.save()` provenance). Separate
+    # set_xlabel/set_ylabel/set_title calls do not flow through the
+    # recipe wrapper. Per neurovista 2026-06-14 — gated `requires="scitex"`.
+    FM010 = Rule(
+        id="STX-FM010",
+        severity="warning",
+        category="figure",
+        message=(
+            "`set_xlabel`/`set_ylabel`/`set_title` detected — figrecipe's "
+            "`ax.set_xyt(x, y, t)` records the labels in the recipe in one call"
+        ),
+        suggestion=(
+            "Replace `ax.set_xlabel('X'); ax.set_ylabel('Y'); ax.set_title('T')` "
+            "with `ax.set_xyt('X', 'Y', 'T')` so the labels are tracked by the "
+            "recipe and stay consistent with figrecipe's panel-metadata model."
+        ),
+        requires="scitex",
+    )
+
+    # FM011 — direct `ax.spines[...].set_visible(False)` defeats the
+    # figrecipe spine helper which also handles tick/label cleanup and
+    # respects the global style. Per neurovista 2026-06-14.
+    FM011 = Rule(
+        id="STX-FM011",
+        severity="warning",
+        category="figure",
+        message=(
+            "`ax.spines[...].set_visible(False)` detected — figrecipe's "
+            "`ax.hide_spines(top=True, right=True, ...)` is the canonical helper"
+        ),
+        suggestion=(
+            "Replace `ax.spines['top'].set_visible(False); "
+            "ax.spines['right'].set_visible(False)` with "
+            "`ax.hide_spines(top=True, right=True)` — the wrapper also handles "
+            "tick/label cleanup and stays consistent with the SciTeX style."
+        ),
+        requires="scitex",
     )
 
     # ------------------------------------------------------------------
@@ -334,6 +315,11 @@ def get_plugin():
     if style_checker is not None:
         checkers.append(style_checker)
 
+    # FM010/FM011 AST checker. Deferred-import safe (see factory docstring).
+    figure_method_checker = _make_figure_method_checker(FM010, FM011)
+    if figure_method_checker is not None:
+        checkers.append(figure_method_checker)
+
     # FIG001 axis-range-alignment checker. We subclass the base checker
     # here so it ships the FIG001 rule object without the plugin loader
     # needing to know about it.
@@ -359,6 +345,8 @@ def get_plugin():
             FM007,
             FM008,
             FM009,
+            FM010,
+            FM011,
             FIG001,
             P001,
             P002,

--- a/src/figrecipe/_wrappers/_axes_style_mixin.py
+++ b/src/figrecipe/_wrappers/_axes_style_mixin.py
@@ -34,10 +34,28 @@ class AxesStyleMixin:
         --------
         >>> ax.hide_spines()  # Hide top and right
         >>> ax.hide_spines(['top', 'right', 'bottom'])
+
+        Notes
+        -----
+        The underlying helper ``figrecipe.styles._axis_helpers.hide_spines``
+        takes per-side booleans (``top=``, ``bottom=``, ``left=``,
+        ``right=``). This mixin previously forwarded the list as the
+        first positional argument, which matplotlib silently coerced to
+        truthy → ``top=True`` and left bottom/left at their defaults, so
+        ``ax.hide_spines(['top','right','left','bottom'])`` only hid top
+        + right regardless of the list contents. Per neurovista
+        2026-06-14: unpack the list into per-side booleans before calling
+        the helper.
         """
         from ..styles._axis_helpers import hide_spines
 
-        return hide_spines(self._ax, spines)
+        if spines is None:
+            return hide_spines(self._ax)
+        # Default ``hide_spines`` has top=True/right=True; passing a list
+        # means "hide exactly these sides" so we explicitly disable any
+        # side not in the list as well.
+        flags = {side: (side in spines) for side in ("top", "bottom", "left", "right")}
+        return hide_spines(self._ax, **flags)
 
     def show_spines(self, spines: Optional[List[str]] = None):
         """Show specified spines.
@@ -50,10 +68,17 @@ class AxesStyleMixin:
         Examples
         --------
         >>> ax.show_spines(['left', 'bottom'])
+
+        Notes
+        -----
+        See ``hide_spines`` — same list-vs-kwarg bug, same fix.
         """
         from ..styles._axis_helpers import show_spines
 
-        return show_spines(self._ax, spines)
+        if spines is None:
+            return show_spines(self._ax)
+        flags = {side: (side in spines) for side in ("top", "bottom", "left", "right")}
+        return show_spines(self._ax, **flags)
 
     def toggle_spines(self, spines: Optional[List[str]] = None):
         """Toggle spine visibility.
@@ -61,15 +86,36 @@ class AxesStyleMixin:
         Parameters
         ----------
         spines : list, optional
-            Spines to toggle
+            Spines to toggle. Sides not listed are left untouched.
 
         Examples
         --------
         >>> ax.toggle_spines(['top'])
+
+        Notes
+        -----
+        See ``hide_spines`` — same list-vs-kwarg bug, same fix. Note that
+        the underlying ``toggle_spines`` helper treats ``None`` as
+        "toggle this side" and an explicit ``True``/``False`` as "set to
+        this value". So for sides NOT in the list we pass ``None`` ... no,
+        that would toggle them too. We instead read their current
+        visibility from the axis and pass that back, which is the correct
+        "leave this side alone" semantics.
         """
         from ..styles._axis_helpers import toggle_spines
 
-        return toggle_spines(self._ax, spines)
+        if spines is None:
+            return toggle_spines(self._ax)
+        # For each side: if it's in the requested list, pass None to let
+        # the helper toggle it; otherwise pass its current visibility back
+        # so it remains unchanged.
+        flags = {}
+        for side in ("top", "bottom", "left", "right"):
+            if side in spines:
+                flags[side] = None  # None = toggle
+            else:
+                flags[side] = self._ax.spines[side].get_visible()
+        return toggle_spines(self._ax, **flags)
 
     def rotate_labels(
         self,

--- a/tests/figrecipe/_quality/test__figure_method_checker.py
+++ b/tests/figrecipe/_quality/test__figure_method_checker.py
@@ -1,0 +1,160 @@
+"""Tests for STX-FM010 / STX-FM011 figure-method AST rules.
+
+Real ast.parse + FigureMethodChecker — no mocks. Each test follows
+Arrange / Act / Assert with one assertion. Test names are >=3 words
+and describe behaviour.
+
+The checker imports scitex_dev.linter.checker symbols lazily inside
+``_emit()``, so the test module gracefully importorskips when
+scitex_dev isn't installable in this environment.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+pytest.importorskip("scitex_dev.linter.checker")
+pytest.importorskip("scitex_dev.linter.config")
+
+from figrecipe._quality._linter_plugin import get_plugin  # noqa: E402
+
+_PLUGIN = get_plugin()
+_FM010 = next(r for r in _PLUGIN["rules"] if r.id == "STX-FM010")
+_FM011 = next(r for r in _PLUGIN["rules"] if r.id == "STX-FM011")
+
+
+def _make_config():
+    from scitex_dev.linter.config import load_config
+
+    return load_config(start_path=__file__)
+
+
+def _run(src: str):
+    """Parse *src* and run the FigureMethodChecker; return issues."""
+    from figrecipe._quality._linter_checkers import _make_figure_method_checker
+
+    tree = ast.parse(src)
+    source_lines = src.splitlines()
+    cls = _make_figure_method_checker(_FM010, _FM011)
+    checker = cls(source_lines, _make_config())
+    checker.visit(tree)
+    return checker.issues
+
+
+# ---------------------------------------------------------------------------
+# STX-FM010 — set_xlabel / set_ylabel / set_title
+# ---------------------------------------------------------------------------
+
+
+def test_fm010_warns_on_set_xlabel_call():
+    # Arrange
+    src = "def f(ax):\n    ax.set_xlabel('time')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert any(i.rule.id == "STX-FM010" for i in issues)
+
+
+def test_fm010_warns_on_set_ylabel_call():
+    # Arrange
+    src = "def f(ax):\n    ax.set_ylabel('amplitude')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert any(i.rule.id == "STX-FM010" for i in issues)
+
+
+def test_fm010_warns_on_set_title_call():
+    # Arrange
+    src = "def f(ax):\n    ax.set_title('panel A')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert any(i.rule.id == "STX-FM010" for i in issues)
+
+
+def test_fm010_does_not_fire_on_set_xyt_call():
+    # Arrange — set_xyt is the recommended API; must not be flagged.
+    src = "def f(ax):\n    ax.set_xyt('x', 'y', 't')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not any(i.rule.id == "STX-FM010" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# STX-FM011 — ax.spines[...].set_visible(False)
+# ---------------------------------------------------------------------------
+
+
+def test_fm011_warns_on_spines_set_visible_false():
+    # Arrange
+    src = "def f(ax):\n    ax.spines['top'].set_visible(False)\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert any(i.rule.id == "STX-FM011" for i in issues)
+
+
+def test_fm011_does_not_fire_on_spines_set_visible_true():
+    # Arrange — set_visible(True) is restoration; not the antipattern.
+    src = "def f(ax):\n    ax.spines['top'].set_visible(True)\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not any(i.rule.id == "STX-FM011" for i in issues)
+
+
+def test_fm011_does_not_fire_on_hide_spines_call():
+    # Arrange — recommended API.
+    src = "def f(ax):\n    ax.hide_spines(top=True, right=True)\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not any(i.rule.id == "STX-FM011" for i in issues)
+
+
+def test_fm011_does_not_fire_on_unrelated_set_visible():
+    # Arrange — set_visible(False) on something that isn't ax.spines[...].
+    src = "def f(ax):\n    ax.xaxis.set_visible(False)\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not any(i.rule.id == "STX-FM011" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# Allow-comment honoured
+# ---------------------------------------------------------------------------
+
+
+def test_fm010_respects_stx_allow_comment():
+    # Arrange
+    src = "def f(ax):\n    ax.set_xlabel('time')  # stx-allow: STX-FM010\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not any(i.rule.id == "STX-FM010" for i in issues)
+
+
+# EOF

--- a/tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py
+++ b/tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py
@@ -1,0 +1,135 @@
+"""Tests for AxesStyleMixin spine list-arg fix.
+
+Per neurovista 2026-06-14: ``hide_spines`` / ``show_spines`` /
+``toggle_spines`` on the mixin previously forwarded the list as the
+first positional argument to the low-level helper (which expects
+per-side booleans), so ``ax.hide_spines(['top','right','left','bottom'])``
+only hid top + right regardless of the list contents.
+
+These tests construct a plain matplotlib axes, drive the mixin against
+it, and assert spine visibility on every side.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+from figrecipe._wrappers._axes_style_mixin import AxesStyleMixin  # noqa: E402
+
+
+class _StubAxesWrapper(AxesStyleMixin):
+    """Minimal wrapper that exposes a real matplotlib axis as ``self._ax``.
+
+    The mixin only touches ``self._ax`` for spine ops, so we don't need
+    the full RecordingAxes machinery here.
+    """
+
+    def __init__(self, ax):
+        self._ax = ax
+
+
+def _make_ax():
+    fig, ax = plt.subplots()
+    return _StubAxesWrapper(ax), ax, fig
+
+
+# ---------------------------------------------------------------------------
+# hide_spines
+# ---------------------------------------------------------------------------
+
+
+def test_hide_spines_with_full_list_hides_all_four_sides():
+    # Arrange
+    wrapper, ax, fig = _make_ax()
+
+    # Act
+    wrapper.hide_spines(["top", "right", "left", "bottom"])
+
+    # Assert
+    hidden = {
+        s: not ax.spines[s].get_visible() for s in ("top", "bottom", "left", "right")
+    }
+    plt.close(fig)
+    assert hidden == {"top": True, "bottom": True, "left": True, "right": True}
+
+
+def test_hide_spines_default_hides_top_and_right_only():
+    # Arrange
+    wrapper, ax, fig = _make_ax()
+
+    # Act
+    wrapper.hide_spines()
+
+    # Assert
+    visible = {
+        s: ax.spines[s].get_visible() for s in ("top", "bottom", "left", "right")
+    }
+    plt.close(fig)
+    assert visible == {"top": False, "bottom": True, "left": True, "right": False}
+
+
+def test_hide_spines_list_hides_exactly_requested_sides():
+    # Arrange
+    wrapper, ax, fig = _make_ax()
+
+    # Act — request only left and bottom.
+    wrapper.hide_spines(["left", "bottom"])
+
+    # Assert — only left + bottom hidden; top + right stay visible (per the
+    # "exactly these" semantics; top/right defaults are overridden when a
+    # list is given).
+    visible = {
+        s: ax.spines[s].get_visible() for s in ("top", "bottom", "left", "right")
+    }
+    plt.close(fig)
+    assert visible == {"top": True, "bottom": False, "left": False, "right": True}
+
+
+# ---------------------------------------------------------------------------
+# show_spines
+# ---------------------------------------------------------------------------
+
+
+def test_show_spines_with_classic_pair_shows_only_left_and_bottom():
+    # Arrange — start with all four spines hidden so we can see only the
+    # ones we ask show_spines to display.
+    wrapper, ax, fig = _make_ax()
+    for s in ("top", "bottom", "left", "right"):
+        ax.spines[s].set_visible(False)
+
+    # Act
+    wrapper.show_spines(["left", "bottom"])
+
+    # Assert
+    visible = {
+        s: ax.spines[s].get_visible() for s in ("top", "bottom", "left", "right")
+    }
+    plt.close(fig)
+    assert visible == {"top": False, "bottom": True, "left": True, "right": False}
+
+
+# ---------------------------------------------------------------------------
+# toggle_spines
+# ---------------------------------------------------------------------------
+
+
+def test_toggle_spines_toggles_only_listed_sides():
+    # Arrange — all four start visible (matplotlib default).
+    wrapper, ax, fig = _make_ax()
+
+    # Act — toggle top + bottom only.
+    wrapper.toggle_spines(["top", "bottom"])
+
+    # Assert — top + bottom flipped to hidden; left + right unchanged.
+    visible = {
+        s: ax.spines[s].get_visible() for s in ("top", "bottom", "left", "right")
+    }
+    plt.close(fig)
+    assert visible == {"top": False, "bottom": False, "left": True, "right": True}
+
+
+# EOF


### PR DESCRIPTION
## Summary

Three sibling fixes uncovered by neurovista's Fig 1 dogfooding pass (full meta-finding: lead's `~/proj/lead/GITIGNORED/neurovista-linter-rules-elevation.md`).

1. **Circular-import in plugin factories.** `_linter_plugin.py` imported `scitex_dev.linter.checker` symbols at build time, but figrecipe's factories run *during* scitex_dev's `load_plugins()` → ImportError → factory returned `None` → `StyleKwargChecker` (P006-P009) was silently dropped. Figure-style rules effectively never ran. Fixed by deferring the import into `_emit()`. Checker factories extracted to a new `_linter_checkers.py` to keep `_linter_plugin.py` under the project line cap.

2. **`hide_spines` / `show_spines` / `toggle_spines` list-arg bug.** The mixin forwarded a LIST as the first positional to the low-level helpers, which expect per-side booleans. `ax.hide_spines(['top','right','left','bottom'])` only hid top + right regardless of the list. All three fixed by unpacking the list into per-side kwargs. neurovista left `toggle_spines` for the maintainer; lead asked for it included.

3. **STX-FM010 + STX-FM011 figure-style rules authored.**
   - **FM010**: prohibit `set_xlabel` / `set_ylabel` / `set_title` → recommend `set_xyt(x, y, t)` so labels flow through the recipe metadata.
   - **FM011**: prohibit `ax.spines[...].set_visible(False)` → recommend `ax.hide_spines(top=True, right=True, ...)`.
   Both gated `requires="scitex"`, severity=warning, category=figure. Both fire via the new `FigureMethodChecker` AST visitor (same deferred-import discipline).

## Test plan

- [x] `pytest tests/figrecipe/_quality/test__figure_method_checker.py tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py tests/figrecipe/_quality/test__axis_alignment_checker.py` — **21 / 21 passing locally** (no mocks, real ast.parse + real matplotlib axes).
- [x] `python -c "import figrecipe; figrecipe._quality._linter_plugin.get_plugin()"` succeeds; all 4 checkers (FMChecker, StyleKwargChecker, FigureMethodChecker, _AxisAlignmentChecker) register; rule count = 21 (incl. STX-FM010, STX-FM011).
- [ ] CI green on `develop`.

## Files

- `src/figrecipe/_quality/_linter_plugin.py` — header + rule defs + checker wiring; factories extracted.
- `src/figrecipe/_quality/_linter_checkers.py` (new) — `_make_style_kwarg_checker` + `_make_figure_method_checker`, both deferred-import safe.
- `src/figrecipe/_wrappers/_axes_style_mixin.py` — list→kwargs unpacking for hide/show/toggle.
- `tests/figrecipe/_quality/test__figure_method_checker.py` (new) — FM010/FM011 positive/negative + opt-out coverage.
- `tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py` (new) — real-matplotlib coverage of the spine fix.