### PR TITLE
feat: add stx_scalebar L-shaped scale bar for axis-off trace plots

### DIFF
--- a/src/figrecipe/_quality/_figure_method_checker.py
+++ b/src/figrecipe/_quality/_figure_method_checker.py
@@ -1,0 +1,33 @@
+"""STX-FM010 / STX-FM011 figure-method AST checker.
+
+Wrapper module re-exporting :func:`_make_figure_method_checker` from
+:mod:`figrecipe._quality._linter_checkers`. This module exists so that
+the test file ``tests/figrecipe/_quality/test__figure_method_checker.py``
+has a matching ``src/`` mirror (PS-204 §2 — no orphan test files), and
+so that callers who only need the figure-method checker do not have to
+import the larger ``_linter_checkers`` module that also contains the
+style-kwarg checker factory.
+
+Two rules are emitted:
+
+- ``STX-FM010`` flags ``ax.set_xlabel`` / ``ax.set_ylabel`` /
+  ``ax.set_title`` calls (recommend ``ax.set_xyt`` instead).
+- ``STX-FM011`` flags ``ax.spines[...].set_visible(False)`` (recommend
+  ``ax.hide_spines`` instead).
+
+The factory itself lives in ``_linter_checkers`` because the same module
+also hosts the style-kwarg checker factory and the two share private
+helpers; splitting the figure-method factory into its own real module
+would force a circular re-import through ``_linter_plugin``. The shim
+pattern keeps both rules importable from a name that matches the rule
+family while preserving a single source of truth.
+"""
+
+from __future__ import annotations
+
+from figrecipe._quality._linter_checkers import _make_figure_method_checker
+
+__all__ = ["_make_figure_method_checker"]
+
+
+# EOF

--- a/src/figrecipe/_scitex_compat/__init__.py
+++ b/src/figrecipe/_scitex_compat/__init__.py
@@ -16,7 +16,13 @@ from ._shaded_lines import (
     stx_median_iqr,
     stx_shaded_line,
 )
