### PR TITLE
ci(tests): add pip cache to pytest-matrix (~60-90s/cell saved)

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -23,6 +23,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # Built-in pip cache keyed on (pyproject.toml, py-version).
+          # Cuts the dependency-install step from ~60-90s to <10s on
+          # cache hit (pip skips wheel downloads + reuses the resolver
+          # output). Cold-cache runs (first push after a pyproject
+          # bump) pay full cost; warm runs short-circuit. Safe: the
+          # cache key encodes the lockfile-equivalent (pyproject.toml),
+          # so any dep change invalidates the cache — no stale-deps
+          # risk.
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- Adds `cache: 'pip'` + `cache-dependency-path: pyproject.toml` to `actions/setup-python@v5` in the `pytest-matrix` workflow.
- pytest-matrix currently medians **761s** wall (n=10, last 10 successful develop runs). Install step is the dominant cost (~60-90s x 3 cells).
- Expected: **~580-620s** wall on warm runs (-20 to -25%).

## Why
Operator-mandated initiative: ecosystem CI must be fast and reliable, permanently. This is the lowest-risk highest-impact lever before we get into matrix consolidation or self-hosted runner provisioning.

## Risk
Low. Cache key encodes `pyproject.toml` and python-version, so any dep change invalidates the cache (no stale-deps risk). Cold-cache runs pay full cost.

## Test plan
- [ ] Push triggers tests workflow.
- [ ] First run (cold): durations ~ baseline.
- [ ] Second run (warm): pytest-matrix wall time drops to ~580-620s.
- [ ] No new failures.

## Roadmap (separate work)
- Matrix consolidation (drop redundant py versions / gate via `if:`).
- Route heavy jobs to `scitex-todo-runner-01` once Python 3.11/3.12/3.13 is provisioned on it.
- Spartan HPC registration (long-term, only if needed beyond the runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)