### PR TITLE
fix(gui): tolerate non-strict Connection header in terminal WS handshake (HTTP 426)

### DIFF
--- a/src/figrecipe/_django/terminal.py
+++ b/src/figrecipe/_django/terminal.py
@@ -81,6 +81,63 @@ async def terminal_ws_handler(websocket, path=None):
             pass
 
 
+def _repair_connection_header(request):
+    """Make a non-strict WebSocket upgrade request acceptable.
+
+    Some browsers and (more often) reverse proxies send a request that is
+    clearly a WebSocket upgrade -- it carries ``Upgrade: websocket`` and a
+    ``Sec-WebSocket-Key`` -- but whose ``Connection`` header does not contain
+    an ``Upgrade`` token (e.g. ``Connection: keep-alive``). Since
+    ``websockets`` >= 14 the handshake parser strictly requires an ``Upgrade``
+    token in ``Connection`` and otherwise rejects the handshake with
+    HTTP 426 (``InvalidUpgrade: invalid Connection header``).
+
+    This runs as a ``process_request`` hook, *before* the strict ``accept()``
+    validation, and appends ``Upgrade`` to the ``Connection`` header only when
+    the request is unambiguously a WebSocket upgrade. It never fabricates an
+    upgrade for plain HTTP requests, so normal (already-correct) clients are
+    unaffected.
+
+    Returns ``None`` so the handshake continues normally.
+    """
+    try:
+        headers = request.headers
+        upgrade_values = ",".join(headers.get_all("Upgrade")).lower()
+        is_ws_upgrade = (
+            "websocket" in upgrade_values
+            and headers.get("Sec-WebSocket-Key") is not None
+        )
+        if not is_ws_upgrade:
+            return None
+
+        connection_tokens = []
+        for value in headers.get_all("Connection"):
+            connection_tokens.extend(
+                tok.strip() for tok in value.split(",") if tok.strip()
+            )
+        has_upgrade_token = any(tok.lower() == "upgrade" for tok in connection_tokens)
+        if not has_upgrade_token:
+            # Replace the Connection header with a clean, RFC-compliant value
+            # that preserves any existing tokens and adds "Upgrade".
+            del headers["Connection"]
+            connection_tokens.append("Upgrade")
+            headers["Connection"] = ", ".join(connection_tokens)
+            logger.debug("Repaired non-strict Connection header for WebSocket upgrade")
+    except Exception as exc:  # never block the handshake on a repair failure
+        logger.debug("Connection header repair skipped: %s", exc)
+    return None
+
+
+def _process_request(connection, request):
+    """``process_request`` hook for the modern ``websockets.asyncio`` server.
+
+    Signature is ``(connection, request)``; ``request`` exposes a mutable
+    ``headers`` mapping. Returning ``None`` lets the handshake proceed.
+    """
+    _repair_connection_header(request)
+    return None
+
+
 def start_terminal_server(port: int = 5051):
     """Start standalone WebSocket terminal server."""
     try:
@@ -93,7 +150,12 @@ def start_terminal_server(port: int = 5051):
         return None
 
     async def serve():
-        async with websockets.serve(terminal_ws_handler, "127.0.0.1", port):
+        async with websockets.serve(
+            terminal_ws_handler,
+            "127.0.0.1",
+            port,
+            process_request=_process_request,
+        ):
             logger.info("Terminal server on ws://127.0.0.1:%d", port)
             await asyncio.Future()
 

