### PR TITLE
fix(recipe): never emit 0-byte recipe; drop non-serializable legend handler_map

### DIFF
--- a/src/figrecipe/_reproducer/_legend.py
+++ b/src/figrecipe/_reproducer/_legend.py
@@ -51,6 +51,13 @@ def replay_legend_call(
             handles.append(patch)
         kwargs["handles"] = handles
 
+    # Drop figrecipe-internal metadata keys (underscore-prefixed) that
+    # were recorded for provenance/debugging only and are NOT valid
+    # matplotlib legend kwargs (e.g. ``_handler_map_summary``, the safe
+    # summary of a dropped non-serializable custom handler_map).
+    for meta_key in [k for k in kwargs if isinstance(k, str) and k.startswith("_")]:
+        kwargs.pop(meta_key)
+
     # Create legend
     legend = ax.legend(*args, **kwargs)
 

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -79,13 +79,35 @@ def save_recipe(
     # Convert numpy types to native Python types
     data = _convert_numpy_types(data)
 
-    # Save YAML
+    # Save YAML.
+    #
+    # Write atomically via a sibling temp file + os.replace so a dump that
+    # raises mid-serialization (e.g. a non-YAML-able object that slipped
+    # into the record) NEVER leaves a truncated 0-byte recipe on disk that
+    # would silently break downstream compose()/load_recipe(). Either the
+    # full valid recipe lands, or the write fails loud and the previous
+    # file (if any) is untouched.
+    import os
+    import tempfile
+
     yaml = YAML()
     yaml.preserve_quotes = True
     yaml.indent(mapping=2, sequence=4, offset=2)
 
-    with open(path, "w") as f:
-        yaml.dump(data, f)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.stem}.", suffix=".yaml.tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.dump(data, f)
+    except Exception:
+        # Fail loud: clean up the partial temp file, do not clobber path.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    os.replace(tmp_name, path)
 
     return path
 

--- a/src/figrecipe/_wrappers/_legend_wrapper.py
+++ b/src/figrecipe/_wrappers/_legend_wrapper.py
@@ -176,11 +176,37 @@ def _apply_frame_styling(legend) -> None:
             frame.set_edgecolor(edgecolor)
 
 
+# Legend kwargs whose values are render-time matplotlib objects
+# (artists, custom HandlerBase instances, ...) that are NOT YAML- or
+# pickle-serializable. Capturing them verbatim makes the recipe dump
+# raise, which previously left a 0-byte recipe on disk. We drop them
+# from the recorded recipe: they affect only how the legend is drawn,
+# not its semantic content (labels/handles metadata are captured
+# separately via ``_handle_specs``).
+_NON_SERIALIZABLE_LEGEND_KWARGS = frozenset(
+    {
+        "handler_map",  # {handle: HandlerBase} -> live artists + handlers
+        "handles",  # handled below via _handle_specs
+    }
+)
+
+
 def _record_legend_call(recorder, position, args, kwargs, call_id) -> None:
-    """Record the legend call into the recorder for later reproduction."""
+    """Record the legend call into the recorder for later reproduction.
+
+    Render-time matplotlib objects (a custom ``handler_map`` of
+    :class:`~matplotlib.legend_handler.HandlerBase` instances, live
+    artist handles, ...) are *not* recorded verbatim: they are not
+    YAML-serializable and would otherwise make the recipe dump raise.
+    The legend's semantic content (handle labels + colors) is captured
+    via ``_handle_specs`` instead, and a safe summary of any dropped
+    ``handler_map`` is kept for debugging.
+    """
     record_kwargs = dict(kwargs)
+
+    # Capture handle metadata before dropping the live artists.
     if "handles" in record_kwargs:
-        handles = record_kwargs.pop("handles")
+        handles = record_kwargs.get("handles")
         handle_specs = []
         for h in handles:
             spec: dict[str, Any] = {"label": h.get_label()}
@@ -190,6 +216,22 @@ def _record_legend_call(recorder, position, args, kwargs, call_id) -> None:
                 spec["edgecolor"] = list(h.get_edgecolor())
             handle_specs.append(spec)
         record_kwargs["_handle_specs"] = handle_specs
+
+    # Record that a custom handler_map was used (safe repr) but drop the
+    # live, non-serializable objects so the recipe dump never breaks.
+    handler_map = record_kwargs.get("handler_map")
+    if handler_map:
+        try:
+            record_kwargs["_handler_map_summary"] = [
+                type(handler).__name__ for handler in handler_map.values()
+            ]
+        except Exception:
+            record_kwargs["_handler_map_summary"] = "custom"
+
+    # Drop all render-time-only legend objects from the recorded recipe.
+    for key in _NON_SERIALIZABLE_LEGEND_KWARGS:
+        record_kwargs.pop(key, None)
+
     recorder.record_call(
         ax_position=position,
         method_name="legend",


### PR DESCRIPTION
## Problem

figrecipe wrote a **0-byte (empty) recipe .yaml** for any figure whose panel registered a **custom legend handler** -- a \`matplotlib.legend_handler.HandlerBase\` subclass passed via \`ax.legend(handler_map={handle: handler})\`. The empty recipe then crashed downstream \`compose()\`/\`load_recipe()\` with \`'NoneType' object has no attribute 'get'\`.

Reproducer: neurovista's raster panel \`plot_fig01b_15pt_raster.py\` (custom vertical-line \`HandlerBase\` for the day-100 entry) saved a 0-byte recipe, while sibling panels wrote valid 30-60 KB recipes.

## Root cause

\`_legend_wrapper._record_legend_call\` copied the legend kwargs verbatim into the recipe, including \`handler_map\` -- a dict of live, non-YAML-able matplotlib objects (\`Line2D\` handle keys + \`HandlerBase\` values). At save time \`ruamel.yaml.dump\` opened the file (truncating it to 0 bytes) then raised \`RepresenterError: cannot represent an object: <matplotlib.lines.Line2D ...>\` mid-dump, leaving a 0-byte file behind.

## Fix

- **\`_wrappers/_legend_wrapper.py\`** -- drop render-time-only legend objects (\`handler_map\`, live \`handles\`) from the recorded recipe. Keep a safe summary (\`_handler_map_summary\` = handler class names) for provenance; semantic content is still captured via \`_handle_specs\`. The custom handler keeps rendering the live figure; only the recipe is sanitized.
- **\`_serializer/_save.py\`** -- write the recipe YAML **atomically** (temp file + \`os.replace\`). A dump that raises now **fails loud** and never leaves a truncated 0-byte recipe; either the full valid recipe lands or the prior file is untouched.
- **\`_reproducer/_legend.py\`** -- strip underscore-prefixed figrecipe-internal metadata keys before calling \`ax.legend\`, so recorded \`_handler_map_summary\`/\`_handle_specs\` don't reach matplotlib on replay.

## Verification

neurovista \`plot_fig01b_15pt_raster.py\`:
- recipe yaml: **0 bytes -> 29,660 bytes**
- save-time **Reproducible Validation: PASSED** (legend with the custom vertical-line handler still renders)
- \`load_recipe(...)\` returns a **FigureRecord** (not None / no crash)
- smart \`compose_fig01.py\` now gets **past panel B** (its remaining failure is the unrelated \`render_compose_captions\` NameError tracked separately)

Note: stacked on \`fix/scatter-hist-kde-line-and-suptitle-style\` so the editable venv keeps the KDE + suptitle work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)