### PR TITLE
ci(tests): route pytest-matrix to Spartan self-hosted runner

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Per lead's CI-speedup directive (2026-06-15), route the `pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml` workflow to a labelled self-hosted runner registered on Spartan (HPC).
- Workflow STEPS are untouched per operator directive — only the `runs-on:` line changes.
- pytest-matrix is the primary CI offender (~761s median); Spartan compute (8 cpu, 16G mem, sapphire partition) should land closer to scitex-todo timings on the existing parallel-test path.

## Runner

- Name: `spartan-figrecipe-runner-01`
- Labels: `self-hosted, Linux, X64, spartan, spartan-compute`
- Node: `spartan-bm177` (SLURM job 26137638, sapphire, publiccpu QoS, 7-day walltime with USR1 self-resubmit)
- Workspace: `/home/ywatanabe/actions-runner-figrecipe/`

## Test plan

- [ ] CI triggers and pytest-matrix jobs (py3.11/3.12/3.13) target `spartan-figrecipe-runner-01`.
- [ ] Setup-python resolves via `AGENT_TOOLSDIRECTORY=/home/ywatanabe/.runner-toolcache` (uv-installed Pythons on `~/.local/bin`).
- [ ] Other workflows (`auto-merge-to-develop`, `quality-audit`, `import-smoke`, `newb-docs-quality`, `rtd-sphinx-build`) keep targeting `ubuntu-latest` and stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)