### PR TITLE
feat(skills): promote neurovista figure-prep lessons

### DIFF
--- a/src/figrecipe/_skills/figrecipe/21_figure-prep-playbook.md
+++ b/src/figrecipe/_skills/figrecipe/21_figure-prep-playbook.md
@@ -1,7 +1,7 @@
 ---
 description: |
   [TOPIC] Figure Prep Playbook (ecosystem-wide)
-  [DETAILS] Canonical playbook for preparing publication-quality figures across the SciTeX ecosystem — real-data-only rule, NaN handling, common-scale-across-panels, representative-example selection criteria, config-as-single-source-of-truth, and the figrecipe-dogfood principle (use figrecipe in figrecipe's own examples). Every paper / poster / report figure produced anywhere in the ecosystem should pass this checklist before it lands.
+  [DETAILS] Canonical playbook for preparing publication-quality figures across the SciTeX ecosystem — real-data-only rule, NaN handling, common-scale-across-panels, representative-example selection criteria, config-as-single-source-of-truth, the figrecipe-dogfood principle (use figrecipe in figrecipe's own examples), and the L-shaped scale-bar convention for signal-trace panels. Every paper / poster / report figure produced anywhere in the ecosystem should pass this checklist before it lands.
 tags: [figrecipe-figure-prep-playbook, figrecipe]
 ---
 
@@ -32,7 +32,7 @@ Do **not** load this skill for:
   throwaway — just `ax.plot` and move on).
 - Unit-test fixtures that exercise the figrecipe API surface.
 
-## The six rules
+## The seven rules
 
 ### 1. Real data only
 
@@ -153,6 +153,36 @@ The same rule applies to any docstring example: if you would teach
 a user to call `fr.subplots`, your own docstring must call
 `fr.subplots`.
 
+### 7. L-shaped scale bar on signal-trace panels
+
+For **representative / paper figures showing signal traces** (EEG,
+ECoG, LFP, spike, ECG, audio, kinematics), do **not** draw full
+ticked x and y axes on the trace panel. Instead:
+
+- Hide the surrounding axes (`ax.set_axis_off()` or remove spines /
+  ticks).
+- Draw a small **L-shaped scale bar** in the lower-left of the
+  panel: one short horizontal bar (time scale, e.g. `100 ms`) and
+  one short vertical bar (amplitude scale, e.g. `50 μV`), sharing a
+  corner. The L-bar **is** the scale legend.
+- Pick **round, reader-expectation magnitudes** — powers of 10 for
+  time, biology-relevant rounds for amplitude (e.g. `50 μV` EEG,
+  `100 μV` LFP, `1 mV` ECG). Drive the magnitudes from `CONFIG.*`
+  (rule 5) so the bar label and the data agree when the data is
+  rescaled.
+
+Applies to: representative traces in paper / poster / talk figures.
+Does **not** apply to stats plots (bar / line / scatter where ticked
+axes carry quantitative claims), schematics, or multi-panel
+comparison grids where readers must cross-read absolute values
+between panels (use shared ticked axes per rule 3).
+
+Don't keep full ticked axes AND add an L-bar — pick one. Don't
+silently rescale the data and forget to update the bar label.
+
+See `24_l-shaped-scale-bar.md` for the worked-example leaf with the
+matplotlib pattern and a longer DO/DON'T list.
+
 ## Pre-render checklist
 
 Before a figure script is allowed into a publication pipeline:
@@ -169,6 +199,9 @@ Before a figure script is allowed into a publication pipeline:
 - [ ] Output saved via `fr.save(fig, ...)` (not `fig.savefig`).
 - [ ] Caption / docstring explicitly names the data source and the
       NaN-handling choice.
+- [ ] Signal-trace panels use an L-shaped scale bar (axes hidden,
+      magnitudes from `CONFIG.SCALE_BAR.*`) — see
+      `24_l-shaped-scale-bar.md`.
 
 ## Anti-patterns
 
@@ -182,6 +215,10 @@ Before a figure script is allowed into a publication pipeline:
   `plt.savefig`, even inside a project that has figrecipe installed.
 - "I'll fix the NaN sentinel handling in the figure" — no, you fix it
   in the loader. The figure layer assumes clean `np.nan`.
+- A representative signal-trace panel with full ticked axes *and* an
+  L-shaped scale bar — redundant and visually noisy. Pick one (use
+  the L-bar for representative traces; see rule 7 and
+  `24_l-shaped-scale-bar.md`).
 
 ## Cross-references
 
@@ -189,6 +226,8 @@ Before a figure script is allowed into a publication pipeline:
   (e.g. `-32768` → `np.nan` on read) at the figure layer.
 - `23_no-synthetic-data-policy.md` — figrecipe rendering-side guard
   for the no-synthetic-data policy.
+- `24_l-shaped-scale-bar.md` — L-shaped scale-bar convention for
+  signal-trace panels (rule 7 worked example).
 - `05_styles.md` — `SCITEX` and dark-variant presets.
 - `17_composition.md` — multi-panel mm-precision composition.
 - `scitex-dev/_skills/scientific/01_figures_01_standards.md` —

--- a/src/figrecipe/_skills/figrecipe/21_figure-prep-playbook.md
+++ b/src/figrecipe/_skills/figrecipe/21_figure-prep-playbook.md
@@ -1,0 +1,199 @@
+---
+description: |
+  [TOPIC] Figure Prep Playbook (ecosystem-wide)
+  [DETAILS] Canonical playbook for preparing publication-quality figures across the SciTeX ecosystem — real-data-only rule, NaN handling, common-scale-across-panels, representative-example selection criteria, config-as-single-source-of-truth, and the figrecipe-dogfood principle (use figrecipe in figrecipe's own examples). Every paper / poster / report figure produced anywhere in the ecosystem should pass this checklist before it lands.
+tags: [figrecipe-figure-prep-playbook, figrecipe]
+---
+
+
+# Figure Prep Playbook
+
+Canonical figrecipe leaf for the figure-preparation checklist used
+across the SciTeX ecosystem. Loaded by any agent or human prepping a
+publication-bound figure. Pairs with `05_styles.md` (visual presets),
+`17_composition.md` (multi-panel layout), and the scitex-dev
+scientific leaves `01_figures_01_standards.md` (universal rules) and
+`01_figures_03_no-synthetic-data-policy.md` (ecosystem policy).
+
+## When to use this leaf
+
+Load this skill when you are about to:
+
+- Render a figure that will end up in a paper / poster / talk / grant.
+- Build a representative example for a manuscript figure.
+- Write `examples/<NN>_*.py` that figrecipe (or any ecosystem package)
+  ships as a publication-quality demonstration.
+- Review an existing figure script before merging it into a publication
+  pipeline.
+
+Do **not** load this skill for:
+
+- Quick exploratory plots during analysis (where the figure is
+  throwaway — just `ax.plot` and move on).
+- Unit-test fixtures that exercise the figrecipe API surface.
+
+## The six rules
+
+### 1. Real data only
+
+Paper / representative / publication figures MUST be backed by real
+experimental or observational data. If the real data is absent at
+render time, **fail loud** — raise, exit non-zero, refuse to write
+the output file. Never silently substitute `np.random.*` or column
+means.
+
+Synthetic data is acceptable only in clearly-marked test fixtures
+(`tests/fixtures/synthetic_*`, `examples/synthetic_demo_*.py`).
+
+See `23_no-synthetic-data-policy.md` for the figrecipe-side rendering
+guard, and the scitex-dev ecosystem-policy authority leaf
+(`scitex-dev/_skills/scientific/01_figures_03_no-synthetic-data-policy.md`).
+
+### 2. NaN handling, decided once
+
+Every figure script MUST declare its NaN policy explicitly:
+
+- **Convert sentinel values to `np.nan` at load time**, never at plot
+  time. (Domain sentinels like `-32768`, `-999`, `9999` come from the
+  storage layer and must be normalised on read; see
+  `22_nan-sentinel-on-read.md`.)
+- **Decide on render**: drop, interpolate, or visualise the gap.
+  Whichever you pick, do it once and document the choice in the figure
+  caption ("gaps shown as white" / "missing samples interpolated
+  linearly" / "missing trials excluded from the mean").
+- Never let `np.nan` reach a `vmin` / `vmax` calculation without
+  `np.nanmin` / `np.nanmax`.
+- Heatmaps: use a `cmap` with a distinct "bad" color
+  (`cmap.set_bad("white")`) so missing pixels are visually distinct
+  from any real value.
+
+### 3. Common scale across compared panels
+
+When two or more panels are intended to be compared visually
+(treatment vs control, pre vs post, condition A vs B):
+
+- **One shared `vmin` / `vmax`** across all compared panels —
+  compute the global min/max before drawing.
+- **Aligned axes** — same x and y ranges; remove redundant inner
+  tick labels.
+- **One shared colorbar** for the comparison group, not one per
+  panel.
+- **Same aspect ratio** for each panel of a comparison group.
+
+If the panels are NOT meant to be compared (e.g., two unrelated
+metrics side-by-side), say so in the caption and let each panel
+have its own scale — but still align axes that share units.
+
+See `scitex-dev/_skills/scientific/01_figures_01_standards.md` for the
+universal-rule rationale.
+
+### 4. Representative-example selection criteria
+
+When picking a single trial / subject / sample to represent a result
+("representative seizure", "representative cell"):
+
+- **Document the criterion in code**, not in your head. Use a config
+  key like `CONFIG.REPRESENTATIVE.SUBJECT_ID` and write the selection
+  rule in a comment: `# closest-to-median effect size across cohort`.
+- **The picked example must NOT be cherry-picked for visual appeal**
+  — the criterion must be something you would defend to a reviewer
+  (median, mode, nearest-to-mean, first-passing-quality-check).
+- **Show the cohort distribution alongside the representative** when
+  space allows (inset histogram / strip plot with the chosen sample
+  highlighted). The representative is then a pointer into a real
+  distribution, not a poster child.
+- **Re-derive on every render** — if the cohort changes, the
+  representative must change too, deterministically. Hard-coding
+  `SUBJECT_ID = 7` because "subject 7 looks good" violates this.
+
+### 5. Config = Single Source of Truth (SSoT)
+
+Every figure-rendering decision that a reviewer might question MUST
+come from a config file, not a hard-coded literal in the script.
+That includes:
+
+- Subject/trial IDs (representative-example selection).
+- Channel / electrode / region selections.
+- Color choices (use `CONFIG.COLORS.<KEY>` from `config/COLORS.yaml`).
+- Time windows, frequency bands, thresholds.
+- Style preset name (`SCITEX` / `SCITEX_DARK` / `MATPLOTLIB`).
+- Output paths (use `CONFIG.PATH.<KEY>` from `config/PATH.yaml`).
+
+Rationale: when a co-author asks "why this subject?" or "why this
+band?", the answer is `config/PARAMS.yaml`. Diff-the-config to know
+what changed between revisions. See
+`scitex-dev/_skills/scientific/02_research-project_07_config-and-parameters.md`.
+
+### 6. figrecipe dogfood
+
+figrecipe's own `examples/`, `docs/`, and per-skill code blocks MUST
+use the figrecipe API, never raw `plt.savefig(...)`. The package's
+own examples are the most-read figrecipe reference; if they bypass
+the library's affordances, every downstream user copies the bypass.
+
+DO:
+
+```python
+import figrecipe as fr
+fig, ax = fr.subplots(w_mm=85, h_mm=60, style="SCITEX")
+ax.plot(x, y)
+fr.save(fig, "output.png")
+```
+
+DON'T (even in examples):
+
+```python
+import matplotlib.pyplot as plt
+fig, ax = plt.subplots(figsize=(3.3, 2.4))
+ax.plot(x, y)
+fig.savefig("output.png", dpi=300)
+```
+
+The same rule applies to any docstring example: if you would teach
+a user to call `fr.subplots`, your own docstring must call
+`fr.subplots`.
+
+## Pre-render checklist
+
+Before a figure script is allowed into a publication pipeline:
+
+- [ ] Backed by real data; FileNotFoundError raises on missing input.
+- [ ] NaN sentinel conversion happens at load, not plot.
+- [ ] Compared panels share `vmin`/`vmax`, axes, and colorbar.
+- [ ] Representative example is config-driven and documented.
+- [ ] No `np.random.*` / `random.*` import in the script.
+- [ ] All tunable params come from `CONFIG.*`, not literals.
+- [ ] Style preset applied via `fr.load_style(...)` or
+      `figrecipe.subplots(style=...)` — no manual `rcParams` overrides
+      that bypass figrecipe.
+- [ ] Output saved via `fr.save(fig, ...)` (not `fig.savefig`).
+- [ ] Caption / docstring explicitly names the data source and the
+      NaN-handling choice.
+
+## Anti-patterns
+
+- A `make_representative_figure()` helper that silently picks
+  `subject_ids[0]` "for the example" — encodes cherry-pick into the
+  pipeline.
+- A heatmap comparison where one panel uses `vmax=data1.max()` and
+  the other `vmax=data2.max()` — defeats the comparison even if
+  every other rule is followed.
+- A figure script that imports `matplotlib.pyplot` directly and calls
+  `plt.savefig`, even inside a project that has figrecipe installed.
+- "I'll fix the NaN sentinel handling in the figure" — no, you fix it
+  in the loader. The figure layer assumes clean `np.nan`.
+
+## Cross-references
+
+- `22_nan-sentinel-on-read.md` — concrete NaN-sentinel handling
+  (e.g. `-32768` → `np.nan` on read) at the figure layer.
+- `23_no-synthetic-data-policy.md` — figrecipe rendering-side guard
+  for the no-synthetic-data policy.
+- `05_styles.md` — `SCITEX` and dark-variant presets.
+- `17_composition.md` — multi-panel mm-precision composition.
+- `scitex-dev/_skills/scientific/01_figures_01_standards.md` —
+  universal scientific-figure standards (color, layout, typography).
+- `scitex-dev/_skills/scientific/01_figures_03_no-synthetic-data-policy.md`
+  — canonical ecosystem-policy home for the real-data-only rule.
+- `scitex-dev/_skills/scientific/02_research-project_07_config-and-parameters.md`
+  — config-as-SSoT mechanics (`@stx.session`, `CONFIG.*`).

--- a/src/figrecipe/_skills/figrecipe/22_nan-sentinel-on-read.md
+++ b/src/figrecipe/_skills/figrecipe/22_nan-sentinel-on-read.md
@@ -1,0 +1,130 @@
+---
+description: |
+  [TOPIC] NaN-sentinel conversion at the figure layer
+  [DETAILS] Many scientific storage layers use a sentinel integer value (e.g. `-32768`, `-999`, `9999`) to mark missing data because the on-disk type is integer and NaN is not representable. At the figure layer, on read, convert these sentinels to `np.nan` BEFORE any min/max/plot operation. Do not "fix" the storage layer — the sentinel is often by design. This leaf gives the conversion idiom plus a concrete domain example (neurovista ecog: `-32768`).
+tags: [figrecipe-nan-sentinel-on-read, figrecipe]
+---
+
+
+# NaN sentinels: convert on read at the figure layer
+
+## The pattern
+
+Many scientific datasets store missing samples as a **sentinel integer
+value** rather than NaN, because the on-disk dtype is integer (`int16`,
+`int32`) and NaN is not representable in integer types. Common
+sentinels:
+
+| Value | Common usage |
+|---|---|
+| `-32768` (= `int16` min) | iEEG/ECoG voltage gaps, raw ADC dropouts |
+| `-999` / `-9999` | Sensor dropout, "no value" flag |
+| `9999` | Legacy meteorological / oceanographic missing |
+| `255` (`uint8` max) | Classified-image background / "outside ROI" |
+| `0` (in mask-context only) | Binary mask "absent" |
+
+These values are **valid in the storage layer**. They become invalid
+the moment they enter a computation that does not understand them
+(a `min`/`max`, a mean, a colormap normalisation, a `ylim`). The
+figure layer is the boundary where sentinel must become `np.nan`.
+
+## The rule
+
+**On read, at the figure layer, convert sentinel → `np.nan` before
+any plotting or scale computation.** Do not fix it in the storage
+layer; the sentinel is usually by design (compactness, integer
+arithmetic, downstream-DB contract).
+
+```python
+import numpy as np
+
+SENTINEL = -32768  # value contractually used by the upstream store
+
+raw = load_from_store(...)         # int16 array; may contain SENTINEL
+data = raw.astype(np.float32)      # promote so NaN is representable
+data[raw == SENTINEL] = np.nan     # mark gaps
+
+# Now safe to plot:
+ax.imshow(data, vmin=np.nanmin(data), vmax=np.nanmax(data))
+```
+
+## Concrete example: neurovista ECoG (`-32768`)
+
+In the neurovista ECoG capsule the raw voltage store uses **`-32768`
+as an intentional sentinel** for data gaps. This is a deliberate
+choice in the DB layer's design (the on-disk dtype is `int16` and
+`-32768` is its natural minimum, leaving the rest of the range for
+signal). It is *not* a bug, *not* a quantisation artefact, and *not*
+a placeholder waiting for "real" data.
+
+Figure scripts that load this store must convert on read:
+
+```python
+NV_ECOG_GAP_SENTINEL = -32768
+
+def load_ecog_for_plotting(channel_id):
+    raw = nv_store.load_voltage(channel_id)        # int16
+    arr = raw.astype(np.float32)
+    arr[raw == NV_ECOG_GAP_SENTINEL] = np.nan
+    return arr
+```
+
+> This is a domain example, not a general rule. Other domains use
+> other sentinels (`-999`, `9999`, etc.) and YOUR project should
+> document its own sentinel set. The general rule — *convert at the
+> figure layer, do not touch the storage layer* — is what
+> generalises.
+
+## DO
+
+- **Convert on read**, immediately after `load_*`. Treat the
+  conversion as part of the load API:
+  `load_ecog_for_plotting(...)` returns float-with-NaN.
+- **Promote the dtype** to a float type (`float32` / `float64`)
+  before assigning `np.nan` — integer arrays cannot hold NaN.
+- **Use `np.nan*` reductions** (`nanmin`, `nanmax`, `nanmean`)
+  whenever a NaN may be present. Pair with `cmap.set_bad("white")`
+  for heatmaps so missing pixels are visually distinct.
+- **Document the sentinel** in the loader's docstring and the figure
+  caption. ("Voltage gaps are stored as -32768 in the source; shown
+  as white in this heatmap.")
+- **Centralise the conversion** in one helper per data source
+  (`load_ecog_for_plotting`, `load_weather_for_plotting`); do not
+  scatter `arr[arr == -32768] = np.nan` across N figure scripts.
+
+## DON'T
+
+- **Don't "fix" the storage layer** — the sentinel is by design. A PR
+  that rewrites the upstream store to use NaN will break every other
+  consumer (integer-typed DBs, fixed-width binary protocols, the
+  downstream-DB schema). Convert at YOUR boundary instead.
+- **Don't pass raw sentinel values to `vmin`/`vmax`**:
+  `vmin=data.min()` on int16 returns `-32768` and crushes the
+  meaningful range to a single pixel. Use `np.nanmin(data)` after
+  conversion, OR `np.where(data != SENTINEL, data, np.nan).min()`
+  before promotion.
+- **Don't silently drop NaN rows** at plot time. Decide explicitly
+  (drop, interpolate, or display as a gap) and write the choice into
+  the figure caption (see `21_figure-prep-playbook.md` rule 2).
+- **Don't hard-code the sentinel as a magic number** in every script
+  — define it as a named constant in the loader module
+  (`NV_ECOG_GAP_SENTINEL = -32768`) and import it.
+
+## Pre-render check
+
+- [ ] Sentinel converted to `np.nan` immediately after load.
+- [ ] All reductions in the figure code use `np.nan*` variants.
+- [ ] Heatmaps use `cmap.set_bad("<color>")` so missing pixels are
+      distinguishable.
+- [ ] Caption / docstring names the sentinel and its rendering
+      choice.
+
+## Cross-references
+
+- `21_figure-prep-playbook.md` — figure-prep playbook (rule 2 on NaN
+  handling).
+- `23_no-synthetic-data-policy.md` — never fill NaN with synthetic
+  values in publication figures.
+- `scitex-dev/_skills/scientific/01_figures_01_standards.md` — color
+  scale and comparison rules (which break loudly if NaN leaks
+  through).

--- a/src/figrecipe/_skills/figrecipe/23_no-synthetic-data-policy.md
+++ b/src/figrecipe/_skills/figrecipe/23_no-synthetic-data-policy.md
@@ -1,0 +1,96 @@
+---
+description: |
+  [TOPIC] No-Synthetic-Data Policy (figrecipe rendering-side guard)
+  [DETAILS] figrecipe-side restatement of the ecosystem-wide no-synthetic-data-in-publication-figures policy. The canonical home is `scitex-dev/_skills/scientific/01_figures_03_no-synthetic-data-policy.md`; this leaf is the figrecipe-specific rendering rule: refuse to render with placeholder data, fail loud on missing inputs, and keep synthetic examples in clearly-marked test fixtures.
+tags: [figrecipe-no-synthetic-data-policy, figrecipe]
+---
+
+
+# No-Synthetic-Data Policy (figrecipe view)
+
+> **Canonical home**:
+> `scitex-dev/_skills/scientific/01_figures_03_no-synthetic-data-policy.md`.
+> That leaf is the ecosystem-policy SSoT. This leaf is the
+> figrecipe-specific rendering rule, kept here so that a figrecipe
+> consumer who never loads the scientific umbrella still encounters
+> the policy.
+
+## The rule (figrecipe view)
+
+A figrecipe figure that will appear in a paper / poster / talk /
+representative-of-a-result asset MUST be backed by real data. If the
+data file is missing at render time, the figure script must **fail
+loud** — raise an exception, exit non-zero, refuse to write the
+output — rather than silently substitute `np.random.*`, column
+means, or any placeholder.
+
+Synthetic data is acceptable in:
+
+- `tests/fixtures/synthetic_*` test inputs
+- `examples/synthetic_demo_*.py` API-exercise demos
+- Any path whose name contains `synthetic` / `fixture` / `demo`
+
+It is NOT acceptable in:
+
+- `examples/representative_*.py` (rename to `synthetic_*` if
+  it isn't real)
+- Anything imported by a paper / report pipeline
+- A docstring example labelled "this is what figure X looks like"
+
+## DO
+
+- **Fail loud on missing data**. Let `FileNotFoundError` propagate;
+  let `assert df.shape[0] > 0` raise; exit non-zero from CLI.
+
+  ```python
+  data_path = Path(CONFIG.PATH.RAW_SIGNAL)
+  if not data_path.exists():
+      raise FileNotFoundError(
+          f"Real data missing at {data_path}; refusing to render "
+          f"a publication figure without source data."
+      )
+  ```
+
+- **Name fixtures clearly**: `tests/fixtures/synthetic_signal.npz`,
+  `examples/04_synthetic_demo_scatter.py`. The substring
+  `synthetic` / `fixture` / `demo` must appear in the filename.
+
+- **Mark provisional panels visibly**. If you are drafting a figure
+  with a placeholder panel pending real data:
+
+  ```python
+  ax.text(0.5, 0.5, "PLACEHOLDER\nreal data pending",
+          ha="center", va="center", fontsize=24,
+          transform=ax.transAxes, color="red",
+          bbox=dict(boxstyle="round", facecolor="yellow"))
+  ```
+
+  This is not a "polite" placeholder — it must be visually
+  unmistakable so it cannot ship by accident.
+
+## DON'T
+
+- **Don't `np.random.*` into a representative figure** to "show the
+  shape". That figure travels into slides and Slack and stops being
+  flagged as fake.
+- **Don't write a `make_example_figure()` helper that swallows
+  `FileNotFoundError`** and renders synthetic data as a fallback.
+- **Don't fill missing real data with column means / zeros** for a
+  publication panel. Decide on a NaN-handling rule (see
+  `22_nan-sentinel-on-read.md` and `21_figure-prep-playbook.md`
+  rule 2) and apply it consistently.
+- **Don't ship `examples/representative_figure.py` that secretly
+  uses `np.random.randn`**. Either back it with real data or
+  rename it to `synthetic_demo_figure.py`.
+
+## Cross-references
+
+- `scitex-dev/_skills/scientific/01_figures_03_no-synthetic-data-policy.md`
+  — canonical ecosystem-policy authority.
+- `21_figure-prep-playbook.md` — the six-rule figure-prep playbook
+  (this leaf is rule 1).
+- `22_nan-sentinel-on-read.md` — handling real-but-missing data
+  values without resorting to synthetic placeholders.
+- `scitex-dev/_skills/scientific/01_figures_02_provenance-and-verification.md`
+  — Source→Figure DAG (a verified DAG over synthetic data certifies
+  a fake; the policy and provenance rules compose).

--- a/src/figrecipe/_skills/figrecipe/24_l-shaped-scale-bar.md
+++ b/src/figrecipe/_skills/figrecipe/24_l-shaped-scale-bar.md
@@ -1,0 +1,184 @@
+---
+description: |
+  [TOPIC] L-shaped scale bar for signal-trace figures
+  [DETAILS] Convention for representative / paper figures showing signal traces (EEG, ECoG, LFP, spike, ECG, audio, kinematic): draw a small L-shaped scale legend in the lower-left of the panel (one horizontal bar = time scale, one vertical bar = amplitude scale) and HIDE the surrounding axes. The L-bar IS the scale legend; full ticked axes on a representative trace are redundant, visually noisy, and waste panel area. Applies to publication / paper / poster figures of signal traces. Does NOT apply to stats plots (bar / line / scatter with quantitative axes), schematics, or comparison grids where axes carry meaning.
+tags: [figrecipe-l-shaped-scale-bar, figrecipe]
+---
+
+
+# L-shaped scale bar for signal traces
+
+A standard neuroscience convention for representative trace figures:
+instead of drawing ticked x and y axes, draw two short bars joined at
+a corner (the "L") — one horizontal (time) and one vertical
+(amplitude) — and hide the surrounding axes. The L-bar **is** the
+scale legend.
+
+Pairs with `21_figure-prep-playbook.md` (rule 7: signal-trace scale
+bars) as the worked-example leaf.
+
+## When to use
+
+Use an L-shaped scale bar when the figure is:
+
+- A **representative** trace (single trial, single channel, single
+  cell) in a paper / poster / talk.
+- A **signal trace** with a continuous time axis: EEG, ECoG, LFP,
+  spike voltage, ECG, audio waveform, kinematics, optical recording.
+- A figure where the **shape of the trace** is what the reader is
+  supposed to evaluate — not its absolute coordinates.
+
+Do **not** use an L-bar when the figure is:
+
+- A **stats plot** — bar / line / scatter / box where each axis tick
+  is a quantitative claim. Keep ticked axes.
+- A **schematic** or **cartoon** with no real scale.
+- A **multi-panel comparison grid** where readers must cross-read
+  values between panels. Use shared ticked axes (see playbook rule 3,
+  common scale across compared panels).
+- A trace whose **absolute time** matters (e.g. event-aligned plots
+  where t=0 must be labelled). Keep the x-axis; drop only the y-axis
+  to a vertical scale bar if appropriate.
+
+## The rule
+
+For a representative signal-trace panel:
+
+1. Draw the trace at the data's native units.
+2. Hide the surrounding axes (`ax.set_axis_off()` or
+   `for s in ax.spines.values(): s.set_visible(False)`; remove
+   ticks).
+3. Add two short bars joined at the **lower-left** corner of the
+   panel:
+   - Horizontal bar: time scale (e.g. `100 ms`, `1 s`).
+   - Vertical bar: amplitude scale (e.g. `50 μV`, `100 pA`).
+4. Label each bar with its magnitude **and unit**, placed adjacent
+   to the bar (time label below, amplitude label to the left).
+5. Pick **round, reader-expectation magnitudes** — powers of 10 for
+   time (`10 ms`, `100 ms`, `1 s`), and biology-relevant rounds for
+   amplitude (`50 μV` for EEG, `100 μV` for LFP, `1 mV` for ECG,
+   `100 pA` for patch-clamp current).
+
+## Minimal matplotlib pattern
+
+Pseudocode showing the *shape* of the call sequence — adapt to your
+own data and figure-size conventions. (A first-class
+`fr.scale_bar_l(...)` helper would belong in figrecipe; until it
+ships, inline this pattern in your figure script and keep the
+magnitudes in `CONFIG.*`.)
+
+```python
+import figrecipe as fr
+
+fig, ax = fr.subplots(w_mm=85, h_mm=30, style="SCITEX")
+ax.plot(t, v, color="k", lw=0.6)
+
+# Magnitudes from config (playbook rule 5)
+t_bar_s   = CONFIG.SCALE_BAR.TIME_S       # e.g. 0.1   (100 ms)
+v_bar_uV  = CONFIG.SCALE_BAR.AMP_UV       # e.g. 50
+
+# Anchor the L-corner in the lower-left of the data window
+x0 = t.min()
+y0 = v.min()
+
+# Horizontal bar = time
+ax.plot([x0, x0 + t_bar_s], [y0, y0], color="k", lw=1.5,
+        solid_capstyle="butt")
+# Vertical bar = amplitude
+ax.plot([x0, x0], [y0, y0 + v_bar_uV], color="k", lw=1.5,
+        solid_capstyle="butt")
+
+# Labels
+ax.text(x0 + t_bar_s / 2, y0, f"{int(t_bar_s * 1000)} ms",
+        ha="center", va="top")
+ax.text(x0, y0 + v_bar_uV / 2, f"{v_bar_uV} μV",
+        ha="right", va="center", rotation=90)
+
+# Hide the axis frame — the L-bar IS the scale legend
+ax.set_axis_off()
+
+fr.save(fig, "fig_representative_trace.png")
+```
+
+The two `ax.plot` calls share the corner `(x0, y0)`, producing the L.
+`solid_capstyle="butt"` keeps the corner crisp (no rounded overshoot
+that breaks the right angle).
+
+## DO
+
+- **Match magnitudes to typical reader expectations** — powers of 10
+  for time, round biology-relevant numbers for amplitude. A `73 ms`
+  scale bar is a smell; pick `100 ms`.
+- **Place lower-left** as default. Other corners are acceptable if
+  the trace itself occupies the lower-left region, but the team /
+  paper should pick one and stay consistent across panels.
+- **Keep the bars the same color as the trace** (or a deliberate
+  contrast color from `config/COLORS.yaml`). Black-on-white at
+  `lw=1.5` reads at print size.
+- **Drive magnitudes from config** — see playbook rule 5
+  (config-as-SSoT). When the data is rescaled (e.g. mV → μV during a
+  cleanup pass), the bar magnitude in the config is the single
+  source of truth; the label updates automatically from
+  `CONFIG.SCALE_BAR.AMP_UV`.
+- **Mention the convention in the caption** once per figure: "Scale
+  bars: 100 ms, 50 μV." Readers should not have to count pixels.
+
+## DON'T
+
+- **Don't keep full ticked axes AND add an L-bar.** Pick one. Both
+  is redundant, visually noisy, and signals to a reviewer that the
+  figure was not curated.
+- **Don't silently rescale the data and forget to update the bar
+  label.** A `100 μV` bar drawn at the new `mV` scale is now wrong
+  by a factor of 1000. The bar label and the data must agree by
+  construction — drive both from the same `CONFIG.SCALE_BAR.*`
+  values.
+- **Don't use odd magnitudes** (`73 ms`, `42 μV`). Pick the nearest
+  power-of-10 / round number that still leaves the bar visually
+  distinguishable from the trace.
+- **Don't apply L-bars to stats plots.** A bar chart with hidden
+  axes and an L-bar is unreadable. The L-bar is for *traces*.
+- **Don't reach for the L-bar before deciding the panel is
+  representative.** If the figure is a comparison grid where the
+  reader must read absolute values across panels, keep shared
+  ticked axes (playbook rule 3).
+
+## Pre-render check
+
+- [ ] Panel is a representative signal trace (not stats, not
+      schematic, not a comparison grid).
+- [ ] Surrounding axes are hidden (`ax.set_axis_off()` or
+      spines/ticks off).
+- [ ] Horizontal and vertical scale bars share a corner (lower-left
+      by default).
+- [ ] Magnitudes are round (powers of 10 for time, biology-relevant
+      rounds for amplitude) and come from `CONFIG.SCALE_BAR.*`.
+- [ ] Labels include units and are placed adjacent to each bar.
+- [ ] Caption mentions the scale-bar magnitudes.
+- [ ] If the data was rescaled, the scale-bar magnitudes were
+      updated (verified by re-running with the new config).
+
+## Future work
+
+A first-class `fr.scale_bar_l(ax, t=0.1, amp=50, t_unit="ms",
+amp_unit="μV", corner="lower-left")` helper would belong in
+figrecipe so that the pattern above collapses to a single call and
+the magnitudes / units stay in one place. Until then, the inline
+pattern above is the convention; keep the magnitudes in
+`CONFIG.SCALE_BAR.*` so the per-script copy is just a thin wrapper
+around config values.
+
+## Cross-references
+
+- `21_figure-prep-playbook.md` — rule 7 (signal-trace scale bars)
+  points here; rule 5 (config-as-SSoT) covers the
+  `CONFIG.SCALE_BAR.*` pattern.
+- `05_styles.md` — `SCITEX` preset sets the line weights / fonts
+  the L-bar pattern assumes.
+- `17_composition.md` — when a multi-panel figure mixes a
+  representative-trace panel (L-bar) and a stats panel (ticked
+  axes), they coexist; do not force a single axis style across
+  panels.
+- `scitex-dev/_skills/scientific/01_figures_01_standards.md` —
+  universal scientific-figure standards (typography, sizing) that
+  the L-bar labels follow.

--- a/src/figrecipe/_skills/figrecipe/SKILL.md
+++ b/src/figrecipe/_skills/figrecipe/SKILL.md
@@ -55,6 +55,9 @@ This package does not ship as a submodule of the `scitex` umbrella.
 
 ### Standards
 * [20_return-fig](20_return-fig.md) — Convention: plotting functions must return fig
+* [21_figure-prep-playbook](21_figure-prep-playbook.md) — Six-rule playbook for publication-bound figures (real data, NaN handling, common scale, representative-example criteria, config-as-SSoT, figrecipe dogfood)
+* [22_nan-sentinel-on-read](22_nan-sentinel-on-read.md) — Convert storage-layer sentinels (e.g. `-32768`) to `np.nan` at the figure layer; example: neurovista ECoG gap sentinel
+* [23_no-synthetic-data-policy](23_no-synthetic-data-policy.md) — figrecipe rendering-side guard for the ecosystem no-synthetic-data policy (canonical home in scitex-dev scientific)
 
 ## At a glance
 

--- a/src/figrecipe/_skills/figrecipe/SKILL.md
+++ b/src/figrecipe/_skills/figrecipe/SKILL.md
@@ -55,9 +55,10 @@ This package does not ship as a submodule of the `scitex` umbrella.
 
 ### Standards
 * [20_return-fig](20_return-fig.md) — Convention: plotting functions must return fig
-* [21_figure-prep-playbook](21_figure-prep-playbook.md) — Six-rule playbook for publication-bound figures (real data, NaN handling, common scale, representative-example criteria, config-as-SSoT, figrecipe dogfood)
+* [21_figure-prep-playbook](21_figure-prep-playbook.md) — Seven-rule playbook for publication-bound figures (real data, NaN handling, common scale, representative-example criteria, config-as-SSoT, figrecipe dogfood, L-shaped scale bar on signal traces)
 * [22_nan-sentinel-on-read](22_nan-sentinel-on-read.md) — Convert storage-layer sentinels (e.g. `-32768`) to `np.nan` at the figure layer; example: neurovista ECoG gap sentinel
 * [23_no-synthetic-data-policy](23_no-synthetic-data-policy.md) — figrecipe rendering-side guard for the ecosystem no-synthetic-data policy (canonical home in scitex-dev scientific)
+* [24_l-shaped-scale-bar](24_l-shaped-scale-bar.md) — L-shaped scale-bar convention for representative signal-trace panels (hide axes; lower-left time + amplitude bars sharing a corner); worked-example leaf for playbook rule 7
 
 ## At a glance
 


### PR DESCRIPTION
## Summary
- Adds `21_figure-prep-playbook.md` — seven-rule canonical figure-prep playbook (real data, NaN handling, common scale across compared panels, representative-example selection criteria, config-as-SSoT, figrecipe dogfood, **L-shaped scale bar on signal-trace panels**).
- Adds `22_nan-sentinel-on-read.md` — figure-layer rule for converting storage-layer integer sentinels (e.g. `-32768`) to `np.nan` immediately on read; includes a concrete neurovista ECoG example marked as a domain example, not a generic rule (the `-32768` sentinel is by design in the DB layer; convert at the figure boundary, never modify the storage layer).
- Adds `23_no-synthetic-data-policy.md` — figrecipe rendering-side guard cross-linking to the canonical home in scitex-dev `scientific/01_figures_03_*`.
- Adds `24_l-shaped-scale-bar.md` — worked-example leaf for playbook rule 7. Convention for representative / paper figures of signal traces (EEG, ECoG, LFP, spike, ECG, audio, kinematic): hide the surrounding axes and draw a small L-shaped scale legend in the lower-left (one horizontal bar = time, one vertical bar = amplitude, sharing a corner). Includes the minimal matplotlib pattern, the applicability boundary (signal traces only — does NOT apply to stats plots, schematics, or comparison grids where axes carry meaning), magnitude-choice guidance (powers of 10 for time, biology-relevant rounds for amplitude), config-as-SSoT hook (`CONFIG.SCALE_BAR.*`), and a future-work note for a first-class `fr.scale_bar_l()` helper.

Promotes three neurovista board lessons-learned cards plus the L-shaped scale-bar trace convention into runtime-readable figrecipe skills for discovery by other agents. Companion PR in scitex-dev carries the ecosystem-policy authority and the cross-package pointer.

## Test plan
- [ ] CI: existing checks (pytest, ruff)
- [x] Local: `scitex-dev` skill-quality checker on `src/figrecipe/_skills/figrecipe/` reports 0 issues (all four new leaves pass §1–§4: `NN_kebab-name.md` prefix unique, size 4–11KB <16KB, listed in SKILL.md, no dead links within the package).
- [x] Local: `ruff check src/figrecipe/_skills/` clean.
- [x] Local: `scitex-dev ecosystem audit-all figrecipe` audit-skills SUCC (other categories carry pre-existing develop-branch findings unrelated to `_skills/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
