### PR TITLE
fix(save): route save/validation status through scitex-logging

### DIFF
--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -3,7 +3,28 @@
 """Save function helpers for the public API."""
 
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
+
+# figrecipe routes its save / reproducibility-validation status through
+# scitex-logging when available, so those lines carry the same INFO:/SUCC:/WARN:
+# prefixes + colours as scitex.io and @stx.session scripts (no more bare,
+# uncoloured print() output next to scitex-logging lines). Loosely coupled --
+# the same try-import policy as the scitex-clew integration; falls back to
+# print() when scitex-logging is absent.
+from .._logging import get_logger
+
+# Save settings / path / transparency helpers live in _save_config; re-exported
+# here so existing ``from .._api._save import get_save_dpi`` (etc.) keep working.
+from ._save_config import (  # noqa: F401
+    IMAGE_EXTENSIONS,
+    YAML_EXTENSIONS,
+    _get_default_image_format,
+    _is_opaque_facecolor,
+    _make_patches_opaque,
+    get_save_dpi,
+    get_save_transparency,
+    resolve_save_paths,
+)
 
 # Import helpers from separate module
 from ._save_helpers import _capture_axes_bboxes, _capture_content_layout
@@ -11,135 +32,7 @@ from ._save_helpers import (
     save_hitmap as _save_hitmap,
 )
 