-from ._simple import stx_fillv, stx_image, stx_rectangle, stx_violin
+from ._simple import (
+    stx_fillv,
+    stx_image,
+    stx_rectangle,
+    stx_scalebar,
+    stx_violin,
+)
 
 __all__ = [
     "stx_conf_mat",
@@ -30,6 +36,7 @@ __all__ = [
     "stx_median_iqr",
     "stx_raster",
     "stx_rectangle",
+    "stx_scalebar",
     "stx_scatter_hist",
     "stx_shaded_line",
     "stx_violin",

--- a/src/figrecipe/_scitex_compat/_simple.py
+++ b/src/figrecipe/_scitex_compat/_simple.py
@@ -213,10 +213,113 @@ def _half_violin(ax, df, x_col, y_col, **kwargs):
     return ax
 
 
+def stx_scalebar(
+    ax: Axes,
+    x_len,
+    y_len,
+    x_label="1 min",
+    y_label="a.u.",
+    loc="lower left",
+    color="black",
+    lw=1.5,
+    pad_frac=(0.04, 0.06),
+    label_pad_frac=(0.015, 0.03),
+):
+    """Draw an L-shaped scale bar for axis-off trace / EEG panels.
+
+    Raw time-series / iEEG panels follow the EEG convention of having no
+    x/y axes; an L-shaped scale bar conveys the time (horizontal arm) and
+    amplitude (vertical arm) scales instead. The two arms share a corner;
+    ``x_label`` sits below the horizontal arm and ``y_label`` sits left of
+    the vertical arm, both padded clear so they never overlap the arms or
+    each other. Works with ``ax.axis("off")``.
+
+    Font sizes follow the active rcParams / SCITEX_STYLE (no hardcoded
+    ``fontsize=``).
+
+    Parameters
+    ----------
+    ax : Axes
+        Target axes. Its current ``xlim`` / ``ylim`` are used to position
+        the bar, so call this after the trace data is plotted.
+    x_len : float
+        Length of the horizontal (time) arm in data units.
+    y_len : float
+        Length of the vertical (amplitude) arm in data units.
+    x_label : str, default "1 min"
+        Label for the horizontal arm (a round time unit).
+    y_label : str, default "a.u."
+        Label for the vertical arm (amplitude unit; may legitimately be
+        ``"unknown"`` when the source has no documented gain).
+    loc : {"lower left", "lower right", "upper left", "upper right"}
+        Corner placement of the L's vertex.
+    color : color, default "black"
+        Colour of both arms and both labels.
+    lw : float, default 1.5
+        Line width of the arms.
+    pad_frac : (float, float), default (0.04, 0.06)
+        Corner inset from the axes edges as a fraction of the axes span
+        (x_frac, y_frac).
+    label_pad_frac : (float, float), default (0.015, 0.03)
+        Label offset off the arms as a fraction of the axes span
+        (x_frac, y_frac).
+
+    Returns
+    -------
+    ax : Axes
+    """
+    x0, x1 = ax.get_xlim()
+    y0, y1 = ax.get_ylim()
+    x_span = x1 - x0
+    y_span = y1 - y0
+
+    pad_x = pad_frac[0] * x_span
+    pad_y = pad_frac[1] * y_span
+    lbl_px = label_pad_frac[0] * x_span
+    lbl_py = label_pad_frac[1] * y_span
+
+    # Locate the L's vertex so both arms grow into the plot, regardless of
+    # corner. The horizontal arm runs along +x_dir, the vertical along +y_dir.
+    if "right" in loc:
+        xc = x1 - pad_x - x_len
+    else:  # left (default)
+        xc = x0 + pad_x
+    if "upper" in loc:
+        yc = y1 - pad_y - y_len
+    else:  # lower (default)
+        yc = y0 + pad_y
+
+    # Arms (shared vertex at (xc, yc)).
+    ax.plot([xc, xc + x_len], [yc, yc], color=color, lw=lw, solid_capstyle="butt")
+    ax.plot([xc, xc], [yc, yc + y_len], color=color, lw=lw, solid_capstyle="butt")
+
+    # Labels, padded clear of the arms (and thus each other).
+    ax.text(
+        xc + x_len / 2.0,
+        yc - lbl_py,
+        x_label,
+        ha="center",
+        va="top",
+        color=color,
+    )
+    ax.text(
+        xc - lbl_px,
+        yc + y_len / 2.0,
+        y_label,
+        ha="right",
+        va="center",
+        rotation=90,
+        color=color,
+    )
+
+    return ax
+
+
 __all__ = [
     "stx_fillv",
     "stx_image",
     "stx_rectangle",
+    "stx_scalebar",
     "stx_violin",
 ]
 

--- a/src/figrecipe/_skills/figrecipe/24_l-shaped-scale-bar.md
+++ b/src/figrecipe/_skills/figrecipe/24_l-shaped-scale-bar.md
@@ -2,7 +2,7 @@
 description: |
   [TOPIC] L-shaped scale bar for axis-off trace / EEG panels
   [DETAILS] ax.stx_scalebar() draws an L-shaped time/amplitude scale bar instead of x/y axes. Use after ax.axis("off") on raw time-series / iEEG plots.
-tags: [figrecipe-plot, figrecipe-trace, figrecipe-eeg, figrecipe]
+tags: [figrecipe-l-shaped-scale-bar, figrecipe-plot, figrecipe-trace, figrecipe-eeg, figrecipe]
 ---
 
 

--- a/src/figrecipe/_skills/figrecipe/24_l-shaped-scale-bar.md
+++ b/src/figrecipe/_skills/figrecipe/24_l-shaped-scale-bar.md
@@ -1,0 +1,86 @@
+---
+description: |
+  [TOPIC] L-shaped scale bar for axis-off trace / EEG panels
+  [DETAILS] ax.stx_scalebar() draws an L-shaped time/amplitude scale bar instead of x/y axes. Use after ax.axis("off") on raw time-series / iEEG plots.
+tags: [figrecipe-plot, figrecipe-trace, figrecipe-eeg, figrecipe]
+---
+
+
+# L-shaped scale bar (`ax.stx_scalebar`)
+
+Raw time-series / iEEG plots follow the EEG publication convention of *no*
+x/y axes. The reader still needs to know the time scale and the amplitude
+scale, so we draw an **L-shaped scale bar** instead: a horizontal arm
+encodes time, a vertical arm encodes amplitude, the two arms share a
+corner, and the labels sit padded clear of the arms so nothing overlaps.
+
+The helper is shipped as `ax.stx_scalebar(...)` (also reachable on the
+figrecipe-branded surface as `ax.fr_scalebar(...)` when the
+`scitex_dev._branding` alias registry is installed). The figrecipe-level
+shortcut `fr.scale_bar_l()` follows the same call shape.
+
+## Signature
+
+```python
+ax.stx_scalebar(
+    x_len,                     # horizontal arm length, data units
+    y_len,                     # vertical arm length,   data units
+    x_label="1 min",           # label below the horizontal arm
+    y_label="a.u.",            # label left of the vertical arm
+    loc="lower left",          # corner of the L's vertex
+    color="black",
+    lw=1.5,
+    pad_frac=(0.04, 0.06),     # corner inset (axes-fraction)
+    label_pad_frac=(0.015, 0.03),  # label offset off the arms
+)
+```
+
+`x_len` and `y_len` are in data units, so call this **after** plotting
+the trace data — the helper reads `ax.get_xlim() / ax.get_ylim()` to
+position the bar.
+
+Font sizes follow the active rcParams / SCITEX_STYLE (no hardcoded
+`fontsize=`).
+
+## Example: EEG-style raw trace
+
+```python
+import figrecipe as fr
+import numpy as np
+
+t = np.linspace(0, 60, 60_000)               # 60 s of trace
+y = np.random.randn(t.size).cumsum() * 0.01  # placeholder
+
+fig, ax = fr.subplots(figsize=(6, 1.5))
+ax.plot(t, y, color="black", lw=0.5)
+ax.axis("off")                               # no x/y axes
+ax.stx_scalebar(
+    x_len=10,           # 10 s
+    y_len=0.5,          # 0.5 a.u.
+    x_label="10 s",
+    y_label="0.5 a.u.",
+    loc="lower left",
+)
+fr.save(fig, "eeg_trace.png")
+```
+
+## When to use
+
+- Raw / continuous trace panels (iEEG, LFP, MEG, ECoG snippets) where
+  numeric tick labels would clutter the panel.
+- Any axis-off plot where the *scale* matters more than absolute values.
+
+## When NOT to use
+
+- Scientific bar / line / scatter plots — those want full axes with
+  labelled ticks (use `ax.set_xyt` instead).
+- Heatmaps / imshow / colormap plots — use a colorbar, not a scale bar.
+
+## See also
+
+- `ax.set_xyt(x, y, title)` — the standard "set axis text" helper for
+  non-axis-off plots. STX-FM010 flags `set_xlabel` / `set_ylabel` /
+  `set_title` in favour of it.
+- `ax.hide_spines(...)` — finer-grained spine removal when you only
+  want to hide *some* axes (STX-FM011 flags the manual
+  `ax.spines[...].set_visible(False)` form).

--- a/src/figrecipe/_skills/figrecipe/SKILL.md
+++ b/src/figrecipe/_skills/figrecipe/SKILL.md
@@ -47,6 +47,7 @@ This package does not ship as a submodule of the `scitex` umbrella.
 * [16_plot-types](16_plot-types.md) — All supported plot types with examples
 * [17_composition](17_composition.md) — Multi-panel figure composition (grid and mm-based)
 * [18_cropping](18_cropping.md) — Figure cropping, whitespace removal
+* [24_l-shaped-scale-bar](24_l-shaped-scale-bar.md) — L-shaped time/amplitude scale bar for axis-off trace / EEG panels
 
 ### Workflows
 * [10_workflows](10_workflows.md) — Common figure workflows

--- a/src/figrecipe/_wrappers/_axes_scitex.py
+++ b/src/figrecipe/_wrappers/_axes_scitex.py
@@ -228,6 +228,23 @@ class SciTexMixin:
             self._record_stx_call("stx_violin", (values_list,), kwargs, id)
         return result
 
+    def stx_scalebar(self, x_len, y_len, *, id=None, track=True, **kwargs):
+        """Draw an L-shaped scale bar for axis-off trace / EEG panels.
+
+        The horizontal arm encodes time (``x_len``) and the vertical arm
+        encodes amplitude (``y_len``), sharing a corner, with padded labels
+        that do not overlap. Use with ``ax.axis("off")``. See the underlying
+        ``stx_scalebar`` for the full parameter list (``x_label``, ``y_label``,
+        ``loc``, ``color``, ``lw``, ``pad_frac``, ``label_pad_frac``).
+        """
+        from .._scitex_compat._simple import stx_scalebar
+
+        with self._no_record():
+            result = stx_scalebar(self._ax, x_len, y_len, **kwargs)
+        if self._track and track:
+            self._record_stx_call("stx_scalebar", (x_len, y_len), kwargs, id)
+        return result
+
 
 __all__ = ["SciTexMixin"]
 

--- a/tests/figrecipe/_scitex_compat/test__simple.py
+++ b/tests/figrecipe/_scitex_compat/test__simple.py
@@ -114,6 +114,7 @@ class TestCsvFormat:
         csv_path = tmpdir / "test.csv"
         data_dir = tmpdir / "test_data"
         import pandas as pd
+
         df = pd.read_csv(csv_path)
         assert len(df.columns) >= 2
 
@@ -129,6 +130,7 @@ class TestCsvFormat:
         output_path = tmpdir / "test.yaml"
         fr.save(fig, output_path, csv_format="single")
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "test.csv")
         assert "r0c0_my-trace_x" in df.columns
 
@@ -144,6 +146,7 @@ class TestCsvFormat:
         output_path = tmpdir / "test.yaml"
         fr.save(fig, output_path, csv_format="single")
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "test.csv")
         assert "r0c0_my-trace_y" in df.columns
 
