### PR TITLE
fix(recipe): faithful mm-compose replay of multi-axes + make_axes_locatable marginals

### DIFF
--- a/src/figrecipe/_api/_save_helpers.py
+++ b/src/figrecipe/_api/_save_helpers.py
@@ -5,7 +5,7 @@
 from pathlib import Path
 from typing import Optional
 
-from .._utils._grid import parse_grid_id
+from .._utils._grid import grid_id
 
 
 def _crop_to_axes_size(
@@ -127,53 +127,67 @@ def _capture_axes_bboxes(fig, crop_offset: Optional[dict] = None) -> None:
         Contains: left, upper, right, lower, original_width, original_height,
         new_width, new_height (all in pixels).
     """
-    for ax in fig.fig.get_axes():
-        # Get axes position in figure coordinates (0-1 range)
-        bbox = ax.get_position()
+
+    def _to_cropped(bbox) -> list:
+        """Convert an mpl axes position to (cropped) figure-fraction bbox."""
         bbox_list = [bbox.x0, bbox.y0, bbox.width, bbox.height]
+        if crop_offset is None:
+            return bbox_list
+        # Convert from figure coords to pixel coords, then to cropped coords
+        orig_w = crop_offset["original_width"]
+        orig_h = crop_offset["original_height"]
+        new_w = crop_offset["new_width"]
+        new_h = crop_offset["new_height"]
+        crop_left = crop_offset["left"]
+        crop_upper = crop_offset["upper"]
 
-        # Adjust for crop offset if provided
-        if crop_offset is not None:
-            # Convert from figure coords to pixel coords, then to cropped coords
-            orig_w = crop_offset["original_width"]
-            orig_h = crop_offset["original_height"]
-            new_w = crop_offset["new_width"]
-            new_h = crop_offset["new_height"]
-            crop_left = crop_offset["left"]
-            crop_upper = crop_offset["upper"]
+        # Original pixel positions (matplotlib y=0 is bottom, image y=0 is top)
+        x0_px = bbox.x0 * orig_w
+        y0_px = (1 - bbox.y0 - bbox.height) * orig_h  # Convert to image coords
+        w_px = bbox.width * orig_w
+        h_px = bbox.height * orig_h
 
-            # Original pixel positions (matplotlib y=0 is bottom, image y=0 is top)
-            x0_px = bbox.x0 * orig_w
-            y0_px = (1 - bbox.y0 - bbox.height) * orig_h  # Convert to image coords
-            w_px = bbox.width * orig_w
-            h_px = bbox.height * orig_h
+        # Adjust for crop (translate origin)
+        x0_cropped = x0_px - crop_left
+        y0_cropped = y0_px - crop_upper
 
-            # Adjust for crop (translate origin)
-            x0_cropped = x0_px - crop_left
-            y0_cropped = y0_px - crop_upper
+        # Convert back to figure coordinates (0-1 range in cropped image)
+        new_x0 = x0_cropped / new_w
+        new_y0 = 1 - (y0_cropped + h_px) / new_h  # Back to matplotlib coords
+        new_w_frac = w_px / new_w
+        new_h_frac = h_px / new_h
+        return [new_x0, new_y0, new_w_frac, new_h_frac]
 
-            # Convert back to figure coordinates (0-1 range in cropped image)
-            new_x0 = x0_cropped / new_w
-            new_y0 = 1 - (y0_cropped + h_px) / new_h  # Back to matplotlib coords
-            new_w_frac = w_px / new_w
-            new_h_frac = h_px / new_h
+    # Map each AxesRecord to ITS OWN mpl axes via the wrapped RecordingAxes
+    # (which carry both ``_position`` and the underlying ``_ax``). The previous
+    # implementation looped over fig.get_axes() and matched by position, but
+    # every mpl axes matched the first record whose key-derived position equalled
+    # its own — so for a multi-subplot figure all subplots overwrote r0c0's bbox,
+    # and r1c0/r2c0 ended up with no bbox at all. Marginal axes created via
+    # make_axes_locatable are not wrapped, so they are correctly skipped here.
+    matched_records = set()
+    for row in fig.axes:
+        for rec_ax in row:
+            mpl_ax = getattr(rec_ax, "_ax", rec_ax)
+            position = getattr(rec_ax, "_position", None)
+            if position is None:
+                continue
+            key = grid_id(position[0], position[1])
+            ax_record = fig.record.axes.get(key)
+            if ax_record is None:
+                continue
+            ax_record.bbox = _to_cropped(mpl_ax.get_position())
+            matched_records.add(key)
 
-            bbox_list = [new_x0, new_y0, new_w_frac, new_h_frac]
-
-        # Find corresponding AxesRecord
-        # Try to match by checking if this ax corresponds to a known position
-        for key, ax_record in fig.record.axes.items():
-            # Parse key (accepts "r0c0" or legacy "ax_0_0"); "ax_mm_idx" -> None
-            parsed = parse_grid_id(key)
-            if parsed is not None:
-                # Standard grid format
-                if ax_record.position == parsed:
-                    ax_record.bbox = bbox_list
-                    break
-            elif key.startswith("ax_mm_"):
-                # Mm-based format: ax_mm_idx
-                ax_record.bbox = bbox_list
-                break
+    # Fallback for mm-based composition records (keyed "ax_mm_idx"), which are
+    # not represented in fig.axes positions. Match in order against any
+    # remaining mpl axes.
+    remaining = [k for k in fig.record.axes if k not in matched_records]
+    if remaining:
+        mpl_axes = list(fig.fig.get_axes())
+        for key, mpl_ax in zip(remaining, mpl_axes):
+            if key.startswith("ax_mm_"):
+                fig.record.axes[key].bbox = _to_cropped(mpl_ax.get_position())
 
 
 def save_hitmap(

--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -17,6 +17,7 @@ from .._recorder import FigureRecord
 from .._utils._grid import grid_id, parse_grid_id
 from .._wrappers import RecordingAxes, RecordingFigure
 from ._source_parser import is_image_file as _is_image_file  # noqa: F401
+from ._source_parser import parse_source_spec_with_key as _parse_source_spec_with_key
 from ._source_parser import parse_source_spec_with_path as _parse_source_spec_with_path
 
 # Default DPI for mm-based composition
@@ -131,13 +132,24 @@ def compose(
     """
     if _is_mm_based_sources(sources):
         return _compose_mm_based(
-            sources, canvas_size_mm, dpi, panel_labels, label_style,
-            caption=caption, panel_captions=panel_captions, **kwargs,
+            sources,
+            canvas_size_mm,
+            dpi,
+            panel_labels,
+            label_style,
+            caption=caption,
+            panel_captions=panel_captions,
+            **kwargs,
         )
     else:
         return _compose_grid_based(
-            sources, layout, panel_labels, label_style,
-            caption=caption, panel_captions=panel_captions, **kwargs,
+            sources,
+            layout,
+            panel_labels,
+            label_style,
+            caption=caption,
+            panel_captions=panel_captions,
+            **kwargs,
         )
 
 
@@ -238,6 +250,7 @@ def _compose_mm_based(
     from .._recorder import Recorder
     from .._wrappers import RecordingAxes as RA
     from .._wrappers import RecordingFigure as RF
+    from ._caption_render import render_compose_captions
 
     if canvas_size_mm is None:
         max_x = 0
@@ -262,35 +275,71 @@ def _compose_mm_based(
     axes_list = []
     source_data_dirs = {}
 
-    for idx, (source_path, spec) in enumerate(sources.items()):
+    sub_idx = 0  # global counter for ax_mm_* keys across all panels + subplots
+    for source_path, spec in sources.items():
         xy_mm = spec["xy_mm"]
         size_mm = spec["size_mm"]
 
-        left = xy_mm[0] / canvas_size_mm[0]
-        bottom = 1.0 - (xy_mm[1] + size_mm[1]) / canvas_size_mm[1]
-        width = size_mm[0] / canvas_size_mm[0]
-        height = size_mm[1] / canvas_size_mm[1]
+        # Panel rectangle in figure-fraction coords.
+        panel_left = xy_mm[0] / canvas_size_mm[0]
+        panel_bottom = 1.0 - (xy_mm[1] + size_mm[1]) / canvas_size_mm[1]
+        panel_width = size_mm[0] / canvas_size_mm[0]
+        panel_height = size_mm[1] / canvas_size_mm[1]
 
-        mpl_ax = mpl_fig.add_axes([left, bottom, width, height])
+        source_record, ax_key, path, explicit_key = _parse_source_spec_with_key(
+            source_path
+        )
 
-        source_record, ax_key, path = _parse_source_spec_with_path(source_path)
-        ax_record = source_record.axes.get(ax_key)
+        # Decide which axes of the source recipe to place into this panel.
+        # An explicit (source, ax_key) tuple selects a single axes; a plain
+        # recipe/path replays ALL of its axes (so multi-subplot panels such as
+        # the stacked raw-iEEG traces keep every subplot, not just the first).
+        if explicit_key:
+            selected = {ax_key: source_record.axes.get(ax_key)}
+            if selected[ax_key] is None:
+                available = list(source_record.axes.keys())
+                raise ValueError(
+                    f"Axes '{ax_key}' not found in source. Available: {available}"
+                )
+        else:
+            selected = dict(source_record.axes)
+            if not selected:
+                raise ValueError(f"Source '{source_path}' has no axes to compose.")
 
-        if ax_record is None:
-            available = list(source_record.axes.keys())
-            raise ValueError(
-                f"Axes '{ax_key}' not found in source. Available: {available}"
+        data_dir = None
+        if path is not None:
+            candidate = path.parent / f"{path.stem}_data"
+            if candidate.exists():
+                data_dir = candidate
+
+        for src_key, ax_record in selected.items():
+            # Place this source-axes inside the panel rectangle, preserving its
+            # relative position/size within the original figure when a bbox was
+            # recorded. Without a bbox (single-axes panels), fill the panel.
+            bbox = getattr(ax_record, "bbox", None)
+            if bbox is not None and len(bbox) == 4:
+                bx0, by0, bw, bh = bbox
+            else:
+                bx0, by0, bw, bh = 0.0, 0.0, 1.0, 1.0
+
+            sub_left = panel_left + bx0 * panel_width
+            sub_bottom = panel_bottom + by0 * panel_height
+            sub_width = bw * panel_width
+            sub_height = bh * panel_height
+
+            mpl_ax = mpl_fig.add_axes([sub_left, sub_bottom, sub_width, sub_height])
+
+            target_ax = RA(mpl_ax, recorder, position=(0, sub_idx))
+            axes_list.append(target_ax)
+
+            _replay_axes_record_mm(
+                mpl_ax, ax_record, recorder.figure_record, sub_idx, spec
             )
 
-        target_ax = RA(mpl_ax, recorder, position=(0, idx))
-        axes_list.append(target_ax)
+            if data_dir is not None:
+                source_data_dirs[f"ax_mm_{sub_idx}"] = data_dir
 
-        _replay_axes_record_mm(mpl_ax, ax_record, recorder.figure_record, idx, spec)
-
-        if path is not None:
-            data_dir = path.parent / f"{path.stem}_data"
-            if data_dir.exists():
-                source_data_dirs[f"ax_mm_{idx}"] = data_dir
+            sub_idx += 1
 
     fig = RF(mpl_fig, recorder, axes_list)
 

--- a/src/figrecipe/_composition/_source_parser.py
+++ b/src/figrecipe/_composition/_source_parser.py
@@ -150,12 +150,29 @@ def parse_source_spec_with_path(
     raise TypeError(f"Invalid source spec type: {type(spec)}")
 
 
+def parse_source_spec_with_key(
+    spec: Union[str, Path, FigureRecord, Tuple],
+) -> Tuple[FigureRecord, str, Optional[Path], bool]:
+    """Like ``parse_source_spec_with_path`` but also report key explicitness.
+
+    Returns ``(FigureRecord, ax_key, source_path, explicit_key)`` where
+    ``explicit_key`` is True only when the caller selected a specific axes via a
+    ``(source, ax_key)`` tuple. When False, the source is a plain recipe/path
+    and composition should place ALL of its axes (so multi-subplot panels are
+    not silently reduced to their first axes).
+    """
+    explicit_key = isinstance(spec, tuple) and len(spec) == 2
+    record, ax_key, path = parse_source_spec_with_path(spec)
+    return record, ax_key, path, explicit_key
+
+
 __all__ = [
     "is_image_file",
     "find_companion_recipe",
     "create_image_record",
     "parse_source_spec",
     "parse_source_spec_with_path",
+    "parse_source_spec_with_key",
 ]
 
 # EOF

--- a/src/figrecipe/_recorder/_core.py
+++ b/src/figrecipe/_recorder/_core.py
@@ -451,6 +451,15 @@ class Recorder:
                 if default_val is None and value is None:
                     continue
 
+            # Serialize matplotlib transforms as portable markers so replay can
+            # resolve them to the target axes' transforms; otherwise they fall
+            # through to str() and replay crashes with "'str' object has no
+            # attribute 'contains_branch_seperately'". transAxes reprs as
+            # "BboxTransformTo..."; treat that as the "axes" marker.
+            if key == "transform" and repr(value).startswith("BboxTransformTo"):
+                processed[key] = "axes"
+                continue
+
             if self._is_serializable(value):
                 processed[key] = value
             elif isinstance(value, np.ndarray):

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -16,6 +16,23 @@ from .._utils._grid import parse_grid_id
 from ._colorbars import _replay_colorbars
 
 
+def _maybe_parse_datetime(value: Any) -> Any:
+    """Parse an ISO datetime string to a datetime (for datetime-axis limits).
+
+    Recipes record datetime axis limits as ISO strings; matplotlib cannot
+    convert a raw string to axis units on replay. Returns a ``datetime`` when
+    ``value`` parses as one, otherwise returns ``value`` unchanged.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        from datetime import datetime
+
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return value
+
+
 def reproduce(
     path: Union[str, Path],
     calls: Optional[List[str]] = None,
@@ -355,6 +372,14 @@ def _replay_call(
         from ._stem import replay_stem_call
 
         return replay_stem_call(ax, call)
+    if method_name.startswith("stx_"):
+        # figrecipe scitex-compat plot methods are functions taking a raw mpl
+        # axes; a plain getattr(ax, name) fails on raw axes (e.g. mm-compose
+        # add_axes panels), silently dropping the plot + its make_axes_locatable
+        # marginals. Dispatch to the compat function so it reconstructs fully.
+        from ._scitex import replay_stx_call
+
+        return replay_stx_call(ax, call, result_cache)
 
     method = getattr(ax, method_name, None)
 
@@ -373,6 +398,14 @@ def _replay_call(
     # Get kwargs and reconstruct arrays
     kwargs = reconstruct_kwargs(call.kwargs)
 
+    # Axis-limit methods on a datetime axis recorded their bounds as ISO
+    # datetime strings; matplotlib can't convert a raw string to axis units on
+    # replay (raises "Failed to convert value(s) to axis units"). Parse such
+    # strings back to datetime so the recorded limits are reapplied.
+    if method_name in ("set_xlim", "set_ylim", "axvline", "axhline"):
+        args = [_maybe_parse_datetime(a) for a in args]
+        kwargs = {k: _maybe_parse_datetime(v) for k, v in kwargs.items()}
+
     # Handle special transform markers
     if "transform" in kwargs:
         transform_val = kwargs["transform"]
@@ -382,6 +415,21 @@ def _replay_call(
             kwargs["transform"] = ax.transData
         elif transform_val == "figure":
             kwargs["transform"] = ax.figure.transFigure
+        elif isinstance(transform_val, str):
+            # A non-marker stringified transform (e.g. a Bbox/blended transform
+            # that the recorder could not serialize as a clean marker). Passing
+            # the raw string to matplotlib raises
+            # "'str' object has no attribute 'contains_branch_seperately'".
+            # Map an axes-bbox transform back to ax.transAxes (the common case,
+            # e.g. scalebars drawn in axes fraction); otherwise drop it so the
+            # element still draws in the default (data) transform.
+            low = transform_val.replace("\n", " ").replace(" ", "")
+            if "BboxTransformTo" in transform_val and (
+                "x1=1.0" in low or "Affine2D().scale" in transform_val
+            ):
+                kwargs["transform"] = ax.transAxes
+            else:
+                kwargs.pop("transform")
 
     # Fix fill_between: 'color' overrides 'edgecolor', use 'facecolor' instead
     if method_name in ("fill_between", "fill_betweenx"):

--- a/src/figrecipe/_reproducer/_scitex.py
+++ b/src/figrecipe/_reproducer/_scitex.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Replay for figrecipe's ``stx_*`` scitex-compat plot methods.
+
+These methods (recorded as ``stx_scatter_hist``, ``stx_raster``, ...) are
+implemented as *functions* that take a plain matplotlib ``Axes`` as the first
+argument (see ``figrecipe._scitex_compat``).  On replay the target is a raw
+matplotlib axes (e.g. the ``add_axes`` panel created by mm-composition), which
+does NOT carry the ``stx_*`` methods that ``RecordingAxes`` exposes — so a
+plain ``getattr(ax, "stx_scatter_hist")`` dispatch returns ``None`` and the
+call is silently dropped.  This module dispatches such calls to the underlying
+compat functions so the plot (and any marginal axes it creates internally via
+``make_axes_locatable``) is faithfully reconstructed.
+"""
+
+from typing import Any, Callable, Dict, Optional
+
+from matplotlib.axes import Axes
+
+from .._recorder import CallRecord
+
+
+def _resolve_stx_function(method_name: str) -> Optional[Callable]:
+    """Return the compat function for an ``stx_*`` method name, or None."""
+    # Import lazily so optional deps don't break import of this module.
+    try:
+        from .._scitex_compat import _heatmap, _scientific, _shaded_lines, _simple
+    except Exception:
+        return None
+
+    registry: Dict[str, Callable] = {}
+    for module in (_scientific, _shaded_lines, _simple, _heatmap):
+        for name in dir(module):
+            if name.startswith("stx_"):
+                registry[name] = getattr(module, name)
+    return registry.get(method_name)
+
+
+def replay_stx_call(
+    ax: Axes, call: CallRecord, result_cache: Optional[Dict[str, Any]] = None
+) -> Any:
+    """Replay an ``stx_*`` compat call on a (possibly raw) matplotlib axes.
+
+    Parameters
+    ----------
+    ax : Axes
+        Target matplotlib axes (raw or RecordingAxes-wrapped).
+    call : CallRecord
+        The recorded ``stx_*`` call.
+    result_cache : dict, optional
+        Cache mapping call_id -> result (for reference resolution).
+
+    Returns
+    -------
+    Any
+        Result of the compat function, or None if it could not be replayed.
+    """
+    from ._reconstruct import reconstruct_kwargs, reconstruct_value
+
+    func = _resolve_stx_function(call.function)
+    # Prefer a bound method when the axes already exposes it (RecordingAxes);
+    # this keeps behaviour identical to direct reproduce for wrapped axes.
+    bound = getattr(ax, call.function, None)
+
+    if func is None and bound is None:
+        return None
+
+    args = []
+    for arg_data in call.args:
+        args.append(reconstruct_value(arg_data, result_cache))
+    kwargs = reconstruct_kwargs(call.kwargs)
+
+    try:
+        if bound is not None and func is None:
+            return bound(*args, **kwargs)
+        # Compat functions take the raw mpl axes as the first positional arg.
+        mpl_ax = ax._ax if hasattr(ax, "_ax") else ax
+        return func(mpl_ax, *args, **kwargs)
+    except Exception as e:
+        import warnings
+
+        warnings.warn(f"Failed to replay {call.function}: {e}")
+        return None
+
+
+__all__ = ["replay_stx_call"]
+
+# EOF

--- a/tests/figrecipe/_composition/test__compose_replay_fidelity.py
+++ b/tests/figrecipe/_composition/test__compose_replay_fidelity.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression tests for mm-compose replay fidelity.
+
+Covers two previously-broken panel types when composed via mm-based
+``compose`` (smart recipe composer):
+
+1. MULTI-AXES figures (e.g. ``subplots(nrows=3, ncols=1)``) used to replay as
+   only the first axes; the other subplots were dropped because mm-compose only
+   fetched the default axes key from the source recipe.
+
+2. ``make_axes_locatable`` MARGINALS (``stx_scatter_hist``) used to vanish on
+   replay because ``stx_*`` methods were dispatched via ``getattr`` on a raw
+   matplotlib axes (which lacks them), silently dropping the call.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import pytest
+
+import figrecipe as fr
+
+
+@pytest.fixture
+def stacked_composed(tmp_path):
+    """Compose a 3-row source recipe into a single mm panel."""
+    fig, axes = fr.subplots(nrows=3, ncols=1)
+    for i, ax in enumerate(np.ravel(axes)):
+        ax.plot([0, 1, 2], [i, i + 1, i], id=f"line_{i}")
+    recipe = tmp_path / "stacked.yaml"
+    fr.save(fig, recipe, validate=False, verbose=False)
+
+    sources = {str(recipe): {"xy_mm": (0, 0), "size_mm": (80, 80)}}
+    comp_fig, _ = fr.compose(sources, canvas_size_mm=(90, 90))
+    return comp_fig.fig if hasattr(comp_fig, "fig") else comp_fig
+
+
+@pytest.fixture
+def joint_composed(tmp_path):
+    """Compose an stx_scatter_hist source recipe into a single mm panel."""
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=200)
+    y = rng.normal(size=200)
+
+    fig, ax = fr.subplots()
+    ax.stx_scatter_hist(x, y, kde=True, id="sh")
+    recipe = tmp_path / "joint.yaml"
+    fr.save(fig, recipe, validate=False, verbose=False)
+
+    sources = {str(recipe): {"xy_mm": (0, 0), "size_mm": (80, 80)}}
+    comp_fig, _ = fr.compose(sources, canvas_size_mm=(90, 90))
+    return comp_fig.fig if hasattr(comp_fig, "fig") else comp_fig
+
+
+def test_multiaxes_source_places_all_three_subplots(stacked_composed):
+    # Arrange
+    mpl = stacked_composed
+    # Act
+    n_axes = len(mpl.get_axes())
+    # Assert
+    assert n_axes == 3
+
+
+def test_multiaxes_subplots_each_keep_their_line(stacked_composed):
+    # Arrange
+    mpl = stacked_composed
+    # Act
+    line_counts = [len(a.lines) for a in mpl.get_axes()]
+    # Assert
+    assert all(n >= 1 for n in line_counts)
+
+
+def test_multiaxes_subplots_are_vertically_stacked(stacked_composed):
+    # Arrange
+    mpl = stacked_composed
+    # Act
+    bottoms = sorted(a.get_position().y0 for a in mpl.get_axes())
+    # Assert
+    assert bottoms[0] < bottoms[1] < bottoms[2]
+
+
+def test_scatter_hist_creates_main_plus_two_marginals(joint_composed):
+    # Arrange
+    mpl = joint_composed
+    # Act
+    n_axes = len(mpl.get_axes())
+    # Assert
+    assert n_axes >= 3
+
+
+def test_scatter_hist_scatter_collection_present(joint_composed):
+    # Arrange
+    mpl = joint_composed
+    # Act
+    has_scatter = any(len(a.collections) >= 1 for a in mpl.get_axes())
+    # Assert
+    assert has_scatter
+
+
+def test_scatter_hist_kde_marginal_lines_present(joint_composed):
+    # Arrange
+    mpl = joint_composed
+    # Act
+    has_marginal_lines = any(len(a.lines) >= 1 for a in mpl.get_axes())
+    # Assert
+    assert has_marginal_lines
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+
+# EOF


### PR DESCRIPTION
## Problem

The recorder writes valid recipes (PR #182) and mm-compose runs, but
recipe-REPLAY mangled two panel types when composed via the smart composer:

1. **Multi-axes figures** (`plt.subplots(nrows=3, ncols=1)`, e.g. the
   neurovista stacked raw-iEEG panel) replayed as only the **first** axes —
   the other subplots were dropped.
2. **`make_axes_locatable` marginals** (`stx_scatter_hist` jointplot) — the
   scatter + KDE marginals **vanished** on replay; only the legend remained.

## Root causes

1. `_compose_mm_based` fetched a single default `ax_key` from the source recipe
   and replayed it into one `add_axes` box, so all but the first subplot were
   ignored. Compounding this, `_capture_axes_bboxes` matched every mpl axes to
   the first record whose key-derived position equalled its own, so all
   subplots overwrote `r0c0`'s bbox and `r1c0`/`r2c0` got **no** bbox at all.
2. `stx_*` methods are functions taking a raw mpl axes as their first arg, but
   replay dispatched them via `getattr(ax, name)` on the raw `add_axes` panel
   (which lacks `stx_scatter_hist`), so the call was silently skipped — the
   marginals it creates internally via `make_axes_locatable` never ran.

## Fixes

- **bbox capture** (`_save_helpers`): map each `AxesRecord` to **its own** mpl
  axes via the wrapped `RecordingAxes` (`_position`/`_ax`), so every subplot
  records a correct bbox; marginal axes (unwrapped) are correctly skipped.
- **mm-compose** (`_compose`): for a plain recipe source (not an explicit
  `(source, ax_key)` tuple), place **all** of its axes into the panel,
  sub-dividing the panel rectangle by each axes' recorded bbox.
- **stx replay** (new `_reproducer/_scitex.py` + dispatch in `_replay_call`):
  route `stx_*` calls to the scitex-compat functions on the raw axes so plots
  and their `make_axes_locatable` marginals are reconstructed.
- **transform serialization** (`_recorder`): record `transform=ax.transAxes`
  as the `"axes"` marker; replay also guards against legacy stringified
  transforms (fixes a scalebar replay crash:
  `'str' object has no attribute 'contains_branch_seperately'`).
- **datetime axis limits**: replay parses ISO datetime strings for
  `set_xlim`/`set_ylim`/`axvline`/`axhline` so datetime-axis limits reapply
  instead of warning.
- Moved the module-level `render_compose_captions` import into
  `_compose_mm_based` (was only imported in the grid path).

## Verification

- `compose_fig01.py` (neurovista smart composer) now renders **all three**
  stacked raw-iEEG trace rows AND the jointplot scatter + KDE marginals, with
  **no replay warnings**.
- 268 existing composition/reproducer/recorder tests pass; 6 new regression
  tests (`test__compose_replay_fidelity.py`) cover both panel types.

Based on `fix/recipe-legend-handler-serialization` to retain the prior
KDE + suptitle + recorder fixes.