### PR TITLE
feat(save): compact {png,yaml} save line + red ERROR for failed validation

### DIFF
--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -21,6 +21,7 @@ from ._save_config import (  # noqa: F401
     _get_default_image_format,
     _is_opaque_facecolor,
     _make_patches_opaque,
+    format_saved_target,
     get_save_dpi,
     get_save_transparency,
     resolve_save_paths,
@@ -376,13 +377,12 @@ def save_figure(
         result = validate_on_save(fig, saved_yaml, mse_threshold=validate_mse_threshold)
         status = "PASSED" if result.valid else "FAILED"
         if verbose:
-            # Success path -> SUCC (green); failed validation -> WARN (yellow),
-            # so the status reads correctly through scitex-logging instead of a
-            # flat, uncoloured print().
-            line = (
-                f"Saved: {image_path} + {yaml_path} (Reproducible Validation: {status})"
-            )
-            (_log.success if result.valid else _log.warning)(line)
+            # Success path -> SUCC (green); failed validation -> ERROR (red), so
+            # the status reads correctly through scitex-logging instead of a flat,
+            # uncoloured print(). image + recipe collapse to fig.{png,yaml}.
+            target = format_saved_target(image_path, yaml_path)
+            line = f"Saved: {target} (Reproducible Validation: {status})"
+            (_log.success if result.valid else _log.error)(line)
         if not result.valid:
             msg = f"Reproducibility validation failed (MSE={result.mse:.1f}): {result.message}"
             if validate_error_level == "error":
@@ -395,7 +395,7 @@ def save_figure(
         return image_path, yaml_path, result
 
     if verbose:
-        _log.success(f"Saved: {image_path} + {yaml_path}")
+        _log.success(f"Saved: {format_saved_target(image_path, yaml_path)}")
     return image_path, yaml_path, None
 
 

--- a/src/figrecipe/_api/_save_config.py
+++ b/src/figrecipe/_api/_save_config.py
@@ -144,6 +144,22 @@ def _make_patches_opaque(fig):
     return restore
 
 
+def format_saved_target(image_path, yaml_path) -> str:
+    """Render the saved image + recipe compactly.
+
+    When the two outputs share a directory and stem (the common case --
+    ``fig.png`` + ``fig.yaml``), collapse them to shell brace-expansion form
+    ``.../fig.{png,yaml}`` instead of spelling both paths with a ``+``. Falls
+    back to ``"<image> + <yaml>"`` when they don't share a stem/parent.
+    """
+    img, yml = Path(image_path), Path(yaml_path)
+    if img.parent == yml.parent and img.stem == yml.stem:
+        img_ext = img.suffix.lstrip(".")
+        yml_ext = yml.suffix.lstrip(".")
+        return str(img.parent / f"{img.stem}.{{{img_ext},{yml_ext}}}")
+    return f"{image_path} + {yaml_path}"
+
+
 __all__ = [
     "IMAGE_EXTENSIONS",
     "YAML_EXTENSIONS",
@@ -153,6 +169,7 @@ __all__ = [
     "get_save_transparency",
     "_is_opaque_facecolor",
     "_make_patches_opaque",
+    "format_saved_target",
 ]
 
 # EOF


### PR DESCRIPTION
## What
Two polish items on figrecipe's save status line (follow-up to #187):

1. **Compact path** — the image+recipe line now collapses to shell brace form `.../fig.{png,yaml}` instead of spelling both full paths with ` + `. New `format_saved_target` helper in `_save_config` (re-exported); falls back to `a + b` when stems/dirs differ.
2. **Red on failure** — a failed reproducibility check now logs at **ERROR (red)** instead of WARNING (yellow), so a genuine validation failure stands out.

## Tests
`test__save.py` + `test__save_helpers.py` pass; brace helper verified (same-stem → brace, diff-stem → fallback, pdf works); ERROR renders red via scitex-logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)