### PR TITLE
feat(validate): actionable reproducibility-failure message (cause, %, where)

### DIFF
--- a/src/figrecipe/_quality/_validator.py
+++ b/src/figrecipe/_quality/_validator.py
@@ -71,6 +71,33 @@ class ValidationResult:
         return "\n".join(lines)
 
 
+def _pixel_divergence_message(mse: float, mse_threshold: float, diff: dict) -> str:
+    """Actionable message for a same-size reproduction that diverges in pixels.
+
+    States the MSE vs threshold, how much of the canvas changed, and where the
+    change is concentrated (bounding box as % of the figure) so the cause is
+    legible from the log instead of a bare "MSE exceeds threshold".
+    """
+    msg = (
+        f"same image size but pixels differ: MSE ({mse:.2f}) exceeds threshold "
+        f"({mse_threshold})"
+    )
+    frac = diff.get("diff_fraction")
+    bbox = diff.get("diff_bbox")
+    if frac is not None:
+        msg += f"; {frac:.1%} of pixels changed"
+    if bbox is not None:
+        r0, r1, c0, c1 = bbox
+        msg += (
+            f", concentrated in rows {r0:.0%}-{r1:.0%} x cols {c0:.0%}-{c1:.0%} "
+            f"(top-left origin)"
+        )
+    md = diff.get("max_diff")
+    if md is not None and not np.isnan(md):
+        msg += f"; max channel diff {md:.0f}/255"
+    return msg
+
+
 def validate_recipe(
     fig,
     recipe_path: Union[str, Path],
@@ -139,15 +166,21 @@ def validate_recipe(
         # Compare images
         diff = compare_images(original_path, reproduced_path)
 
-        # Determine validity
+        # Determine validity, with an ACTIONABLE message on failure: say whether
+        # it's a size mismatch or a same-size pixel divergence, and for the latter
+        # how much of the canvas changed + where (so the cause is obvious from the
+        # log, not a bare "FAILED").
         mse = diff["mse"]
         if np.isnan(mse):
-            # Different sizes - invalid
             valid = False
-            message = f"Image dimensions differ: {diff['size1']} vs {diff['size2']}"
+            message = (
+                f"image SIZE mismatch: original {diff['size1']} (HxW) vs "
+                f"reproduced {diff['size2']} -- the reproduced figure has "
+                f"different pixel dimensions (layout/figsize not reproduced)"
+            )
         elif mse > mse_threshold:
             valid = False
-            message = f"MSE ({mse:.2f}) exceeds threshold ({mse_threshold})"
+            message = _pixel_divergence_message(mse, mse_threshold, diff)
         else:
             valid = True
             message = "Reproduction matches original within threshold"

--- a/src/figrecipe/_utils/_image_diff.py
+++ b/src/figrecipe/_utils/_image_diff.py
@@ -175,6 +175,12 @@ def compare_images(
 
         Image.fromarray(diff_img).save(diff_path)
 
+    # Localize WHERE the images differ (helps diagnose a failed reproduction:
+    # which fraction of the canvas changed, and the bounding box of the change as
+    # fractions of H x W). Computed on the comparable (same-size or tolerance-
+    # cropped) pixels; ``None`` when sizes are too different to overlap.
+    diff_fraction, diff_bbox = _diff_region(img1, img2)
+
     return {
         "identical": mse == 0,
         "mse": float(mse),
@@ -185,7 +191,40 @@ def compare_images(
         "same_size": img1.shape == img2.shape,
         "file_size1": file_size1,
         "file_size2": file_size2,
+        "diff_fraction": diff_fraction,
+        "diff_bbox": diff_bbox,
     }
+
+
+def _diff_region(img1: np.ndarray, img2: np.ndarray, thresh: float = 10.0):
+    """Fraction of differing pixels + their bounding box (H/W fractions).
+
+    Returns ``(fraction, bbox)`` where ``bbox`` is
+    ``(row_min, row_max, col_min, col_max)`` as fractions of height/width, or
+    ``(None, None)`` if the images don't overlap. A pixel "differs" when its
+    mean abs channel difference exceeds ``thresh`` (0-255), which ignores
+    anti-aliasing jitter and isolates real changes.
+    """
+    min_h = min(img1.shape[0], img2.shape[0])
+    min_w = min(img1.shape[1], img2.shape[1])
+    if min_h == 0 or min_w == 0:
+        return None, None
+    a = img1[:min_h, :min_w].astype(float)
+    b = img2[:min_h, :min_w].astype(float)
+    dmap = np.abs(a - b).mean(axis=2) if a.ndim == 3 else np.abs(a - b)
+    mask = dmap > thresh
+    fraction = float(mask.mean())
+    if not mask.any():
+        return fraction, None
+    ys, xs = np.where(mask)
+    h, w = dmap.shape
+    bbox = (
+        round(float(ys.min()) / h, 3),
+        round(float(ys.max()) / h, 3),
+        round(float(xs.min()) / w, 3),
+        round(float(xs.max()) / w, 3),
+    )
+    return fraction, bbox
 
 
 def create_comparison_figure(


### PR DESCRIPTION
## What
A failed save-time reproducibility check logged only `MSE (…) exceeds threshold (…)` — not *why*. Now it states the actual cause:
- **SIZE mismatch** → `original (H,W) vs reproduced (H,W) … layout/figsize not reproduced`.
- **same-size pixel divergence** → `same image size but pixels differ: MSE … ; X% of pixels changed, concentrated in rows a%-b% x cols c%-d%; max channel diff …/255`.

## Why
User asked, for the Fig 1 jointplot failure, "what is the cause? size mismatch?". The line now answers it directly. Real output:
```
FAILED - same image size but pixels differ: MSE (2771.94) exceeds threshold (100.0); 26.0% of pixels changed, concentrated in rows 1%-96% x cols 0%-99%; max channel diff 255/255
```
(→ it is NOT a size mismatch; the scatter_hist marginals re-derive layout on replay, shifting points.)

## How
`compare_images()` now returns `diff_fraction` + `diff_bbox` (new `_diff_region` helper); the validator composes them. The message surfaces on the save line via `result.message`.

Tests: `_utils`/`_quality` image+validate tests pass (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)