--- a/tests/figrecipe/_django/test_terminal.py
+++ b/tests/figrecipe/_django/test_terminal.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the standalone GUI terminal WebSocket server.
+
+Regression coverage for the HTTP 426 handshake bug: with strict
+``websockets`` (>= 14) the opening handshake was rejected when a client or
+proxy sent a ``Connection`` header that did not contain an ``Upgrade`` token
+(e.g. ``Connection: keep-alive``). The ``_process_request`` hook repairs such
+non-strict-but-unambiguous WebSocket upgrade requests so the handshake
+succeeds, while leaving genuine non-WebSocket requests rejected.
+"""
+
+import socket
+import time
+
+import pytest
+
+from figrecipe._django import terminal
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _send_handshake(port, connection_header, *, ws_upgrade=True):
+    """Send a raw handshake and return the HTTP status line."""
+    s = socket.create_connection(("127.0.0.1", port), timeout=5)
+    try:
+        lines = ["GET / HTTP/1.1", f"Host: 127.0.0.1:{port}"]
+        if ws_upgrade:
+            lines += [
+                "Upgrade: websocket",
+                "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+                "Sec-WebSocket-Version: 13",
+            ]
+        lines.append(f"Connection: {connection_header}")
+        req = "\r\n".join(lines) + "\r\n\r\n"
+        s.sendall(req.encode())
+        time.sleep(0.4)
+        data = s.recv(4096).decode("utf-8", "replace")
+    finally:
+        s.close()
+    return data.splitlines()[0] if data else ""
+
+
+class _FakeHeaders(dict):
+    def get_all(self, name):
+        v = self.get(name)
+        return [v] if v is not None else []
+
+
+def _fake_request(headers):
+    return type("Req", (), {"headers": _FakeHeaders(headers)})()
+
+
+@pytest.fixture(scope="module")
+def terminal_port():
+    pytest.importorskip("websockets")
+    port = _free_port()
+    thread = terminal.start_terminal_server(port=port)
+    assert thread is not None
+    time.sleep(1.0)
+    yield port
+
+
+@pytest.mark.parametrize(
+    "connection_header",
+    [
+        "Upgrade",
+        "keep-alive, Upgrade",
+        "keep-alive",  # the original failing case (no Upgrade token)
+        "Keep-Alive",
+        "close",
+    ],
+)
+def test_websocket_upgrade_handshake_succeeds(terminal_port, connection_header):
+    # Arrange
+    port = terminal_port
+    # Act
+    status = _send_handshake(port, connection_header)
+    # Assert
+    assert "101" in status
+
+
+def test_plain_http_request_is_not_upgraded(terminal_port):
+    # Arrange
+    port = terminal_port
+    # Act: no Upgrade/Sec-WebSocket-Key headers present
+    status = _send_handshake(port, "keep-alive", ws_upgrade=False)
+    # Assert
+    assert "101" not in status
+
+
+def test_repair_adds_upgrade_token_when_missing():
+    # Arrange
+    req = _fake_request(
+        {
+            "Upgrade": "websocket",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Connection": "keep-alive",
+        }
+    )
+    # Act
+    terminal._repair_connection_header(req)
+    # Assert
+    assert "upgrade" in req.headers["Connection"].lower()
+
+
+def test_repair_preserves_existing_connection_tokens():
+    # Arrange
+    req = _fake_request(
+        {
+            "Upgrade": "websocket",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Connection": "keep-alive",
+        }
+    )
+    # Act
+    terminal._repair_connection_header(req)
+    # Assert
+    assert "keep-alive" in req.headers["Connection"].lower()
+
+
+def test_repair_leaves_non_websocket_request_untouched():
+    # Arrange
+    req = _fake_request({"Connection": "keep-alive"})
+    # Act
+    terminal._repair_connection_header(req)
+    # Assert
+    assert req.headers["Connection"] == "keep-alive"


### PR DESCRIPTION
## Problem

\`figrecipe start-gui <dir>\` launches a raw \`websockets\` terminal server on \`ws://127.0.0.1:5051\` (alongside the Django dev server on http 5050). The browser's WS handshake was **rejected with HTTP 426 Upgrade Required**, breaking the GUI terminal panel:

\`\`\`
websockets.exceptions.InvalidUpgrade: invalid Connection header: keep-alive
INFO: connection rejected (426 Upgrade Required)
ERRO: opening handshake failed
\`\`\`

## Root cause

- Installed \`websockets\` is **16.0**. Since websockets >= 14 the opening-handshake parser (\`ServerProtocol.accept()\`) strictly requires an \`upgrade\` token inside the \`Connection\` header and otherwise raises \`InvalidUpgrade\` -> 426.
- Reproduced against the actual server (\`src/figrecipe/_django/terminal.py\`):
  - \`Connection: Upgrade\` -> 101 OK
  - \`Connection: keep-alive, Upgrade\` -> 101 OK
  - **\`Connection: keep-alive\` (no Upgrade token) -> 426** ← the failing browser/proxy case from the report

## Fix

Add a \`process_request\` hook to \`websockets.serve(...)\`. It runs **before** the strict \`accept()\` validation and, **only** for unambiguous WebSocket upgrade requests (\`Upgrade: websocket\` **and** \`Sec-WebSocket-Key\` present), appends an \`Upgrade\` token to the \`Connection\` header when one is missing. Existing tokens are preserved (\`keep-alive\` -> \`keep-alive, Upgrade\`). Genuine non-WebSocket requests are left untouched and still get 426, so nothing is weakened.

File: \`src/figrecipe/_django/terminal.py\`

## Verification (no real browser)

Run with \`PYTHONPATH=src\` against the fixed server:

- Raw-socket handshakes: \`Upgrade\`, \`keep-alive, Upgrade\`, \`keep-alive\`, \`Keep-Alive\`, \`close\` -> **all 101 Switching Protocols**.
- Plain HTTP GET (no upgrade headers) -> still **426** (not coerced).
- Native \`websockets.asyncio.client.connect()\` (same v16.0): connects and a pty \`echo\` round-trips end-to-end.
- New regression tests in \`tests/figrecipe/_django/test_terminal.py\` (9 tests) pass; existing \`tests/figrecipe/_cli/test__gui.py\` + \`tests/figrecipe/_django/\` (35 tests) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)