### PR TITLE
fix(scatter-hist): KDE marginals line-only + suptitle inherits SCITEX_STYLE

### DIFF
--- a/src/figrecipe/_scitex_compat/_scientific.py
+++ b/src/figrecipe/_scitex_compat/_scientific.py
@@ -304,6 +304,7 @@ def stx_scatter_hist(
     hist_alpha=0.5,
     scatter_ratio=0.8,
     kde=False,
+    kde_fill=False,
     groups=None,
     palette=None,
     marginal_label=None,
@@ -335,6 +336,11 @@ def stx_scatter_hist(
         When True, draw smooth KDE density curves on the marginals instead of
         histograms. With ``groups`` set, one KDE per group is drawn on each
         marginal, coloured to match the scatter.
+    kde_fill : bool, default False
+        When ``kde=True``, controls whether the area under each KDE curve is
+        shaded. Default ``False`` draws the KDE marginals as line outlines only
+        (no fill) for readability. Set ``True`` to restore the filled look
+        (a translucent band under each curve).
     groups : array-like, optional
         Per-point group labels (``len == len(x)``). One KDE per unique group.
     palette : dict, optional
@@ -414,14 +420,18 @@ def stx_scatter_hist(
                 if gx is not None:
                     gx_plot = _x_grid_to_plot(gx)
                     ax_histx.plot(gx_plot, dx, color=color, alpha=hist_alpha)
-                    ax_histx.fill_between(
-                        gx_plot, dx, color=color, alpha=hist_alpha * 0.4
-                    )
+                    if kde_fill:
+                        ax_histx.fill_between(
+                            gx_plot, dx, color=color, alpha=hist_alpha * 0.4
+                        )
                 # Right marginal: KDE over y (plotted horizontally).
                 gy, dy = _kde_curve(y_arr[mask])
                 if gy is not None:
                     ax_histy.plot(dy, gy, color=color, alpha=hist_alpha)
-                    ax_histy.fill_betweenx(gy, dy, color=color, alpha=hist_alpha * 0.4)
+                    if kde_fill:
+                        ax_histy.fill_betweenx(
+                            gy, dy, color=color, alpha=hist_alpha * 0.4
+                        )
         else:
             gx, dx = _kde_curve(x_float)
             if gx is not None:

--- a/src/figrecipe/_wrappers/_figure.py
+++ b/src/figrecipe/_wrappers/_figure.py
@@ -9,12 +9,13 @@ from matplotlib.figure import Figure
 
 from .._utils._grid import grid_id
 from ._axes import RecordingAxes
+from ._figure_text import FigureTextMixin
 
 if TYPE_CHECKING:
     from .._recorder import FigureRecord, Recorder
 
 
-class RecordingFigure:
+class RecordingFigure(FigureTextMixin):
     """Wrapper around matplotlib Figure that manages recording.
 
     Parameters
@@ -173,107 +174,9 @@ class RecordingFigure:
             pass
         return default
 
-    def suptitle(self, t: str, **kwargs) -> Any:
-        """Set super title for the figure and record it.
-
-        Parameters
-        ----------
-        t : str
-            The super title text.
-        **kwargs
-            Additional arguments passed to matplotlib's suptitle().
-
-        Returns
-        -------
-        Text
-            The matplotlib Text object.
-        """
-        # Auto-apply fontsize from style if not specified
-        if "fontsize" not in kwargs:
-            kwargs["fontsize"] = self._get_style_fontsize("suptitle_pt", 10)
-        # Record the suptitle call
-        self._recorder.figure_record.suptitle = {"text": t, "kwargs": kwargs}
-        # Call the underlying figure's suptitle
-        return self._fig.suptitle(t, **kwargs)
-
-    def supxlabel(self, t: str, **kwargs) -> Any:
-        """Set super x-label for the figure and record it.
-
-        Parameters
-        ----------
-        t : str
-            The super x-label text.
-        **kwargs
-            Additional arguments passed to matplotlib's supxlabel().
-
-        Returns
-        -------
-        Text
-            The matplotlib Text object.
-        """
-        # Auto-apply fontsize from style if not specified
-        if "fontsize" not in kwargs:
-            kwargs["fontsize"] = self._get_style_fontsize("supxlabel_pt", 8)
-        # Record the supxlabel call
-        self._recorder.figure_record.supxlabel = {"text": t, "kwargs": kwargs}
-        # Call the underlying figure's supxlabel
-        return self._fig.supxlabel(t, **kwargs)
-
-    def supylabel(self, t: str, **kwargs) -> Any:
-        """Set super y-label for the figure and record it.
-
-        Parameters
-        ----------
-        t : str
-            The super y-label text.
-        **kwargs
-            Additional arguments passed to matplotlib's supylabel().
-
-        Returns
-        -------
-        Text
-            The matplotlib Text object.
-        """
-        # Auto-apply fontsize from style if not specified
-        if "fontsize" not in kwargs:
-            kwargs["fontsize"] = self._get_style_fontsize("supylabel_pt", 8)
-        # Record the supylabel call
-        self._recorder.figure_record.supylabel = {"text": t, "kwargs": kwargs}
-        # Call the underlying figure's supylabel
-        return self._fig.supylabel(t, **kwargs)
-
-    def text(self, x: float, y: float, s: str, **kwargs) -> Any:
-        """Place text on the figure and record it.
-
-        Proxy for ``matplotlib.figure.Figure.text`` that also captures the
-        call in the recipe so ``reproduce()`` can replay it. Without this,
-        ``fig.text`` annotations would be rendered in the original figure
-        but missing from the reproduction, leading to dimension mismatches
-        during reproducibility validation.
-
-        Parameters
-        ----------
-        x, y : float
-            Position in figure coordinates.
-        s : str
-            The text string.
-        **kwargs
-            Additional arguments passed to matplotlib's fig.text().
-
-        Returns
-        -------
-        Text
-            The matplotlib Text object.
-        """
-        serializable_kwargs = {
-            k: v
-            for k, v in kwargs.items()
-            if isinstance(v, (str, int, float, bool, list, tuple, type(None)))
-        }
-        self._recorder.figure_record.figure_texts.append(
-            {"x": x, "y": y, "s": s, "kwargs": serializable_kwargs}
-        )
-        return self._fig.text(x, y, s, **kwargs)
+    # suptitle / supxlabel / supylabel / text live in FigureTextMixin
+    # (._figure_text); the suptitle there inherits SCITEX_STYLE (size +
+    # non-bold weight).
 
     def colorbar(self, mappable, ax=None, **kwargs) -> Any:
         """Add a colorbar and record it for reproduction."""
@@ -499,64 +402,7 @@ class RecordingFigure:
             save_hitmap=save_hitmap,
         )
 
-    def set_supxyt(
-        self,
-        xlabel: Optional[str] = None,
-        ylabel: Optional[str] = None,
-        title: Optional[str] = None,
-        **kwargs,
-    ) -> "RecordingFigure":
-        """Set supxlabel, supylabel, and suptitle in one call.
-
-        Parameters
-        ----------
-        xlabel : str, optional
-        ylabel : str, optional
-        title : str, optional
-        **kwargs : dict
-            Passed to the underlying methods.
-
-        Examples
-        --------
-        >>> fig.set_supxyt('Time (s)', 'Amplitude', 'All Channels')
-        """
-        if xlabel is not None:
-            self.supxlabel(xlabel, **kwargs)
-        if ylabel is not None:
-            self.supylabel(ylabel, **kwargs)
-        if title is not None:
-            self.suptitle(title, **kwargs)
-        return self
-
-    def set_supxytc(
-        self,
-        xlabel: Optional[str] = None,
-        ylabel: Optional[str] = None,
-        title: Optional[str] = None,
-        caption: Optional[str] = None,
-        **kwargs,
-    ) -> "RecordingFigure":
-        """Set supxlabel, supylabel, suptitle, and caption in one call.
-
-        Parameters
-        ----------
-        xlabel : str, optional
-        ylabel : str, optional
-        title : str, optional
-        caption : str, optional
-            Figure caption metadata (stored in recipe, not rendered).
-        **kwargs : dict
-            Passed to the underlying methods.
-
-        Examples
-        --------
-        >>> fig.set_supxytc('Time', 'Voltage', 'Neural Data',
-        ...                 'Figure 1. Overview of neural recordings.')
-        """
-        self.set_supxyt(xlabel, ylabel, title, **kwargs)
-        if caption is not None:
-            self.set_caption(caption)
-        return self
+    # set_supxyt / set_supxytc live in FigureTextMixin (._figure_text).
 
     def save_recipe(
         self,

--- a/src/figrecipe/_wrappers/_figure_text.py
+++ b/src/figrecipe/_wrappers/_figure_text.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Figure-level super-text methods for RecordingFigure.
+
+Extracted from ``_figure.py`` to keep that module focused. ``FigureTextMixin``
+provides the figure-wide text helpers (suptitle / supxlabel / supylabel /
+text / set_supxyt / set_supxytc). The mixin relies on attributes and helpers
+supplied by ``RecordingFigure``: ``self._fig``, ``self._recorder``,
+``self._get_style_fontsize`` and ``self.set_caption``.
+"""
+
+from typing import Any, Optional
+
+
+class FigureTextMixin:
+    """Super-text (suptitle / supxlabel / supylabel / text) methods."""
+
+    def suptitle(self, t: str, **kwargs) -> Any:
+        """Set super title for the figure and record it.
+
+        Parameters
+        ----------
+        t : str
+            The super title text.
+        **kwargs
+            Additional arguments passed to matplotlib's suptitle().
+
+        Returns
+        -------
+        Text
+            The matplotlib Text object.
+
+        Notes
+        -----
+        When the caller does not specify them explicitly, the font size is
+        inherited from the active SCITEX_STYLE (``fonts.suptitle_pt``, ~7 pt)
+        and the font weight defaults to ``"normal"`` (not bold), so a bare
+        ``fig.suptitle("...")`` matches the style rather than matplotlib's
+        bold suptitle default. Either matplotlib alias (``size`` /
+        ``weight``) is respected when supplied.
+        """
+        # Auto-apply fontsize from style if not specified (accept the ``size``
+        # alias too, so an explicit caller value always wins).
+        if "fontsize" not in kwargs and "size" not in kwargs:
+            kwargs["fontsize"] = self._get_style_fontsize("suptitle_pt", 7)
+        # Default to non-bold so the suptitle inherits the style rather than
+        # matplotlib's bold default. Respect either alias if provided.
+        if "fontweight" not in kwargs and "weight" not in kwargs:
+            kwargs["fontweight"] = "normal"
+        # Record the suptitle call
+        self._recorder.figure_record.suptitle = {"text": t, "kwargs": kwargs}
+        # Call the underlying figure's suptitle
+        return self._fig.suptitle(t, **kwargs)
+
+    def supxlabel(self, t: str, **kwargs) -> Any:
+        """Set super x-label for the figure and record it.
+
+        Parameters
+        ----------
+        t : str
+            The super x-label text.
+        **kwargs
+            Additional arguments passed to matplotlib's supxlabel().
+
+        Returns
+        -------
+        Text
+            The matplotlib Text object.
+        """
+        # Auto-apply fontsize from style if not specified
+        if "fontsize" not in kwargs:
+            kwargs["fontsize"] = self._get_style_fontsize("supxlabel_pt", 8)
+        # Record the supxlabel call
+        self._recorder.figure_record.supxlabel = {"text": t, "kwargs": kwargs}
+        # Call the underlying figure's supxlabel
+        return self._fig.supxlabel(t, **kwargs)
+
+    def supylabel(self, t: str, **kwargs) -> Any:
+        """Set super y-label for the figure and record it.
+
+        Parameters
+        ----------
+        t : str
+            The super y-label text.
+        **kwargs
+            Additional arguments passed to matplotlib's supylabel().
+
+        Returns
+        -------
+        Text
+            The matplotlib Text object.
+        """
+        # Auto-apply fontsize from style if not specified
+        if "fontsize" not in kwargs:
+            kwargs["fontsize"] = self._get_style_fontsize("supylabel_pt", 8)
+        # Record the supylabel call
+        self._recorder.figure_record.supylabel = {"text": t, "kwargs": kwargs}
+        # Call the underlying figure's supylabel
+        return self._fig.supylabel(t, **kwargs)
+
+    def text(self, x: float, y: float, s: str, **kwargs) -> Any:
+        """Place text on the figure and record it.
+
+        Proxy for ``matplotlib.figure.Figure.text`` that also captures the
+        call in the recipe so ``reproduce()`` can replay it. Without this,
+        ``fig.text`` annotations would be rendered in the original figure
+        but missing from the reproduction, leading to dimension mismatches
+        during reproducibility validation.
+
+        Parameters
+        ----------
+        x, y : float
+            Position in figure coordinates.
+        s : str
+            The text string.
+        **kwargs
+            Additional arguments passed to matplotlib's fig.text().
+
+        Returns
+        -------
+        Text
+            The matplotlib Text object.
+        """
+        serializable_kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if isinstance(v, (str, int, float, bool, list, tuple, type(None)))
+        }
+        self._recorder.figure_record.figure_texts.append(
+            {"x": x, "y": y, "s": s, "kwargs": serializable_kwargs}
+        )
+        return self._fig.text(x, y, s, **kwargs)
+
+    def set_supxyt(
+        self,
+        xlabel: Optional[str] = None,
+        ylabel: Optional[str] = None,
+        title: Optional[str] = None,
+        **kwargs,
+    ) -> "FigureTextMixin":
+        """Set supxlabel, supylabel, and suptitle in one call.
+
+        Parameters
+        ----------
+        xlabel : str, optional
+        ylabel : str, optional
+        title : str, optional
+        **kwargs : dict
+            Passed to the underlying methods.
+
+        Examples
+        --------
+        >>> fig.set_supxyt('Time (s)', 'Amplitude', 'All Channels')
+        """
+        if xlabel is not None:
+            self.supxlabel(xlabel, **kwargs)
+        if ylabel is not None:
+            self.supylabel(ylabel, **kwargs)
+        if title is not None:
+            self.suptitle(title, **kwargs)
+        return self
+
+    def set_supxytc(
+        self,
+        xlabel: Optional[str] = None,
+        ylabel: Optional[str] = None,
+        title: Optional[str] = None,
+        caption: Optional[str] = None,
+        **kwargs,
+    ) -> "FigureTextMixin":
+        """Set supxlabel, supylabel, suptitle, and caption in one call.
+
+        Parameters
+        ----------
+        xlabel : str, optional
+        ylabel : str, optional
+        title : str, optional
+        caption : str, optional
+            Figure caption metadata (stored in recipe, not rendered).
+        **kwargs : dict
+            Passed to the underlying methods.
+
+        Examples
+        --------
+        >>> fig.set_supxytc('Time', 'Voltage', 'Neural Data',
+        ...                 'Figure 1. Overview of neural recordings.')
+        """
+        self.set_supxyt(xlabel, ylabel, title, **kwargs)
+        if caption is not None:
+            self.set_caption(caption)
+        return self
+
+
+# EOF

--- a/src/figrecipe/styles/presets/SCITEX.yaml
+++ b/src/figrecipe/styles/presets/SCITEX.yaml
@@ -28,7 +28,7 @@ fonts:
   axis_label_pt: 7
   tick_label_pt: 7
   title_pt: 8
-  suptitle_pt: 9      # Figure suptitle (slightly larger than subplot titles)
+  suptitle_pt: 7      # Figure suptitle (inherits style; small + non-bold)
   supxlabel_pt: 7     # Figure-level x-label (same as axis labels)
   supylabel_pt: 7     # Figure-level y-label (same as axis labels)
   panel_label_pt: 10  # Panel labels (A, B, C, ...) - bold, prominent


### PR DESCRIPTION
Two targeted figure fixes, stacked on top of the KDE-marginals feature (#172).

## Fix 1 — KDE marginals draw as line-only outlines (no fill)
`stx_scatter_hist(..., kde=True)` previously shaded the area under each KDE
marginal with `fill_between` / `fill_betweenx`, which clutters the panel.

- New param **`kde_fill: bool = False`**. Default `False` = line outline only
  (no fill under the curve) for readability. `kde_fill=True` restores the
  filled look (translucent band under each curve).
- Per-group KDE curves still render in their palette colours on both the top
  (x) and right (y) marginals; datetime-x handling unchanged.

New signature:
```python
stx_scatter_hist(ax, x, y, fig=None, hist_bins=20, scatter_alpha=0.6,
                 scatter_size=20, scatter_color=None, hist_color_x="blue",
                 hist_color_y="red", hist_alpha=0.5, scatter_ratio=0.8,
                 kde=False, kde_fill=False, groups=None, palette=None,
                 marginal_label=None, **kwargs)
```

## Fix 2 — suptitle inherits SCITEX_STYLE (size + weight)
`RecordingFigure.suptitle` fell back to 10 pt and rendered bold.

- `SCITEX.yaml` `fonts.suptitle_pt`: **9 → 7**.
- `suptitle()` now defaults `fontsize` to `fonts.suptitle_pt` (7) and
  `fontweight` to **`"normal"`** when the caller passes neither. Explicit
  `fontsize`/`size` and `fontweight`/`weight` kwargs still win.
- Net: `fig.suptitle("X")` → ~7 pt, non-bold, driven by SCITEX_STYLE.

## Refactor (size-limit)
Extracted figure super-text methods (suptitle / supxlabel / supylabel /
text / set_supxyt / set_supxytc) into `FigureTextMixin`
(`_wrappers/_figure_text.py`) so `_figure.py` stays under the module size
limit. Public API unchanged — `RecordingFigure(FigureTextMixin)`.

## Verification
- 127 wrappers + `_scientific` tests pass.
- Unit check: bare `fig.suptitle("X")` → size 7.0, weight normal; explicit
  `fontsize=20, fontweight="bold"` respected.
- Editable-installed into the neurovista venv and re-rendered Fig 1 panel C:
  KDE marginals are unfilled outlines and the "Patient #10" suptitle is small
  and non-bold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)