@@ -221,6 +224,7 @@ class TestCsvFormat:
         output_path = tmpdir / "multi.yaml"
         fr.save(fig, output_path, csv_format="single")
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "multi.csv")
         assert "r0c0_sine_x" in df.columns
 
@@ -236,6 +240,7 @@ class TestCsvFormat:
         output_path = tmpdir / "multi.yaml"
         fr.save(fig, output_path, csv_format="single")
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "multi.csv")
         assert "r0c0_sine_y" in df.columns
 
@@ -251,6 +256,7 @@ class TestCsvFormat:
         output_path = tmpdir / "multi.yaml"
         fr.save(fig, output_path, csv_format="single")
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "multi.csv")
         assert "r0c0_cosine_x" in df.columns
 
@@ -266,6 +272,7 @@ class TestCsvFormat:
         output_path = tmpdir / "multi.yaml"
         fr.save(fig, output_path, csv_format="single")
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "multi.csv")
         assert "r0c0_cosine_y" in df.columns
 
@@ -281,6 +288,7 @@ class TestCsvFormat:
         output_path = tmpdir / "multiax.yaml"
         fr.save(fig, output_path, csv_format="single", validate=False)
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "multiax.csv")
         assert "r0c0_left-plot_x" in df.columns
 
@@ -296,6 +304,7 @@ class TestCsvFormat:
         output_path = tmpdir / "multiax.yaml"
         fr.save(fig, output_path, csv_format="single", validate=False)
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "multiax.csv")
         assert "r0c0_left-plot_y" in df.columns
 
