### PR TITLE
feat(style,legend): SCITEX signal/general line widths + stable separate-legend filename

### DIFF
--- a/src/figrecipe/_configure_mpl.py
+++ b/src/figrecipe/_configure_mpl.py
@@ -139,7 +139,12 @@ def configure_mpl(
         dpi_display = int(_s("output", "display_dpi", max(100, output_dpi // 3)))
 
     if line_width is None:
-        line_width = _s("lines", "trace_mm", 0.2) * _MM_TO_PT
+        # General/default ordinary line width (KDE curves, single plots, …).
+        # Falls back to trace_mm only on legacy presets without the key.
+        _general_mm = _s("lines", "linewidth_mm", None)
+        if _general_mm is None:
+            _general_mm = _s("lines", "trace_mm", 0.2)
+        line_width = _general_mm * _MM_TO_PT
 
     if n_ticks is None:
         n_ticks = int(_s("ticks", "n_ticks", 4))

--- a/src/figrecipe/_wrappers/_axes_helpers.py
+++ b/src/figrecipe/_wrappers/_axes_helpers.py
@@ -80,6 +80,30 @@ def inject_clip_on_from_style(kwargs: dict, method_name: str = None) -> dict:
     return kwargs
 
 
+def _resolve_signal_linewidth_token(kwargs: dict) -> dict:
+    """Resolve the special ``linewidth="signal"`` / ``lw="signal"`` token.
+
+    ``"signal"`` maps to the SCITEX style's thin signal-trace width
+    (``lines.signal_linewidth_mm``, ~0.12mm) converted to points. Numeric
+    linewidths pass through untouched. The token is resolved to a number
+    *before* the call is recorded, so recipe replay stays faithful (no
+    figrecipe-specific token leaks into the recorded kwargs).
+    """
+    from .._utils._units import mm_to_pt
+    from ..styles._style_loader import _STYLE_CACHE
+
+    for key in ("linewidth", "lw"):
+        if kwargs.get(key) == "signal":
+            signal_mm = 0.12
+            if _STYLE_CACHE is not None:
+                lines = _STYLE_CACHE.get("lines", {})
+                signal_mm = lines.get(
+                    "signal_linewidth_mm", lines.get("trace_mm", 0.12)
+                )
+            kwargs[key] = mm_to_pt(signal_mm)
+    return kwargs
+
+
 def inject_method_defaults(kwargs: dict, method_name: str) -> dict:
     """Inject method-specific defaults from SCITEX style.
 
@@ -96,6 +120,10 @@ def inject_method_defaults(kwargs: dict, method_name: str) -> dict:
         Updated kwargs with style defaults applied.
     """
     from ..styles._style_loader import _STYLE_CACHE
+
+    # Special linewidth token works regardless of whether a style is loaded
+    # (falls back to 0.12mm) and applies to every wrapped plotting method.
+    kwargs = _resolve_signal_linewidth_token(kwargs)
 
     if _STYLE_CACHE is None:
         return kwargs

--- a/src/figrecipe/_wrappers/_legend_wrapper.py
+++ b/src/figrecipe/_wrappers/_legend_wrapper.py
@@ -95,13 +95,39 @@ def _route_positional_loc(args: tuple, kwargs: dict) -> tuple:
     return args
 
 
-def _record_separate_legend(ax, kwargs: dict) -> None:
+def _stable_axis_id(ax, axis_id=None) -> str:
+    """Deterministic id for the separate-legend filename.
+
+    The downstream saver (scitex.io) builds the legend filename as
+    ``<figstem>_<axis_id>_legend.png``. Previously ``axis_id`` fell back
+    to ``hash(ax)``, which is non-deterministic across processes/renders,
+    so every render emitted a NEW file with a different id. We instead
+    derive a STABLE id from the axes' grid position (row, col), so the
+    same panel always writes the same ``_legend.png`` and overwrites in
+    place. Multiple distinct axes still get distinct (stable) ids.
+    """
+    if axis_id is not None:
+        return str(axis_id)
+    pos = getattr(ax, "_id", None)
+    if pos is not None:
+        return str(pos)
+    # Fallback: position within the figure's axes list (stable per figure).
+    try:
+        fig = ax.get_figure()
+        return f"ax{fig.axes.index(ax)}"
+    except (ValueError, AttributeError):
+        return "ax0"
+
+
+def _record_separate_legend(ax, kwargs: dict, axis_id=None) -> None:
     """Capture handles + labels onto fig._separate_legend_params.
 
     Implements the protocol that
     :func:`scitex.io._save_modules._legends.save_separate_legends`
     consumes — at save time, that function writes the legend to a
-    standalone file alongside the main figure.
+    standalone file alongside the main figure. ``axis_id`` is a STABLE
+    identifier (derived from the panel's grid position) so the legend
+    filename is deterministic and overwrites in place across renders.
     """
     h_kw = kwargs.pop("handles", None)
     l_kw = kwargs.pop("labels", None)
@@ -121,7 +147,7 @@ def _record_separate_legend(ax, kwargs: dict) -> None:
         {
             "handles": list(h_kw),
             "labels": list(l_kw),
-            "axis_id": getattr(ax, "_id", None) or hash(ax),
+            "axis_id": _stable_axis_id(ax, axis_id),
             "figsize": sep_kw.pop("figsize", (4, 2)),
             "frameon": sep_kw.pop("frameon", True),
             "fancybox": sep_kw.pop("fancybox", False),
@@ -131,7 +157,7 @@ def _record_separate_legend(ax, kwargs: dict) -> None:
     )
 
 
-def _resolve_loc_kwargs(ax, kwargs: dict) -> None:
+def _resolve_loc_kwargs(ax, kwargs: dict, axis_id=None) -> None:
     """Translate figrecipe-extended loc strings to matplotlib kwargs.
 
     Mutates *kwargs* in place. Falls back to ``loc='best'`` when the
@@ -146,7 +172,7 @@ def _resolve_loc_kwargs(ax, kwargs: dict) -> None:
             kwargs["loc"] = OUTER_VARIANTS[norm]["loc"]
             kwargs.setdefault("borderaxespad", 0.0)
         elif norm == "separate":
-            _record_separate_legend(ax, kwargs)
+            _record_separate_legend(ax, kwargs, axis_id=axis_id)
             outer = OUTER_VARIANTS["outer right"]
             kwargs["loc"] = outer["loc"]
             kwargs["bbox_to_anchor"] = outer["bbox_to_anchor"]
@@ -258,8 +284,14 @@ def build_legend_wrapper(recording_ax) -> Any:
         # Step 1: catch the `ax.legend('upper right')` anti-pattern.
         args = _route_positional_loc(args, kwargs)
 
-        # Step 2: resolve figrecipe-extended `loc=` strings.
-        _resolve_loc_kwargs(recording_ax._ax, kwargs)
+        # Step 2: resolve figrecipe-extended `loc=` strings. Pass the
+        # RecordingAxes' stable grid position so a 'separate' legend gets a
+        # deterministic filename (no random per-render id).
+        _pos = getattr(recording_ax, "_position", None)
+        _axis_id = (
+            "_".join(str(p) for p in _pos) if isinstance(_pos, (tuple, list)) else _pos
+        )
+        _resolve_loc_kwargs(recording_ax._ax, kwargs, axis_id=_axis_id)
 
         # Step 3: call matplotlib.
         legend = original_legend(*args, **kwargs)

--- a/src/figrecipe/styles/_kwargs_converter.py
+++ b/src/figrecipe/styles/_kwargs_converter.py
@@ -57,6 +57,13 @@ def to_subplots_kwargs(style: Optional["DotDict"] = None) -> Dict[str, Any]:
         "ticks_n_ticks_max": style.ticks.get("n_ticks_max", 4),
         # Lines (lines.* in YAML)
         "lines_trace_mm": style.lines.trace_mm,
+        # General/default ordinary line width (KDE curves, single plots, …).
+        # Falls back to the signal/trace width on legacy presets without it.
+        "lines_linewidth_mm": style.lines.get("linewidth_mm", style.lines.trace_mm),
+        # Thin width for dense signal traces (opt-in token lw="signal").
+        "lines_signal_linewidth_mm": style.lines.get(
+            "signal_linewidth_mm", style.lines.trace_mm
+        ),
         "lines_errorbar_mm": style.lines.get("errorbar_mm", 0.12),
         "lines_errorbar_cap_mm": style.lines.get("errorbar_cap_mm", 0.8),
         "lines_grid_mm": style.lines.get("grid_mm"),

--- a/src/figrecipe/styles/_style_applier.py
+++ b/src/figrecipe/styles/_style_applier.py
@@ -178,9 +178,18 @@ def apply_style_mm(ax: Axes, style: Dict[str, Any]) -> float:
     if style.get("hide_right_spine", True):
         ax.spines["right"].set_visible(False)
 
-    # Convert trace thickness from mm to points and set as default line width
+    # Set matplotlib's default line width from the GENERAL/default line width
+    # (lines.linewidth_mm; ~0.8mm). Ordinary lines (KDE curves, single plots)
+    # that pass no lw= inherit this. The thin signal/trace width is opt-in via
+    # lw="signal". Fall back to trace_thickness_mm on legacy presets.
+    general_lw_mm = style.get(
+        "lines_linewidth_mm", style.get("trace_thickness_mm", 0.3)
+    )
+    general_lw_pt = mm_to_pt(general_lw_mm)
+    mpl.rcParams["lines.linewidth"] = general_lw_pt
+    # Preserve the trace/signal line width for the documented return value
+    # (callers use it as ax.plot(..., lw=trace_lw) for dense signal traces).
     trace_lw_pt = mm_to_pt(style.get("trace_thickness_mm", 0.3))
-    mpl.rcParams["lines.linewidth"] = trace_lw_pt
 
     # Grid line width — update both rcParams (for future gridlines) and
     # existing gridline objects (created at axes init with default linewidth)

--- a/src/figrecipe/styles/presets/SCITEX.yaml
+++ b/src/figrecipe/styles/presets/SCITEX.yaml
@@ -41,7 +41,16 @@ padding:
   title_pt: 4.0
 
 lines:
-  trace_mm: 0.12
+  # Two semantic line widths:
+  #   - signal_linewidth_mm: very thin, for DENSE signal traces (EEG/iEEG,
+  #     spectra) where many overlapping lines must stay legible. Opt in via
+  #     lw="signal" / linewidth="signal" on wrapped plotting methods.
+  #   - linewidth_mm: the GENERAL/default width used by ordinary lines
+  #     (KDE curves, single plots, etc.). Pushed onto matplotlib's
+  #     rcParam lines.linewidth so plt.plot()/ax.plot() inherit it.
+  signal_linewidth_mm: 0.12   # Dense signal traces (opt-in token "signal")
+  linewidth_mm: 0.8           # General/default ordinary line width
+  trace_mm: 0.12              # Back-compat alias of signal_linewidth_mm
   errorbar_mm: 0.12
   errorbar_cap_mm: 0.8
   grid_mm: 0.12

--- a/tests/figrecipe/_wrappers/test__axes_helpers.py
+++ b/tests/figrecipe/_wrappers/test__axes_helpers.py
@@ -4,7 +4,6 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-
 import pytest
 
 
@@ -13,8 +12,50 @@ def test_import__wrappers__axes_helpers_module():
     # Arrange
     # Act
     # Assert
-    module_path = 'figrecipe._wrappers._axes_helpers'
+    module_path = "figrecipe._wrappers._axes_helpers"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+def test_lw_signal_token_resolves_to_signal_width_pt():
+    """lw='signal' maps to the SCITEX style's signal width in points."""
+    # Arrange
+    import figrecipe as fr
+    from figrecipe._utils._units import mm_to_pt
+    from figrecipe._wrappers._axes_helpers import _resolve_signal_linewidth_token
+
+    fr.load_style("SCITEX")
+    expected_pt = mm_to_pt(0.12)  # SCITEX signal_linewidth_mm
+    # Act
+    out = _resolve_signal_linewidth_token({"lw": "signal"})
+    # Assert
+    assert abs(out["lw"] - expected_pt) < 1e-6
+
+
+def test_linewidth_signal_token_resolves_to_signal_width_pt():
+    """linewidth='signal' maps to the SCITEX style's signal width in points."""
+    # Arrange
+    import figrecipe as fr
+    from figrecipe._utils._units import mm_to_pt
+    from figrecipe._wrappers._axes_helpers import _resolve_signal_linewidth_token
+
+    fr.load_style("SCITEX")
+    expected_pt = mm_to_pt(0.12)
+    # Act
+    out = _resolve_signal_linewidth_token({"linewidth": "signal"})
+    # Assert
+    assert abs(out["linewidth"] - expected_pt) < 1e-6
+
+
+def test_numeric_linewidth_passes_through_token_resolver():
+    """Numeric linewidths are left untouched by the token resolver."""
+    # Arrange
+    from figrecipe._wrappers._axes_helpers import _resolve_signal_linewidth_token
+
+    kwargs = {"lw": 3.0}
+    # Act
+    out = _resolve_signal_linewidth_token(kwargs)
+    # Assert
+    assert out["lw"] == 3.0

--- a/tests/figrecipe/_wrappers/test__legend_wrapper.py
+++ b/tests/figrecipe/_wrappers/test__legend_wrapper.py
@@ -1,0 +1,76 @@
+"""Tests for figrecipe._wrappers._legend_wrapper.
+
+Covers the deterministic ('stable') filename behaviour of the
+``loc='separate'`` legend path: the recorded ``axis_id`` must be derived
+from the panel's grid position so the downstream
+``<figstem>_<axis_id>_legend.png`` filename is stable across renders.
+"""
+
+import pytest
+
+
+def test_import__wrappers__legend_wrapper_module():
+    # Arrange
+    module_path = "figrecipe._wrappers._legend_wrapper"
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path
+
+
+def test_separate_legend_axis_id_is_stable_across_renders():
+    """Re-rendering the same panel yields the same separate-legend axis_id."""
+    # Arrange
+    import matplotlib.pyplot as plt
+
+    import figrecipe as fr
+
+    fr.load_style("SCITEX")
+    ids = []
+    # Act
+    for _ in range(3):
+        fig, ax = fr.subplots()
+        ax.plot([0, 1, 2], [0, 1, 0], label="A")
+        ax.legend(loc="separate")
+        ids.append(fig._separate_legend_params[0]["axis_id"])
+        plt.close(fig)
+    # Assert
+    assert ids[0] == ids[1] == ids[2]
+
+
+def test_separate_legend_axis_id_is_not_random_hash():
+    """The axis_id is a stable position string, not a per-process hash."""
+    # Arrange
+    import matplotlib.pyplot as plt
+
+    import figrecipe as fr
+
+    fr.load_style("SCITEX")
+    fig, ax = fr.subplots()
+    ax.plot([0, 1], [0, 1], label="A")
+    # Act
+    ax.legend(loc="separate")
+    axis_id = fig._separate_legend_params[0]["axis_id"]
+    plt.close(fig)
+    # Assert
+    assert axis_id == "0_0"
+
+
+def test_separate_legends_get_distinct_stable_ids_per_panel():
+    """Distinct panels produce distinct (but stable) separate-legend ids."""
+    # Arrange
+    import matplotlib.pyplot as plt
+
+    import figrecipe as fr
+
+    fr.load_style("SCITEX")
+    fig, axes = fr.subplots(1, 2)
+    axes[0].plot([0, 1], [0, 1], label="L")
+    axes[1].plot([0, 1], [1, 0], label="R")
+    # Act
+    axes[0].legend(loc="separate")
+    axes[1].legend(loc="separate")
+    ids = [p["axis_id"] for p in fig._separate_legend_params]
+    plt.close(fig)
+    # Assert
+    assert len(set(ids)) == 2


### PR DESCRIPTION
Stacks on `fix/recipe-replay-multiaxes-marginals` (the currently editable-installed branch) to retain all prior replay/legend fixes.

## Improvement 1 — two SCITEX line widths (signal vs general)
Operator: lines need a SIGNAL width (~0.12 mm, dense EEG/iEEG traces) and a GENERAL width (~0.8 mm) used by default for ordinary lines (KDE curves, etc.). Previously ordinary lines inherited the too-thin 0.12 mm.

- `styles/presets/SCITEX.yaml` → `lines:` adds `signal_linewidth_mm: 0.12` and `linewidth_mm: 0.8`; `trace_mm` kept as a back-compat alias of the signal width.
- `apply_style_mm` sets matplotlib's `rcParams["lines.linewidth"]` from the GENERAL width (`lines_linewidth_mm`, ~0.8 mm) so ordinary lines that pass no `lw=` render at 0.8 mm. It still computes and returns the trace/signal width for callers that draw dense signal traces. `_configure_mpl` falls back to the general width too.
- `_kwargs_converter` exposes `lines_linewidth_mm` + `lines_signal_linewidth_mm` (fall back to `trace_mm` on legacy presets).
- New special token: `lw="signal"` / `linewidth="signal"` on wrapped plotting methods resolves — via the shared `inject_method_defaults` path — to the style's signal width in **points** (`mm/25.4*72`) before the call is recorded, so recipe replay stays faithful. Numeric linewidths pass through unchanged.
- `stx_scatter_hist` KDE marginals (drawn on raw mpl axes with no `lw`) now inherit the 0.8 mm default → visibly thicker.

## Improvement 2 — stable `loc="separate"` legend filename (no random ids)
`ax.legend(loc="separate")` recorded `axis_id = hash(ax)`, non-deterministic per process/render, so the downstream saver wrote a new `<figstem>_<randomid>_legend.png` on every render (operator saw many `fig01b_..._<id>_legend.png` accumulate).

- `_legend_wrapper` now derives `axis_id` deterministically from the RecordingAxes grid position (`row_col`), so the saver writes a stable `<figstem>_<row_col>_legend.png` and overwrites in place. Distinct panels still get distinct stable ids.

## Tests
- Real regression tests for the signal-width token (replacing the `_axes_helpers` placeholder) and a new `_legend_wrapper` mirror asserting the stable, non-random, per-panel-distinct `axis_id`.

## Verification (neurovista venv, editable install of this branch)
- `lines.linewidth` after `subplots()` = 2.268 pt (≈0.8 mm); `lw="signal"` / `linewidth="signal"` = 0.34 pt (≈0.12 mm); numeric passthrough intact.
- `scripts/dataset/visualization/plot_fig01b_pat10_jointplot.py` runs; KDE marginal curves render as solid ~0.8 mm lines (no longer hairline).
- End-to-end `stx.io.save` across 2 renders produces a single stable `myfig_0_0_legend.png` (overwritten, no accumulation).
- Touched-area tests pass (90 in styles+wrappers+reproducer; 10 in the new/edited files).