-# Image extensions supported for saving
-IMAGE_EXTENSIONS = {
-    ".png",
-    ".pdf",
-    ".svg",
-    ".jpg",
-    ".jpeg",
-    ".eps",
-    ".tiff",
-    ".tif",
-}
-YAML_EXTENSIONS = {".yaml", ".yml"}
-
-
-def resolve_save_paths(
-    path: Path,
-    image_format: Optional[str] = None,
-) -> Tuple[Path, Path, str]:
-    """Resolve image and YAML paths from the provided path.
-
-    Parameters
-    ----------
-    path : Path
-        User-provided output path.
-    image_format : str, optional
-        Explicit image format when path is YAML.
-
-    Returns
-    -------
-    tuple
-        (image_path, yaml_path, img_format)
-    """
-    suffix_lower = path.suffix.lower()
-
-    if suffix_lower in IMAGE_EXTENSIONS:
-        # User provided image path
-        image_path = path
-        yaml_path = path.with_suffix(".yaml")
-        img_format = suffix_lower[1:]  # Remove leading dot
-    elif suffix_lower in YAML_EXTENSIONS:
-        # User provided YAML path
-        yaml_path = path
-        img_format = _get_default_image_format(image_format)
-        image_path = path.with_suffix(f".{img_format}")
-    else:
-        # Unknown extension - treat as base name, add both extensions
-        yaml_path = path.with_suffix(".yaml")
-        img_format = _get_default_image_format(image_format)
-        image_path = path.with_suffix(f".{img_format}")
-
-    return image_path, yaml_path, img_format
-
-
-def _get_default_image_format(explicit_format: Optional[str] = None) -> str:
-    """Get default image format from style or fallback to png."""
-    if explicit_format is not None:
-        return explicit_format.lower().lstrip(".")
-
-    # Check global style for preferred format
-    from ..styles._style_loader import _STYLE_CACHE
-
-    if _STYLE_CACHE is not None:
-        try:
-            return _STYLE_CACHE.output.format.lower()
-        except (KeyError, AttributeError):
-            pass
-    return "png"
-
-
-def get_save_dpi(explicit_dpi: Optional[int] = None) -> int:
-    """Get DPI for saving, using style default if not specified."""
-    if explicit_dpi is not None:
-        return explicit_dpi
-
-    from ..styles._style_loader import _STYLE_CACHE
-
-    if _STYLE_CACHE is not None:
-        try:
-            return _STYLE_CACHE.output.dpi
-        except (KeyError, AttributeError):
-            pass
-    return 300
-
-
-def get_save_transparency() -> bool:
-    """Get transparency setting from style."""
-    from ..styles._style_loader import _STYLE_CACHE
-
-    if _STYLE_CACHE is not None:
-        try:
-            return _STYLE_CACHE.output.transparent
-        except (KeyError, AttributeError):
-            pass
-    return False
-
-
-def _is_opaque_facecolor(facecolor) -> bool:
-    """Check if facecolor is an opaque color (not transparent/none)."""
-    if facecolor is None:
-        return False
-    if isinstance(facecolor, str):
-        if facecolor.lower() in ("none", "transparent"):
-            return False
-    return True
-
-
-def _make_patches_opaque(fig):
-    """Temporarily make figure and axes patches opaque. Returns restore function."""
-    original_alphas = []
-
-    # Store and set figure patch alpha
-    fig_patch = fig.fig.patch
-    original_alphas.append(("fig", fig_patch.get_alpha()))
-    fig_patch.set_alpha(1.0)
-
-    # Store and set axes patch alphas
-    for ax in fig.fig.get_axes():
-        ax_patch = ax.patch
-        original_alphas.append(("ax", ax, ax_patch.get_alpha()))
-        ax_patch.set_alpha(1.0)
-
-    def restore():
-        for item in original_alphas:
-            if item[0] == "fig":
-                fig_patch.set_alpha(item[1])
-            else:
-                item[1].patch.set_alpha(item[2])
-
-    return restore
+_log = get_logger("figrecipe")
 
 
 def save_figure(
@@ -277,7 +170,7 @@ def save_figure(
             if tmp_pltz.exists():
                 tmp_pltz.unlink()
         if verbose:
-            print(f"Saved: {path} (Figz bundle)")
+            _log.success(f"Saved: {path} (Figz bundle)")
         return path, None, None
 
     if suffixes[-2:] == [".plt", ".zip"]:
@@ -285,7 +178,7 @@ def save_figure(
 
         Pltz.create(path, fig)
         if verbose:
-            print(f"Saved: {path} (Pltz bundle)")
+            _log.success(f"Saved: {path} (Pltz bundle)")
         return path, None, None
 
     # Bare .zip (no .plt./.fig. infix) and directory-bundle dispatch are
@@ -457,7 +350,7 @@ def save_figure(
     # If not saving recipe, return early
     if not save_recipe:
         if verbose:
-            print(f"Saved: {image_path}")
+            _log.success(f"Saved: {image_path}")
         if _diagram_errors:
             raise ValueError("\n  ".join(_diagram_errors))
         return image_path, None, None
@@ -465,7 +358,7 @@ def save_figure(
     # Raise diagram validation errors after saving image (before recipe)
     if _diagram_errors:
         if verbose:
-            print(f"Saved (with errors): {image_path}")
+            _log.warning(f"Saved (with errors): {image_path}")
         raise ValueError("\n  ".join(_diagram_errors))
 
     # Save the recipe
@@ -483,9 +376,13 @@ def save_figure(
         result = validate_on_save(fig, saved_yaml, mse_threshold=validate_mse_threshold)
         status = "PASSED" if result.valid else "FAILED"
         if verbose:
-            print(
+            # Success path -> SUCC (green); failed validation -> WARN (yellow),
+            # so the status reads correctly through scitex-logging instead of a
+            # flat, uncoloured print().
+            line = (
                 f"Saved: {image_path} + {yaml_path} (Reproducible Validation: {status})"
             )
+            (_log.success if result.valid else _log.warning)(line)
         if not result.valid:
             msg = f"Reproducibility validation failed (MSE={result.mse:.1f}): {result.message}"
             if validate_error_level == "error":
@@ -498,7 +395,7 @@ def save_figure(
         return image_path, yaml_path, result
 
     if verbose:
-        print(f"Saved: {image_path} + {yaml_path}")
+        _log.success(f"Saved: {image_path} + {yaml_path}")
     return image_path, yaml_path, None
 
 

--- a/src/figrecipe/_api/_save_config.py
+++ b/src/figrecipe/_api/_save_config.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save-time settings, path resolution, and transparency helpers.
+
+Extracted from ``_save.py`` (which kept growing past the module line limit) so
+that file stays a focused ``save_figure`` orchestrator. These are the small,
+cohesive helpers that resolve output paths, pick the default image format / DPI
+/ transparency from the active style, and temporarily force opaque patches.
+``_save`` re-exports every public name here, so existing
+``from .._api._save import get_save_dpi`` (etc.) imports keep working.
+"""
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+# Image extensions supported for saving
+IMAGE_EXTENSIONS = {
+    ".png",
+    ".pdf",
+    ".svg",
+    ".jpg",
+    ".jpeg",
+    ".eps",
+    ".tiff",
+    ".tif",
+}
+YAML_EXTENSIONS = {".yaml", ".yml"}
+
+
+def resolve_save_paths(
+    path: Path,
+    image_format: Optional[str] = None,
+) -> Tuple[Path, Path, str]:
+    """Resolve image and YAML paths from the provided path.
+
+    Parameters
+    ----------
+    path : Path
+        User-provided output path.
+    image_format : str, optional
+        Explicit image format when path is YAML.
+
+    Returns
+    -------
+    tuple
+        (image_path, yaml_path, img_format)
+    """
+    suffix_lower = path.suffix.lower()
+
+    if suffix_lower in IMAGE_EXTENSIONS:
+        # User provided image path
+        image_path = path
+        yaml_path = path.with_suffix(".yaml")
+        img_format = suffix_lower[1:]  # Remove leading dot
+    elif suffix_lower in YAML_EXTENSIONS:
+        # User provided YAML path
+        yaml_path = path
+        img_format = _get_default_image_format(image_format)
+        image_path = path.with_suffix(f".{img_format}")
+    else:
+        # Unknown extension - treat as base name, add both extensions
+        yaml_path = path.with_suffix(".yaml")
+        img_format = _get_default_image_format(image_format)
+        image_path = path.with_suffix(f".{img_format}")
+
+    return image_path, yaml_path, img_format
+
+
+def _get_default_image_format(explicit_format: Optional[str] = None) -> str:
+    """Get default image format from style or fallback to png."""
+    if explicit_format is not None:
+        return explicit_format.lower().lstrip(".")
+
+    # Check global style for preferred format
+    from ..styles._style_loader import _STYLE_CACHE
+
+    if _STYLE_CACHE is not None:
+        try:
+            return _STYLE_CACHE.output.format.lower()
+        except (KeyError, AttributeError):
+            pass
+    return "png"
+
+
+def get_save_dpi(explicit_dpi: Optional[int] = None) -> int:
+    """Get DPI for saving, using style default if not specified."""
+    if explicit_dpi is not None:
+        return explicit_dpi
+
+    from ..styles._style_loader import _STYLE_CACHE
+
+    if _STYLE_CACHE is not None:
+        try:
+            return _STYLE_CACHE.output.dpi
+        except (KeyError, AttributeError):
+            pass
+    return 300
+
+
+def get_save_transparency() -> bool:
+    """Get transparency setting from style."""
+    from ..styles._style_loader import _STYLE_CACHE
+
+    if _STYLE_CACHE is not None:
+        try:
+            return _STYLE_CACHE.output.transparent
+        except (KeyError, AttributeError):
+            pass
+    return False
+
+
+def _is_opaque_facecolor(facecolor) -> bool:
+    """Check if facecolor is an opaque color (not transparent/none)."""
+    if facecolor is None:
+        return False
+    if isinstance(facecolor, str):
+        if facecolor.lower() in ("none", "transparent"):
+            return False
+    return True
+
+
+def _make_patches_opaque(fig):
+    """Temporarily make figure and axes patches opaque. Returns restore function."""
+    original_alphas = []
+
+    # Store and set figure patch alpha
+    fig_patch = fig.fig.patch
+    original_alphas.append(("fig", fig_patch.get_alpha()))
+    fig_patch.set_alpha(1.0)
+
+    # Store and set axes patch alphas
+    for ax in fig.fig.get_axes():
+        ax_patch = ax.patch
+        original_alphas.append(("ax", ax, ax_patch.get_alpha()))
+        ax_patch.set_alpha(1.0)
+
+    def restore():
+        for item in original_alphas:
+            if item[0] == "fig":
+                fig_patch.set_alpha(item[1])
+            else:
+                item[1].patch.set_alpha(item[2])
+
+    return restore
+
+
+__all__ = [
+    "IMAGE_EXTENSIONS",
+    "YAML_EXTENSIONS",
+    "resolve_save_paths",
+    "_get_default_image_format",
+    "get_save_dpi",
+    "get_save_transparency",
+    "_is_opaque_facecolor",
+    "_make_patches_opaque",
+]
+
+# EOF

--- a/src/figrecipe/_logging.py
+++ b/src/figrecipe/_logging.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Loosely-coupled scitex-logging for figrecipe console output.
+
+figrecipe emits its save / reproducibility-validation status through
+scitex-logging WHEN it is installed, so those lines carry the same
+``INFO:/SUCC:/WARN:`` prefixes and colours as the rest of the SciTeX
+ecosystem (``scitex.io.save``, ``@stx.session`` scripts). This removes the
+inconsistency where figrecipe's bare ``print("Saved: ...")`` lines appeared
+uncoloured and unprefixed right next to scitex-logging output.
+
+Loosely coupled, leaf-respecting -- the SAME policy as the scitex-clew
+integration (see ``_serializer/_clew.py``): scitex-logging is reached via
+scitex-dev's ``try_import_optional``. If scitex-logging (or scitex-dev) is
+absent, figrecipe falls back to plain ``print`` so it stays dependency-light
+and behaves exactly as before when used standalone.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class _PrintLogger:
+    """Fallback logger used when scitex-logging is unavailable.
+
+    Preserves figrecipe's historical standalone behaviour: save confirmations
+    stay visible on stdout (``info``/``success`` unprefixed, as the old
+    ``print`` calls were; ``warning``/``error`` get a short prefix) without
+    requiring any stdlib logging handler configuration.
+    """
+
+    def info(self, msg: str, *a: Any, **k: Any) -> None:
+        print(msg)
+
+    def success(self, msg: str, *a: Any, **k: Any) -> None:
+        print(msg)
+
+    def warning(self, msg: str, *a: Any, **k: Any) -> None:
+        print(f"WARN: {msg}")
+
+    def error(self, msg: str, *a: Any, **k: Any) -> None:
+        print(f"ERRO: {msg}")
+
+    def debug(self, msg: str, *a: Any, **k: Any) -> None:
+        pass
+
+
+def get_logger(name: str = "figrecipe") -> Any:
+    """Return scitex-logging's logger if available, else a print fallback.
+
+    The returned object always supports ``info``/``success``/``warning``/
+    ``error``/``debug`` so figrecipe call sites stay uniform across backends.
+
+    Parameters
+    ----------
+    name : str
+        Logger name (default ``"figrecipe"``).
+    """
+    try:
+        from scitex_dev import try_import_optional
+
+        slog = try_import_optional("scitex_logging")
+        if slog is not None and hasattr(slog, "getLogger"):
+            return slog.getLogger(name)
+    except Exception:  # optional path: scitex-logging / scitex-dev unavailable
+        pass
+    return _PrintLogger()
+
+
+__all__ = ["get_logger"]
+
+# EOF


### PR DESCRIPTION
## What
figrecipe logged its `Saved: … (Reproducible Validation: …)` lines with raw `print()`, so they appeared **uncoloured and unprefixed** next to scitex.io's scitex-logging output (`INFO:/SUCC:/WARN:`). In any run mixing the two (e.g. neurovista's Fig 1 pipeline) the output looked inconsistent — bare white figrecipe lines beside green `SUCC:` lines.

## Fix
- Route figrecipe's save / reproducibility-validation status through **scitex-logging when available**, loosely coupled via scitex-dev `try_import_optional` (same policy as the scitex-clew integration); `print()` fallback when absent.
- A failed reproducibility check now reads as a yellow `WARN:`; a clean save as a green `SUCC:` — consistent with the rest of the ecosystem.
- Honors `SCITEX_LOGGING_FORCE_COLOR=1` so colours survive piped/teed output.

## Refactor (line-limit compliance)
`_api/_save.py` was at the 512-line limit; extracted the save-settings/path/transparency helpers to `_api/_save_config.py` (re-exported from `_save` so existing imports keep working), leaving `_save.py` a focused `save_figure` orchestrator.

## Tests
`test__save.py` + `test__save_helpers.py` pass; re-export integrity verified; panel C save line confirmed rendering as coloured `WARN:` through scitex-logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)