### PR TITLE
test(gui): read handler source by path (no Django import) in api-switch guard

### DIFF
--- a/tests/figrecipe/_django/handlers/test_api_switch_reload.py
+++ b/tests/figrecipe/_django/handlers/test_api_switch_reload.py
@@ -59,10 +59,13 @@ class TestEditorReloadFlow:
 
 class TestNoStaleInitStyleOverrides:
     def test_handlers_module_has_no_init_style_overrides_caller(self):
-        # Arrange -- the removed method must not be referenced by any handler.
-        from figrecipe._django.handlers import files as files_handlers
+        # Arrange -- read the handler source by PATH; importing the handlers
+        # package pulls in scitex_app's Django models and needs configured
+        # settings. The removed method must not be referenced.
+        import figrecipe
 
-        source = Path(files_handlers.__file__).read_text(encoding="utf-8")
+        files_py = Path(figrecipe.__file__).parent / "_django" / "handlers" / "files.py"
+        source = files_py.read_text(encoding="utf-8")
         # Act
         has_stale_call = "_init_style_overrides" in source
         # Assert


### PR DESCRIPTION
Follow-up to #196. The source-guard test imported `figrecipe._django.handlers`, which pulls in scitex_app's Django chat models and raises `ImproperlyConfigured` without configured settings (the figrecipe suite sets no `DJANGO_SETTINGS_MODULE`). Read `files.py` via `figrecipe.__file__` + path instead — runs anywhere. 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)