### PR TITLE
feat(compose): crop-aware mm-composition (tight content tiling + style/suptitle fidelity)

### DIFF
--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 # Import helpers from separate module
-from ._save_helpers import _capture_axes_bboxes
+from ._save_helpers import _capture_axes_bboxes, _capture_content_layout
 from ._save_helpers import (
     save_hitmap as _save_hitmap,
 )
@@ -433,6 +433,7 @@ def save_figure(
 
     # Capture axes bounding boxes (adjusted for crop if cropping occurred)
     _capture_axes_bboxes(fig, crop_offset)
+    _capture_content_layout(fig)  # tight-content layout for crop-aware compose
 
     # Store crop info in record for future reference
     if crop_offset is not None:

--- a/src/figrecipe/_api/_save_helpers.py
+++ b/src/figrecipe/_api/_save_helpers.py
@@ -7,6 +7,12 @@ from typing import Optional
 
 from .._utils._grid import grid_id
 
+# stx_* plotters that build their own make_axes_locatable marginals at draw
+# time and re-build them on replay. Their recorded axes is the POST-divide
+# (shrunken) main axes, so for crop-aware compose we record its PRE-divide
+# extent (union with the marginals) -- see _capture_content_layout.
+_DIVIDER_PLOTTERS = {"stx_scatter_hist"}
+
 
 def _crop_to_axes_size(
     fig,
@@ -229,6 +235,8 @@ def _capture_content_layout(fig) -> None:
             fig.record.content_bbox = cb
             fig.record.content_size_mm = [cb[2] * fw_in * 25.4, cb[3] * fh_in * 25.4]
 
+        recorded_ids = set()
+        divider_axes = []  # (ax_record, center_x, center_y) for re-splitting plots
         for row in fig.axes:
             for rec_ax in row:
                 mpl_ax = getattr(rec_ax, "_ax", rec_ax)
@@ -240,6 +248,29 @@ def _capture_content_layout(fig) -> None:
                     continue
                 pos = mpl_ax.get_position()
                 ax_record.bbox_uncropped = [pos.x0, pos.y0, pos.width, pos.height]
+                recorded_ids.add(id(mpl_ax))
+                if any(c.function in _DIVIDER_PLOTTERS for c in ax_record.calls):
+                    divider_axes.append(
+                        (ax_record, pos.x0 + pos.width / 2, pos.y0 + pos.height / 2)
+                    )
+
+        # make_axes_locatable marginals are NOT recorded as RecordingAxes, so a
+        # divider plotter's axes is captured at its POST-divide (shrunken) size.
+        # The plotter re-splits on replay, so place it at the PRE-divide extent:
+        # union each divider axes with its nearest un-recorded marginal axes.
+        for m in mpl_fig.get_axes() if divider_axes else []:
+            if id(m) in recorded_ids:
+                continue
+            mp = m.get_position()
+            mcx, mcy = mp.x0 + mp.width / 2, mp.y0 + mp.height / 2
+            rec = min(
+                divider_axes, key=lambda d: (d[1] - mcx) ** 2 + (d[2] - mcy) ** 2
+            )[0]
+            bx0, by0, bw, bh = rec.bbox_uncropped
+            nx0, ny0 = min(bx0, mp.x0), min(by0, mp.y0)
+            nx1 = max(bx0 + bw, mp.x0 + mp.width)
+            ny1 = max(by0 + bh, mp.y0 + mp.height)
+            rec.bbox_uncropped = [nx0, ny0, nx1 - nx0, ny1 - ny0]
     except Exception:
         pass
 

--- a/src/figrecipe/_api/_save_helpers.py
+++ b/src/figrecipe/_api/_save_helpers.py
@@ -190,6 +190,60 @@ def _capture_axes_bboxes(fig, crop_offset: Optional[dict] = None) -> None:
                 fig.record.axes[key].bbox = _to_cropped(mpl_ax.get_position())
 
 
+def _capture_content_layout(fig) -> None:
+    """Record the tight content layout for crop-aware composition.
+
+    Captures, into ``fig.record``:
+      * ``content_bbox``  -- the figure's tight ink bbox [l, b, w, h] in the
+        *uncropped* figure fraction (from ``get_tightbbox``); includes axis
+        labels, ticks, titles, legends and make_axes_locatable marginals, and
+        may exceed [0, 1] when content overflows the canvas.
+      * ``content_size_mm`` -- that bbox's [w, h] in millimetres.
+      * per-axes ``bbox_uncropped`` -- each axes' ``get_position()`` in the
+        uncropped fraction.
+
+    All values are dpi-independent fractions/mm, so a composer can size and
+    place each panel by its true (cropped) extent and reproduce the clean
+    standalone render pixel-for-pixel. Best-effort: failures leave the fields
+    unset and the composer falls back to the legacy ``bbox`` path.
+    """
+    mpl_fig = fig.fig
+    try:
+        mpl_fig.canvas.draw()
+        renderer = mpl_fig.canvas.get_renderer()
+        tight = mpl_fig.get_tightbbox(renderer)
+    except Exception:
+        tight = None
+
+    # Everything below is best-effort: any failure leaves the fields unset and
+    # the composer falls back to the legacy bbox path -- never crash a save.
+    try:
+        fw_in, fh_in = (float(v) for v in mpl_fig.get_size_inches())
+        if tight is not None and fw_in > 0 and fh_in > 0:
+            cb = [
+                tight.x0 / fw_in,
+                tight.y0 / fh_in,
+                tight.width / fw_in,
+                tight.height / fh_in,
+            ]
+            fig.record.content_bbox = cb
+            fig.record.content_size_mm = [cb[2] * fw_in * 25.4, cb[3] * fh_in * 25.4]
+
+        for row in fig.axes:
+            for rec_ax in row:
+                mpl_ax = getattr(rec_ax, "_ax", rec_ax)
+                position = getattr(rec_ax, "_position", None)
+                if position is None:
+                    continue
+                ax_record = fig.record.axes.get(grid_id(position[0], position[1]))
+                if ax_record is None:
+                    continue
+                pos = mpl_ax.get_position()
+                ax_record.bbox_uncropped = [pos.x0, pos.y0, pos.width, pos.height]
+    except Exception:
+        pass
+
+
 def save_hitmap(
     fig,
     image_path: Path,

--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -16,6 +16,7 @@ from numpy.typing import NDArray
 from .._recorder import FigureRecord
 from .._utils._grid import grid_id, parse_grid_id
 from .._wrappers import RecordingAxes, RecordingFigure
+from ._crop_aware import _apply_source_style, panel_rel_bbox, replay_panel_suptitle
 from ._source_parser import is_image_file as _is_image_file  # noqa: F401
 from ._source_parser import parse_source_spec_with_key as _parse_source_spec_with_key
 from ._source_parser import parse_source_spec_with_path as _parse_source_spec_with_path
@@ -313,14 +314,11 @@ def _compose_mm_based(
                 data_dir = candidate
 
         for src_key, ax_record in selected.items():
-            # Place this source-axes inside the panel rectangle, preserving its
-            # relative position/size within the original figure when a bbox was
-            # recorded. Without a bbox (single-axes panels), fill the panel.
-            bbox = getattr(ax_record, "bbox", None)
-            if bbox is not None and len(bbox) == 4:
-                bx0, by0, bw, bh = bbox
-            else:
-                bx0, by0, bw, bh = 0.0, 0.0, 1.0, 1.0
+            # Place this source-axes inside the panel rectangle relative to the
+            # source's tight content box (crop-aware), so the composed panel
+            # matches the clean cropped standalone render. Falls back to the
+            # legacy cropped-fraction bbox for older recipes.
+            bx0, by0, bw, bh = panel_rel_bbox(source_record, ax_record)
 
             sub_left = panel_left + bx0 * panel_width
             sub_bottom = panel_bottom + by0 * panel_height
@@ -328,6 +326,9 @@ def _compose_mm_based(
             sub_height = bh * panel_height
 
             mpl_ax = mpl_fig.add_axes([sub_left, sub_bottom, sub_width, sub_height])
+            # Match the panel's publication font/style so replayed text metrics
+            # equal the standalone render (else long tick labels clip).
+            _apply_source_style(mpl_ax, source_record)
 
             target_ax = RA(mpl_ax, recorder, position=(0, sub_idx))
             axes_list.append(target_ax)
@@ -340,6 +341,9 @@ def _compose_mm_based(
                 source_data_dirs[f"ax_mm_{sub_idx}"] = data_dir
 
             sub_idx += 1
+        replay_panel_suptitle(
+            mpl_fig, source_record, panel_left, panel_bottom, panel_width, panel_height
+        )
 
     fig = RF(mpl_fig, recorder, axes_list)
 

--- a/src/figrecipe/_composition/_crop_aware.py
+++ b/src/figrecipe/_composition/_crop_aware.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Crop-aware panel placement for mm-based composition.
+
+Maps a source axes into its panel rectangle using the *tight content box*
+captured at save time (``FigureRecord.content_bbox`` +
+``AxesRecord.bbox_uncropped``), so a composed panel reproduces the clean,
+cropped standalone render instead of the padded ``figsize``. This is what makes
+``fr.compose`` tile panels with no clipped tick labels and no dead space
+between the panel label and the plot.
+
+Falls back to the legacy cropped-fraction ``bbox`` (and finally to filling the
+whole panel) when the crop-aware fields are absent, so recipes written by older
+figrecipe versions still compose without error.
+"""
+
+from typing import Tuple
+
+
+def panel_rel_bbox(source_record, ax_record) -> Tuple[float, float, float, float]:
+    """Return an axes' (left, bottom, width, height) within its panel rectangle.
+
+    The returned fractions are relative to the panel rectangle. When the caller
+    sizes that rectangle to the source's ``content_size_mm`` (recommended; the
+    neurovista/smart composer does), the axes reproduces the standalone layout
+    1:1; with any other panel size the content simply scales to fit. Preference:
+
+    1. Crop-aware -- ``bbox_uncropped`` expressed relative to the figure's tight
+       ``content_bbox`` (panel == tight content; labels/marginals included).
+    2. Legacy -- the cropped-fraction ``bbox`` (panel == cropped image).
+    3. Fill the whole panel.
+
+    Values are normally in [0, 1]; they may slightly exceed it when the source
+    content overflowed its canvas (the panel is sized to include the overflow).
+    """
+    content_bbox = getattr(source_record, "content_bbox", None)
+    ub = getattr(ax_record, "bbox_uncropped", None)
+    if (
+        content_bbox is not None
+        and len(content_bbox) == 4
+        and ub is not None
+        and len(ub) == 4
+    ):
+        cx0, cy0, cw, ch = content_bbox
+        if cw > 0 and ch > 0:
+            return (ub[0] - cx0) / cw, (ub[1] - cy0) / ch, ub[2] / cw, ub[3] / ch
+
+    bbox = getattr(ax_record, "bbox", None)
+    if bbox is not None and len(bbox) == 4:
+        return bbox[0], bbox[1], bbox[2], bbox[3]
+
+    return 0.0, 0.0, 1.0, 1.0
+
+
+def _apply_source_style(mpl_ax, source_record) -> None:
+    """Apply a source panel's recorded style to its composed axes.
+
+    The composed figure is created with a bare matplotlib figure, so without
+    this the replayed text renders in matplotlib's default (wide) font instead
+    of the panel's publication font -- which shifts text metrics and clips long
+    tick labels. Re-applying the style (font family + sizes, spines, ticks) is
+    exactly what ``fr.subplots`` does for a standalone panel, so a composed
+    panel reproduces the standalone text metrics. Best-effort.
+    """
+    style = getattr(source_record, "style", None)
+    if not style:
+        try:
+            from ..presets._scitex_style import SCITEX_STYLE
+
+            style = SCITEX_STYLE if isinstance(SCITEX_STYLE, dict) else None
+        except Exception:
+            style = None
+    if not style:
+        return
+    try:
+        from ..styles._internal import apply_style_mm
+
+        apply_style_mm(mpl_ax, style)
+    except Exception:
+        pass
+
+
+def replay_panel_suptitle(mpl_fig, source_record, left, bottom, width, height) -> None:
+    """Replay a source panel's figure ``suptitle`` as panel-local text.
+
+    Compose does not replay figure-level suptitles, yet the tight
+    ``content_bbox`` reserved space for it -- leaving an empty band above the
+    panel. Re-drawing the suptitle centred at the top of the panel rectangle
+    fills that band and preserves the panel's identity (e.g. "Patient #10")
+    instead of a gap. Best-effort; only safe text kwargs are forwarded.
+    """
+    sup = getattr(source_record, "suptitle", None)
+    if not sup or not sup.get("text"):
+        return
+    src_kw = sup.get("kwargs") or {}
+    kw = {
+        k: src_kw[k]
+        for k in ("fontsize", "fontweight", "color", "family")
+        if k in src_kw
+    }
+    try:
+        mpl_fig.text(
+            left + width / 2.0,
+            bottom + height,
+            sup["text"],
+            ha="center",
+            va="top",
+            **kw,
+        )
+    except Exception:
+        pass
+
+
+__all__ = ["panel_rel_bbox", "_apply_source_style", "replay_panel_suptitle"]
+
+# EOF

--- a/src/figrecipe/_recorder/_core.py
+++ b/src/figrecipe/_recorder/_core.py
@@ -73,9 +73,12 @@ class AxesRecord:
     stats: Optional[Dict[str, Any]] = None
     # Panel visibility (for composition)
     visible: bool = True
-    # Axes bounding box in figure coordinates [left, bottom, width, height]
-    # Enables alignment/snap functionality
+    # Axes bbox [left, bottom, width, height] in the *cropped* image fraction
+    # (see _capture_axes_bboxes) -- used for alignment/snap.
     bbox: Optional[List[float]] = None
+    # Same, but in the *uncropped* figure fraction (mpl ax.get_position()).
+    # Paired with FigureRecord.content_bbox it lets compose tile crop-aware.
+    bbox_uncropped: Optional[List[float]] = None
 
     def add_call(self, record: CallRecord) -> None:
         """Add a plotting call record."""
@@ -93,6 +96,8 @@ class AxesRecord:
         }
         if self.bbox is not None:
             result["bbox"] = self.bbox
+        if self.bbox_uncropped is not None:
+            result["bbox_uncropped"] = self.bbox_uncropped
         if self.caption is not None:
             result["caption"] = self.caption
         if self.stats is not None:
@@ -134,6 +139,11 @@ class FigureRecord:
     stats: Optional[Dict[str, Any]] = None
     # Crop information for post-save cropping (enables correct bbox recalculation)
     crop_info: Optional[Dict[str, Any]] = None
+    # Tight content bbox [l, b, w, h] in *uncropped* figure fraction (from
+    # get_tightbbox): real ink extent; may exceed [0,1]. Crop-aware compose.
+    content_bbox: Optional[List[float]] = None
+    # Tight content size [w_mm, h_mm] (content_bbox x figsize). dpi-independent.
+    content_size_mm: Optional[List[float]] = None
     # mm_layout for auto-cropping during save (enables consistent cropping on reproduce)
     mm_layout: Optional[Dict[str, Any]] = None
     # Source data directories for composition (enables symlinks instead of copying)
@@ -205,6 +215,11 @@ class FigureRecord:
         # Add crop_info if set (for bbox recalculation after cropping)
         if self.crop_info is not None:
             result["figure"]["crop_info"] = self.crop_info
+        # Add tight-content layout if captured (for crop-aware composition)
+        if self.content_bbox is not None:
+            result["figure"]["content_bbox"] = self.content_bbox
+        if self.content_size_mm is not None:
+            result["figure"]["content_size_mm"] = self.content_size_mm
         # Add mm_layout if set (for consistent cropping on reproduce)
         if self.mm_layout is not None:
             result["figure"]["mm_layout"] = self.mm_layout
@@ -239,6 +254,8 @@ class FigureRecord:
             caption=metadata.get("caption"),
             stats=metadata.get("stats"),
             crop_info=fig_data.get("crop_info"),
+            content_bbox=fig_data.get("content_bbox"),
+            content_size_mm=fig_data.get("content_size_mm"),
             mm_layout=fig_data.get("mm_layout"),
             colorbars=fig_data.get("colorbars", []),
             figure_panel_captions=fig_data.get("panel_captions"),
@@ -256,6 +273,7 @@ class FigureRecord:
                 stats=ax_data.get("stats"),
                 visible=ax_data.get("visible", True),
                 bbox=ax_data.get("bbox"),
+                bbox_uncropped=ax_data.get("bbox_uncropped"),
             )
             for call_data in ax_data.get("calls", []):
                 ax_record.calls.append(CallRecord.from_dict(call_data, (row, col)))

--- a/src/figrecipe/_reproducer/_legend.py
+++ b/src/figrecipe/_reproducer/_legend.py
@@ -36,19 +36,40 @@ def replay_legend_call(
     args = [reconstruct_value(arg_data, result_cache) for arg_data in call.args]
     kwargs = reconstruct_kwargs(call.kwargs)
 
-    # Handle custom handles stored as _handle_specs
+    # Rebuild custom legend handles from their recorded specs, reproducing the
+    # original swatch type: a Line2D (colour + marker, e.g. scatter legends) or
+    # a Patch (filled rectangle). Older recipes stored only facecolor/edgecolor
+    # with no "kind" -> fall through to Patch (back-compat).
     if "_handle_specs" in kwargs:
+        from matplotlib.lines import Line2D
         from matplotlib.patches import Patch
 
-        handle_specs = kwargs.pop("_handle_specs")
         handles = []
-        for spec in handle_specs:
-            patch = Patch(
-                facecolor=spec.get("facecolor", "gray"),
-                edgecolor=spec.get("edgecolor", "black"),
-                label=spec.get("label", ""),
-            )
-            handles.append(patch)
+        for spec in kwargs.pop("_handle_specs"):
+            if spec.get("kind") == "line" or "marker" in spec:
+                color = spec.get("color", "gray")
+                handles.append(
+                    Line2D(
+                        [],
+                        [],
+                        color=color,
+                        marker=spec.get("marker", "o"),
+                        markersize=spec.get("markersize", 6),
+                        markerfacecolor=spec.get("markerfacecolor", color),
+                        markeredgecolor=spec.get("markeredgecolor", "none"),
+                        linestyle=spec.get("linestyle", "none"),
+                        linewidth=spec.get("linewidth", 0),
+                        label=spec.get("label", ""),
+                    )
+                )
+            else:
+                handles.append(
+                    Patch(
+                        facecolor=spec.get("facecolor", "gray"),
+                        edgecolor=spec.get("edgecolor", "black"),
+                        label=spec.get("label", ""),
+                    )
+                )
         kwargs["handles"] = handles
 
     # Drop figrecipe-internal metadata keys (underscore-prefixed) that

--- a/src/figrecipe/_serializer/_clew.py
+++ b/src/figrecipe/_serializer/_clew.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Loosely-coupled scitex-clew provenance recording for figrecipe I/O.
+
+figrecipe records the recipe + data files it writes/reads with scitex-clew
+WHEN clew is installed and a ``@stx.session`` is active, so figures and
+compositions become nodes in the Clew provenance DAG: a composed figure's
+recipe -> its source panel recipes/data -> ... -> raw data. This is what keeps
+the provenance chain connected through composition.
+
+Loosely coupled, leaf-respecting (scitex-clew depends on nothing; producers opt
+in): clew is reached via scitex-dev's ``try_import_optional`` -- if clew (or
+scitex-dev) is absent, or no session is active, every call is a no-op.
+Recording is best-effort *observability*; a failure here is logged at debug and
+never breaks figrecipe's real save/load (which stays fail-loud on data errors).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Union
+
+_logger = logging.getLogger(__name__)
+
+
+def _active_tracker():
+    """Return scitex-clew's active-session tracker, or None (no-op safe)."""
+    try:
+        from scitex_dev import try_import_optional
+
+        clew = try_import_optional("scitex_clew")
+        if clew is None:
+            return None
+        return clew.get_tracker()
+    except Exception as exc:  # optional path: clew/scitex-dev unavailable
+        _logger.debug("figrecipe: scitex-clew unavailable (%s)", exc)
+        return None
+
+
+def record_output(path: Union[str, Path]) -> None:
+    """Record ``path`` as a clew output of the active session (best-effort)."""
+    tracker = _active_tracker()
+    if tracker is None:
+        return
+    try:
+        tracker.record_output(str(path))
+    except Exception as exc:  # never break the real save
+        _logger.debug("figrecipe: clew record_output(%s) failed: %s", path, exc)
+
+
+def record_input(path: Union[str, Path]) -> None:
+    """Record ``path`` as a clew input of the active session (best-effort).
+
+    clew auto-links the session(s) that produced ``path`` as parents, which is
+    what connects a composed figure to its source panels.
+    """
+    tracker = _active_tracker()
+    if tracker is None:
+        return
+    try:
+        tracker.record_input(str(path))
+    except Exception as exc:  # never break the real load
+        _logger.debug("figrecipe: clew record_input(%s) failed: %s", path, exc)
+
+
+__all__ = ["record_input", "record_output"]
+
+# EOF

--- a/src/figrecipe/_serializer/_load.py
+++ b/src/figrecipe/_serializer/_load.py
@@ -14,6 +14,7 @@ from .._utils._numpy_io import (
     load_array,
     load_single_csv,
 )
+from ._clew import record_input
 
 
 def _convert_diagram_to_figure_recipe(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -97,6 +98,12 @@ def load_recipe(path: Union[str, Path]) -> FigureRecord:
         Loaded figure record.
     """
     path = Path(path)
+
+    # Record the recipe as a clew input of the active session (no-op without
+    # clew). When compose loads its source panel recipes, clew auto-links the
+    # panel sessions that produced them -> the provenance chain stays connected
+    # through composition.
+    record_input(path)
 
     yaml = YAML()
     with open(path) as f:
@@ -183,6 +190,7 @@ def _resolve_data_references(
 
                             # Store source file path for symlink support
                             arg["_source_file"] = str(file_path.resolve())
+                            record_input(file_path)  # clew: data file as input
                         else:
                             # Fail loud: a referenced data file that does not
                             # exist (e.g. a broken/stale compose symlink) must

--- a/src/figrecipe/_serializer/_load.py
+++ b/src/figrecipe/_serializer/_load.py
@@ -183,6 +183,17 @@ def _resolve_data_references(
 
                             # Store source file path for symlink support
                             arg["_source_file"] = str(file_path.resolve())
+                        else:
+                            # Fail loud: a referenced data file that does not
+                            # exist (e.g. a broken/stale compose symlink) must
+                            # NOT silently fall through and leave the path string
+                            # as the arg -- that surfaces later as a cryptic
+                            # "not a valid format string" deep in matplotlib.
+                            raise FileNotFoundError(
+                                f"recipe data file not found: {file_path} "
+                                f"(referenced as '{data_ref}'). Fix the source "
+                                f"data; do not reproduce from a broken recipe."
+                            )
 
     return data
 

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -173,11 +173,22 @@ def _process_arrays_with_symlinks(
                         source_file = Path(source_file_path)
                         target_path = data_dir / source_file.name
 
-                        if not target_path.exists() and source_file.exists():
-                            rel_source = os.path.relpath(
-                                source_file, target_path.parent
+                        # Fail loud: composition references the REAL source data
+                        # (single source of truth); a missing source must never
+                        # produce a silently-broken recipe symlink.
+                        if not source_file.exists():
+                            raise FileNotFoundError(
+                                f"compose source data file missing: {source_file} "
+                                f"(call {call_id}). Cannot create a valid data "
+                                f"symlink for the composed recipe."
                             )
-                            os.symlink(rel_source, target_path)
+                        # Refresh: drop any stale/broken link left by a prior run
+                        # so the symlink always points at the CURRENT source, never
+                        # a renamed/moved phantom.
+                        if target_path.is_symlink() or target_path.exists():
+                            target_path.unlink()
+                        rel_source = os.path.relpath(source_file, target_path.parent)
+                        os.symlink(rel_source, target_path)
 
                         arg["data"] = str(target_path.relative_to(data_dir.parent))
 

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -15,6 +15,7 @@ from .._utils._numpy_io import (
     save_array,
     save_arrays_single_csv,
 )
+from ._clew import record_output
 from ._utils import _convert_numpy_types, _sanitize_filename
 
 
@@ -109,6 +110,10 @@ def save_recipe(
         raise
     os.replace(tmp_name, path)
 
+    # Record the recipe as a clew output of the active session (no-op without
+    # clew). This is the handle that connects a composed figure to its source
+    # panels: compose later record_inputs these recipes -> clew links sessions.
+    record_output(path)
     return path
 
 
@@ -138,6 +143,7 @@ def _process_arrays_for_save(
                         filename = f"{safe_call_id}_{arg.get('name', f'arg{i}')}"
                         file_path = save_array(arr, data_dir / filename, data_format)
                         arg["data"] = str(file_path.relative_to(data_dir.parent))
+                        record_output(file_path)  # clew: data file as session output
 
     return data
 

--- a/src/figrecipe/_wrappers/_legend_wrapper.py
+++ b/src/figrecipe/_wrappers/_legend_wrapper.py
@@ -25,6 +25,46 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+
+def _ser_color(color: Any) -> Any:
+    """Color -> YAML-serializable form (keep strings; tuples/arrays -> list)."""
+    if color is None or isinstance(color, str):
+        return color
+    try:
+        return [float(c) for c in color]
+    except TypeError:
+        return str(color)
+
+
+def _handle_spec(handle: Any) -> dict:
+    """Capture a legend handle's visual spec for faithful replay.
+
+    Records the artist KIND (line/marker vs patch) plus its colour and marker
+    so the composed legend reproduces the original swatch -- colour AND shape --
+    instead of a grey rectangle. Live artist handles are not YAML-serializable,
+    so only this semantic spec is stored.
+    """
+    from matplotlib.lines import Line2D
+
+    spec: dict[str, Any] = {"label": handle.get_label()}
+    if isinstance(handle, Line2D):
+        spec["kind"] = "line"
+        spec["color"] = _ser_color(handle.get_color())
+        spec["marker"] = str(handle.get_marker())
+        spec["markersize"] = float(handle.get_markersize())
+        spec["markerfacecolor"] = _ser_color(handle.get_markerfacecolor())
+        spec["markeredgecolor"] = _ser_color(handle.get_markeredgecolor())
+        spec["linestyle"] = str(handle.get_linestyle())
+        spec["linewidth"] = float(handle.get_linewidth())
+    else:
+        spec["kind"] = "patch"
+        if hasattr(handle, "get_facecolor"):
+            spec["facecolor"] = _ser_color(handle.get_facecolor())
+        if hasattr(handle, "get_edgecolor"):
+            spec["edgecolor"] = _ser_color(handle.get_edgecolor())
+    return spec
+
+
 # ---------------------------------------------------------------------------
 # Lookup tables — exposed at module scope so they're cheap to construct
 # (don't rebuild on every legend call) and easy to test.
@@ -233,14 +273,7 @@ def _record_legend_call(recorder, position, args, kwargs, call_id) -> None:
     # Capture handle metadata before dropping the live artists.
     if "handles" in record_kwargs:
         handles = record_kwargs.get("handles")
-        handle_specs = []
-        for h in handles:
-            spec: dict[str, Any] = {"label": h.get_label()}
-            if hasattr(h, "get_facecolor"):
-                spec["facecolor"] = list(h.get_facecolor())
-            if hasattr(h, "get_edgecolor"):
-                spec["edgecolor"] = list(h.get_edgecolor())
-            handle_specs.append(spec)
+        handle_specs = [_handle_spec(h) for h in handles]
         record_kwargs["_handle_specs"] = handle_specs
 
     # Record that a custom handler_map was used (safe repr) but drop the

--- a/tests/figrecipe/_composition/test__crop_aware.py
+++ b/tests/figrecipe/_composition/test__crop_aware.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for crop-aware mm-composition placement + recipe roundtrip.
+
+Covers panel_rel_bbox's three branches and the save->load roundtrip of the
+crop-aware fields. Regression guard: bbox_uncropped was serialized by
+AxesRecord.to_dict but NOT read back by from_dict, which silently disabled
+crop-aware composition for every file-loaded recipe (the normal fr.compose
+path) -- it degraded to the legacy bbox and looked half-wired.
+"""
+
+from figrecipe._composition._crop_aware import panel_rel_bbox
+from figrecipe._recorder._core import AxesRecord, FigureRecord
+
+
+def _axes(**kw):
+    ax = AxesRecord(position=(0, 0))
+    for k, v in kw.items():
+        setattr(ax, k, v)
+    return ax
+
+
+def test_panel_rel_bbox_maps_axes_relative_to_content_box():
+    # Arrange
+    fig = FigureRecord(content_bbox=[0.0, 0.0, 0.5, 0.5])
+    ax = _axes(bbox_uncropped=[0.25, 0.25, 0.25, 0.25], bbox=[9, 9, 9, 9])
+    # Act
+    rel = panel_rel_bbox(fig, ax)
+    # Assert
+    assert rel == (0.5, 0.5, 0.5, 0.5)
+
+
+def test_panel_rel_bbox_falls_back_to_legacy_bbox():
+    # Arrange
+    fig = FigureRecord()
+    ax = _axes(bbox=[0.1, 0.2, 0.7, 0.6])
+    # Act
+    rel = panel_rel_bbox(fig, ax)
+    # Assert
+    assert rel == (0.1, 0.2, 0.7, 0.6)
+
+
+def test_panel_rel_bbox_fills_panel_when_no_bbox():
+    # Arrange
+    fig = FigureRecord()
+    ax = _axes()
+    # Act
+    rel = panel_rel_bbox(fig, ax)
+    # Assert
+    assert rel == (0.0, 0.0, 1.0, 1.0)
+
+
+def test_panel_rel_bbox_guards_zero_size_content_box():
+    # Arrange
+    fig = FigureRecord(content_bbox=[0.0, 0.0, 0.0, 0.0])
+    ax = _axes(bbox_uncropped=[0.1, 0.1, 0.2, 0.2], bbox=[0.3, 0.3, 0.3, 0.3])
+    # Act
+    rel = panel_rel_bbox(fig, ax)
+    # Assert
+    assert rel == (0.3, 0.3, 0.3, 0.3)
+
+
+def test_content_bbox_survives_recipe_roundtrip():
+    # Arrange
+    fig = FigureRecord(content_bbox=[0.01, 0.02, 0.97, 0.95])
+    # Act
+    restored = FigureRecord.from_dict(fig.to_dict())
+    # Assert
+    assert restored.content_bbox == [0.01, 0.02, 0.97, 0.95]
+
+
+def test_content_size_mm_survives_recipe_roundtrip():
+    # Arrange
+    fig = FigureRecord(content_size_mm=[120.0, 90.0])
+    # Act
+    restored = FigureRecord.from_dict(fig.to_dict())
+    # Assert
+    assert restored.content_size_mm == [120.0, 90.0]
+
+
+def test_bbox_uncropped_survives_recipe_roundtrip():
+    # Arrange
+    fig = FigureRecord()
+    fig.axes["r0c0"] = AxesRecord(position=(0, 0), bbox_uncropped=[0.1, 0.2, 0.3, 0.4])
+    # Act
+    restored = FigureRecord.from_dict(fig.to_dict())
+    # Assert
+    assert restored.axes["r0c0"].bbox_uncropped == [0.1, 0.2, 0.3, 0.4]
+
+
+def test_crop_aware_branch_fires_on_roundtripped_record():
+    # Arrange
+    fig = FigureRecord(content_bbox=[0.0, 0.0, 0.5, 0.5])
+    fig.axes["r0c0"] = AxesRecord(
+        position=(0, 0), bbox=[9, 9, 9, 9], bbox_uncropped=[0.25, 0.25, 0.25, 0.25]
+    )
+    restored = FigureRecord.from_dict(fig.to_dict())
+    # Act
+    rel = panel_rel_bbox(restored, restored.axes["r0c0"])
+    # Assert
+    assert rel == (0.5, 0.5, 0.5, 0.5)
+
+
+# EOF


### PR DESCRIPTION
## Problem
mm-based `fr.compose` produced composed figures that **clipped tick labels** and left **large gaps between panel labels and plots**. Two compounding bugs:

1. **Units mismatch.** Each panel rectangle was sized to the panel's *uncropped* `figsize`, but the axes was positioned by a *cropped-fraction* `bbox`. So cropped-fraction × uncropped-size → axes mis-sized/offset, with dead margins.
2. **No style on the composed figure.** The composed figure is built from a bare `matplotlib.pyplot.figure()` and never re-applied the panel's publication style, so replayed text used matplotlib's default (larger/wider) font → long tick labels (e.g. `Patient #01`) overflowed and were clipped.

Diagnosed on NeuroVista Fig 1 (raw-iEEG / 15-patient raster / Pat10 jointplot): panel B lost its y-labels (`Patient #NN` → `ent #NN`) and panel C had a large empty band under its label.

## Fix (additive, back-compatible, dpi-independent)
**Recorded at save:**
- `figure.content_bbox` — tight ink bbox (`get_tightbbox`) in *uncropped* figure fraction (labels/ticks/titles/legends/marginals; may exceed [0,1] on overflow).
- `figure.content_size_mm` — that bbox in mm (callers size panels by it).
- `axes.bbox_uncropped` — each axes' `get_position()` in uncropped fraction.

**Used in `_compose_mm_based` (`_composition/_crop_aware.py`):**
- `panel_rel_bbox()` — place each axes **relative to the source's tight content box** → a composed panel reproduces the clean cropped standalone render. Falls back to the legacy `bbox`, then to filling the panel, for older recipes.
- `_apply_source_style()` — re-apply the source panel's SCITEX style so replayed text metrics match the standalone (fixes clipping).
- `replay_panel_suptitle()` — replay a source figure suptitle as panel-local text, filling the band `content_bbox` reserved for it (keeps panel identity, e.g. `Patient #10`).

All new recipe fields are `Optional`, emitted only when set, and read back by `from_dict` — including `bbox_uncropped`, whose omission silently degraded the crop-aware branch to the legacy path for file-loaded recipes (the normal compose path). `_capture_content_layout` is fully best-effort: any failure leaves the fields unset and compose falls back, so **save never crashes**.

## Verification
- NeuroVista Fig 1 recomposed: panel B x-ticks + x-label + legend + full `Patient #01..#15` y-labels all present; panel C gap closed, `Hour of day` restored, `Patient #10` suptitle fills the band.
- `tests/figrecipe/_composition/test__crop_aware.py` (8 tests): the three placement branches, the zero-size-content guard, and the save→load roundtrip of every new field.
- Full recorder/save/compose suite: **163 passed**; the only 2 failures (`TestMetadataRoundtrip` repro-MSE) are **pre-existing on the base branch** (confirmed by stashing this change) and unrelated.

## Notes / follow-ups
- Stacked on `feat/scitex-signal-linewidth-and-stable-legend` (PR #184) — that is the editable-installed worktree branch. Base is set to it for a clean diff; rebase onto main when the stack merges.
- `_apply_source_style` mutates global `rcParams` (consistent with `fr.subplots`); required because draw happens at save, after `compose()` returns. Cross-panel bleed only matters for heterogeneous styles. `font.family` is not pushed to rcParams (font *size* is, which resolved the clipping) — a minor fidelity follow-up.