### PR TITLE
fix(reproduce): record+replay rotate_labels (fixes jointplot repro) + save <stem>-not-reproduced.<ext> on failure

### DIFF
--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -374,7 +374,12 @@ def save_figure(
     if validate:
         from .._quality._validator import validate_on_save
 
-        result = validate_on_save(fig, saved_yaml, mse_threshold=validate_mse_threshold)
+        result = validate_on_save(
+            fig,
+            saved_yaml,
+            mse_threshold=validate_mse_threshold,
+            image_path=image_path,
+        )
         if verbose:
             # image + recipe collapse to fig.{png,yaml}. Through scitex-logging:
             # green SUCC when reproducible, red ERROR *with the reason* otherwise
@@ -384,9 +389,16 @@ def save_figure(
             if result.valid:
                 _log.success(f"Saved: {target} (Reproducibility Validation: PASSED)")
             else:
+                # Point at the persisted reproduced figure so the divergence is
+                # inspectable (saved beside the figure as <stem>-not-reproduced.<ext>).
+                hint = ""
+                if getattr(result, "not_reproduced_path", None):
+                    from pathlib import Path as _P
+
+                    hint = f"; see {_P(result.not_reproduced_path).name}"
                 _log.error(
                     f"Saved: {target} "
-                    f"(Reproducibility Validation: FAILED - {result.message})"
+                    f"(Reproducibility Validation: FAILED - {result.message}{hint})"
                 )
         if not result.valid:
             msg = f"Reproducibility validation failed (MSE={result.mse:.1f}): {result.message}"

--- a/src/figrecipe/_params/_DECORATION_METHODS.py
+++ b/src/figrecipe/_params/_DECORATION_METHODS.py
@@ -29,6 +29,7 @@ DECORATION_METHODS = {
     "set_yticklabels",
     "tick_params",
     "margins",  # For ax.margins(x=0.02) padding
+    "rotate_labels",  # figrecipe tick-label rotation (recorded so reproduce replays it)
     # Statistical annotations
     "stat_annotation",  # Comparison brackets with stars/p-values
 }

--- a/src/figrecipe/_quality/_validator.py
+++ b/src/figrecipe/_quality/_validator.py
@@ -45,6 +45,10 @@ class ValidationResult:
     same_size: bool
     file_size_diff: int
     message: str
+    # On failure, the reproduced figure is persisted here (``<stem>-not-
+    # reproduced.<ext>`` beside the saved figure) for visual inspection; None
+    # when validation passes or no image path was provided.
+    not_reproduced_path: Optional[str] = None
 
     def __repr__(self) -> str:
         status = "VALID" if self.valid else "INVALID"
@@ -103,6 +107,7 @@ def validate_recipe(
     recipe_path: Union[str, Path],
     mse_threshold: float = 100.0,
     dpi: int = 150,
+    image_path: Union[str, Path, None] = None,
 ) -> ValidationResult:
     """Validate that a recipe can faithfully reproduce the original figure.
 
@@ -156,13 +161,6 @@ def validate_recipe(
             reproduced_path, save_recipe=False, dpi=dpi, verbose=False
         )
 
-        # Close reproduced figure to prevent double display in notebooks
-        # Use .fig to get underlying matplotlib Figure since reproduce() returns RecordingFigure
-        mpl_fig = (
-            reproduced_fig.fig if hasattr(reproduced_fig, "fig") else reproduced_fig
-        )
-        plt.close(mpl_fig)
-
         # Compare images
         diff = compare_images(original_path, reproduced_path)
 
@@ -185,6 +183,37 @@ def validate_recipe(
             valid = True
             message = "Reproduction matches original within threshold"
 
+        # On FAILURE, persist the reproduced figure next to the saved one as
+        # ``<stem>-not-reproduced.<ext>`` so the divergence is inspectable (the
+        # whole point: see WHAT the recipe failed to reproduce). On success,
+        # remove any stale artifact from a previous failing run so a green save
+        # never leaves a misleading "-not-reproduced" file behind.
+        not_reproduced_path = None
+        if image_path is not None:
+            p = Path(image_path)
+            artifact = p.parent / f"{p.stem}-not-reproduced{p.suffix}"
+            if not valid:
+                try:
+                    reproduced_fig.savefig(
+                        artifact, save_recipe=False, dpi=dpi, verbose=False
+                    )
+                    not_reproduced_path = str(artifact)
+                except Exception:
+                    not_reproduced_path = None
+            elif artifact.exists():
+                try:
+                    artifact.unlink()
+                except OSError:
+                    pass
+
+        # Close reproduced figure to prevent double display in notebooks. Use
+        # .fig to get the underlying matplotlib Figure (reproduce() returns a
+        # RecordingFigure).
+        mpl_fig = (
+            reproduced_fig.fig if hasattr(reproduced_fig, "fig") else reproduced_fig
+        )
+        plt.close(mpl_fig)
+
         return ValidationResult(
             valid=valid,
             mse=mse if not np.isnan(mse) else float("inf"),
@@ -197,6 +226,7 @@ def validate_recipe(
             same_size=diff["same_size"],
             file_size_diff=diff["file_size2"] - diff["file_size1"],
             message=message,
+            not_reproduced_path=not_reproduced_path,
         )
 
 
@@ -206,6 +236,7 @@ def validate_on_save(
     mse_threshold: float = 100.0,
     dpi: int = 150,
     raise_on_failure: bool = False,
+    image_path: Union[str, Path, None] = None,
 ) -> Optional[ValidationResult]:
     """Validate recipe immediately after saving.
 
@@ -221,6 +252,10 @@ def validate_on_save(
         DPI for comparison.
     raise_on_failure : bool
         If True, raise ValueError when validation fails.
+    image_path : str or Path, optional
+        Path of the saved figure image. When given and validation fails, the
+        reproduced figure is written beside it as ``<stem>-not-reproduced.<ext>``
+        for inspection.
 
     Returns
     -------
@@ -232,7 +267,9 @@ def validate_on_save(
     ValueError
         If raise_on_failure=True and validation fails.
     """
-    result = validate_recipe(fig, recipe_path, mse_threshold, dpi)
+    result = validate_recipe(
+        fig, recipe_path, mse_threshold, dpi, image_path=image_path
+    )
 
     if raise_on_failure and not result.valid:
         raise ValueError(f"Recipe validation failed: {result.message}")

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -372,6 +372,19 @@ def _replay_call(
         from ._stem import replay_stem_call
 
         return replay_stem_call(ax, call)
+    if method_name == "rotate_labels":
+        # figrecipe tick-label rotation: a styles helper, not an mpl axes method,
+        # so getattr(ax, "rotate_labels") fails on the raw replay axes. Dispatch
+        # to the helper so the rotation (and the tick re-nicing it applies) is
+        # reproduced -- otherwise labels stay horizontal + limits drift.
+        from ..styles._axis_helpers import rotate_labels as _rotate_labels
+
+        kw = {k: call.kwargs.get(k) for k in ("x", "y", "x_ha", "y_ha", "auto_adjust")}
+        try:
+            _rotate_labels(ax, **{k: v for k, v in kw.items() if v is not None})
+        except Exception:
+            pass
+        return None
     if method_name.startswith("stx_"):
         # figrecipe scitex-compat plot methods are functions taking a raw mpl
         # axes; a plain getattr(ax, name) fails on raw axes (e.g. mm-compose

--- a/src/figrecipe/_wrappers/_axes_style_mixin.py
+++ b/src/figrecipe/_wrappers/_axes_style_mixin.py
@@ -147,9 +147,34 @@ class AxesStyleMixin:
         """
         from ..styles._axis_helpers import rotate_labels
 
-        return rotate_labels(
+        result = rotate_labels(
             self._ax, x=x, y=y, x_ha=x_ha, y_ha=y_ha, auto_adjust=auto_adjust
         )
+
+        # Record as a decoration so reproduce() replays the rotation (and the
+        # tick re-nicing it triggers). Without this, rotate_labels mutated only
+        # the raw matplotlib axes and never reached the recipe -- a reproduced
+        # figure kept horizontal labels + different limits, diverging from the
+        # original (scitex-io/figrecipe#: scatter_hist live-vs-reproduce). Guarded
+        # by self._track so internal/no-record contexts don't double-record.
+        if getattr(self, "_track", False) and self._recorder is not None:
+            try:
+                self._recorder.record_call(
+                    ax_position=self._position,
+                    method_name="rotate_labels",
+                    args=(),
+                    kwargs={
+                        "x": x,
+                        "y": y,
+                        "x_ha": x_ha,
+                        "y_ha": y_ha,
+                        "auto_adjust": auto_adjust,
+                    },
+                )
+            except Exception:
+                pass  # recording is best-effort; never break the styling call
+
+        return result
 
     def set_xyt(
         self,


### PR DESCRIPTION
## Two changes

### 1. Fix jointplot reproduction (root cause: rotate_labels not recorded)
`ax.rotate_labels()` applied rotation directly to the raw matplotlib axes and was **never recorded**, so `reproduce()` gave horizontal labels AND different axis limits/ticks (rotate_labels also re-nices ticks) → scatter_hist panels shifted their whole data region → live-vs-reproduce diverged (save-time Reproducibility Validation FAILED), though the figure itself was correct.

Fix: record `rotate_labels` as a decoration (added to `DECORATION_METHODS`; mixin records it, guarded by `self._track`) + dispatch it on replay to the styles helper. **Fig1 jointplot panel C now reproduces (PASSED, MSE 0).** Minimal repro (legend+rotate_labels) confirmed red→green.

### 2. Save the failed reproduction for inspection
On a failed save-time check, persist the reproduced figure beside the saved one as `<stem>-not-reproduced.<ext>` (error log points at it); stale artifact removed on a later passing save. Makes every reproduction failure visually diagnosable.

## Tests
reproducer/recorder/quality/save suites: 157 passed, 16 failed — the 16 are **pre-existing** (identical on clean develop: TestPixelPerfect + TestMetadataRoundtrip). Zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)