@@ -311,6 +320,7 @@ class TestCsvFormat:
         output_path = tmpdir / "multiax.yaml"
         fr.save(fig, output_path, csv_format="single", validate=False)
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "multiax.csv")
         assert "r0c1_right-plot_x" in df.columns
 
@@ -326,6 +336,7 @@ class TestCsvFormat:
         output_path = tmpdir / "multiax.yaml"
         fr.save(fig, output_path, csv_format="single", validate=False)
         import pandas as pd
+
         df = pd.read_csv(tmpdir / "multiax.csv")
         assert "r0c1_right-plot_y" in df.columns
 
@@ -345,7 +356,9 @@ class TestCsvFormatLoadSingleCsv:
         # Act
         # Assert
         import pandas as pd
+
         from figrecipe._utils._numpy_io import load_single_csv
+
         df = pd.DataFrame(
             {
                 "r0c0_trace1_x": [1, 2, 3],
@@ -365,7 +378,9 @@ class TestCsvFormatLoadSingleCsv:
         # Act
         # Assert
         import pandas as pd
+
         from figrecipe._utils._numpy_io import load_single_csv
+
         df = pd.DataFrame(
             {
                 "r0c0_trace1_x": [1, 2, 3],
@@ -385,7 +400,9 @@ class TestCsvFormatLoadSingleCsv:
         # Act
         # Assert
         import pandas as pd
+
         from figrecipe._utils._numpy_io import load_single_csv
+
         df = pd.DataFrame(
             {
                 "r0c0_trace1_x": [1, 2, 3],
@@ -405,7 +422,9 @@ class TestCsvFormatLoadSingleCsv:
         # Act
         # Assert
         import pandas as pd
+
         from figrecipe._utils._numpy_io import load_single_csv
+
         df = pd.DataFrame(
             {
                 "r0c0_trace1_x": [1, 2, 3],
@@ -425,7 +444,9 @@ class TestCsvFormatLoadSingleCsv:
         # Act
         # Assert
         import pandas as pd
+
         from figrecipe._utils._numpy_io import load_single_csv
+
         df = pd.DataFrame(
             {
                 "ax-row-0-col-0_trace-id-trace1_variable-x": [1, 2, 3],
@@ -443,7 +464,9 @@ class TestCsvFormatLoadSingleCsv:
         # Act
         # Assert
         import pandas as pd
+
         from figrecipe._utils._numpy_io import load_single_csv
+
         df = pd.DataFrame(
             {
                 "ax-row-0-col-0_trace-id-trace1_variable-x": [1, 2, 3],
@@ -454,3 +477,150 @@ class TestCsvFormatLoadSingleCsv:
         df.to_csv(csv_path, index=False)
         result = load_single_csv(csv_path)
         assert "trace1" in result["r0c0"]
+
+
+def _trace_axes():
+    """An axis-off trace panel, like an iEEG strip."""
+    fig, ax = plt.subplots()
+    t = np.linspace(0, 600, 600)  # 600 s
+    ax.plot(t, np.sin(t / 20.0) * 50)
+    ax.axis("off")
+    return fig, ax
+
+
+class TestScalebar:
+    """Tests for the L-shaped stx_scalebar primitive."""
+
+    @pytest.fixture(autouse=True)
+    def reset_matplotlib(self):
+        plt.close("all")
+        matplotlib.rcdefaults()
+        yield
+        plt.close("all")
+
+    def test_returns_same_axes(self):
+        # Arrange
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        _, ax = _trace_axes()
+        # Act
+        out = stx_scalebar(ax, 60, 100, x_label="1 min", y_label="unknown")
+        # Assert
+        assert out is ax
+
+    def test_draws_two_arms(self):
+        # Arrange
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        _, ax = _trace_axes()
+        n_before = len(ax.lines)
+        # Act
+        stx_scalebar(ax, 60, 100, x_label="1 min", y_label="unknown")
+        # Assert
+        assert len(ax.lines) == n_before + 2
+
+    def test_horizontal_arm_spans_x_len(self):
+        # Arrange
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        _, ax = _trace_axes()
+        # Act
+        stx_scalebar(ax, 60, 100)
+        horiz = ax.lines[-2]
+        hx, hy = horiz.get_xdata(), horiz.get_ydata()
+        # Assert
+        assert hy[0] == hy[1] and np.isclose(abs(hx[1] - hx[0]), 60)
+
+    def test_vertical_arm_spans_y_len(self):
+        # Arrange
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        _, ax = _trace_axes()
+        # Act
+        stx_scalebar(ax, 60, 100)
+        vert = ax.lines[-1]
+        vx, vy = vert.get_xdata(), vert.get_ydata()
+        # Assert
+        assert vx[0] == vx[1] and np.isclose(abs(vy[1] - vy[0]), 100)
+
+    def test_arms_share_a_vertex(self):
+        # Arrange
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        _, ax = _trace_axes()
+        # Act
+        stx_scalebar(ax, 60, 100)
+        horiz, vert = ax.lines[-2], ax.lines[-1]
+        # Assert
+        assert np.isclose(horiz.get_xdata()[0], vert.get_xdata()[0]) and np.isclose(
+            horiz.get_ydata()[0], vert.get_ydata()[0]
+        )
+
+    def test_arms_are_black(self):
+        # Arrange
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        _, ax = _trace_axes()
+        # Act
+        stx_scalebar(ax, 60, 100, color="black")
+        arms = ax.lines[-2:]
+        # Assert
+        assert all(matplotlib.colors.to_hex(ln.get_color()) == "#000000" for ln in arms)
+
+    def test_two_labels_with_expected_text(self):
+        # Arrange
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        _, ax = _trace_axes()
+        n_txt = len(ax.texts)
+        # Act
+        stx_scalebar(ax, 60, 100, x_label="1 min", y_label="unknown")
+        labels = {t.get_text() for t in ax.texts[n_txt:]}
+        # Assert
+        assert labels == {"1 min", "unknown"}
+
+    def test_labels_do_not_overlap(self):
+        # Arrange
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        _, ax = _trace_axes()
+        n_txt = len(ax.texts)
+        # Act
+        stx_scalebar(ax, 60, 100, x_label="1 min", y_label="unknown")
+        by_text = {t.get_text(): t.get_position() for t in ax.texts[n_txt:]}
+        # Assert
+        assert by_text["1 min"] != by_text["unknown"]
+
+    def test_y_label_is_rotated_vertical(self):
+        # Arrange
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        _, ax = _trace_axes()
+        n_txt = len(ax.texts)
+        # Act
+        stx_scalebar(ax, 60, 100, x_label="1 min", y_label="unknown")
+        by_text = {t.get_text(): t for t in ax.texts[n_txt:]}
+        # Assert
+        assert by_text["unknown"].get_rotation() == 90
+
+    def test_no_hardcoded_fontsize(self):
+        # Arrange: labels should inherit the rcParams font size.
+        from figrecipe._scitex_compat._simple import stx_scalebar
+
+        matplotlib.rcParams["font.size"] = 7.0
+        _, ax = _trace_axes()
+        n_txt = len(ax.texts)
+        # Act
+        stx_scalebar(ax, 60, 100)
+        # Assert
+        assert all(t.get_fontsize() == 7.0 for t in ax.texts[n_txt:])
+
+    def test_recording_axes_method(self):
+        # Arrange
+        fig, ax = fr.subplots()
+        ax.plot(np.linspace(0, 600, 600), np.zeros(600))
+        ax.axis("off")
+        # Act
+        out = ax.stx_scalebar(60, 100, x_label="1 min", y_label="unknown")
+        # Assert
+        assert out is not None


### PR DESCRIPTION
## Summary
Adds a reusable `RecordingAxes.stx_scalebar(...)` method (and underlying `stx_scalebar` impl) for axis-off trace / iEEG / EEG panels, which follow the convention of having no x/y axes — an L-shaped scale bar conveys the time and amplitude scales instead. Dogfoods the hand-rolled helper currently in NeuroVista Fig 1d.

## API
```python
ax.stx_scalebar(
    x_len, y_len,                  # arm lengths in data units
    x_label="1 min", y_label="a.u.",
    loc="lower left",              # corner placement of the L's vertex
    color="black", lw=1.5,
    pad_frac=(0.04, 0.06),         # corner inset (x,y) as axes-fraction
    label_pad_frac=(0.015, 0.03),  # label offset off the arms
)
```

## Behaviour
- Draws two arms from a shared corner: horizontal = time, vertical = amplitude.
- `x_label` sits centred below the horizontal arm (`va=top`); `y_label` sits left of the vertical arm (`ha=right`, `rotation=90`) — both padded clear so they never overlap the arms or each other.
- Black by default (arms and labels). Works with `ax.axis("off")`.
- `loc` selects any corner so the arms grow into the plot.
- No hardcoded `fontsize=` — labels inherit rcParams / SCITEX_STYLE.

## Files
- `src/figrecipe/_scitex_compat/_simple.py` — `stx_scalebar` impl + `__all__`.
- `src/figrecipe/_scitex_compat/__init__.py` — export.
- `src/figrecipe/_wrappers/_axes_scitex.py` — `SciTexMixin.stx_scalebar` wrapper (records the composite call like the other `stx_*` methods).
- `tests/figrecipe/_scitex_compat/test__simple.py` — `TestScalebar` (11 tests: arm geometry, shared vertex, black colour, two non-overlapping labels, y-label rotation, no hardcoded fontsize, RecordingAxes wrapper).

No seaborn, no new dependencies. Verified by rendering an axis-off trace panel with `ax.stx_scalebar(60, 100, x_label="1 min", y_label="unknown")` — black L with clear labels.