### PR TITLE
fix(gui): correct handler import (._core -> .core) — GUI 500 on startup

### DIFF
--- a/src/figrecipe/_django/handlers/files.py
+++ b/src/figrecipe/_django/handlers/files.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 # Directory-listing helpers extracted to _files_tree.py (tree enrichment,
 # recipe detection, working-dir/backend resolution).
-from ._core import _dpi_from_request  # noqa: E402
 from ._files_tree import (  # noqa: E402
     _enrich_tree,
     _find_default_working_dir,
@@ -21,6 +20,7 @@ from ._files_tree import (  # noqa: E402
     _is_figrecipe_yaml_rel,
     _local_build_tree,
 )
+from .core import _dpi_from_request  # noqa: E402
 
 __all__ = [
     "_enrich_tree",

--- a/tests/figrecipe/_django/handlers/test_handlers_import.py
+++ b/tests/figrecipe/_django/handlers/test_handlers_import.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Import guard for the Django handlers package.
+
+A broken intra-package import in any handler (e.g. ``from ._core import …`` when
+the module is ``core``) is invisible to the rest of the suite — nothing else
+imports ``figrecipe._django.handlers`` (it needs Django configured), so such a
+typo only surfaces as a 500 when the GUI server actually starts. This test
+imports the package with Django set up so that class of bug fails in CI instead.
+"""
+
+import os
+
+import pytest
+
+django = pytest.importorskip("django")
+
+
+@pytest.fixture(scope="module")
+def _django_ready():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "figrecipe._django.settings")
+    django.setup()
+
+
+class TestHandlersImport:
+    def test_handlers_package_imports(self, _django_ready):
+        # Arrange -- Django is set up via the fixture.
+        # Act -- importing the package wires every handler module; a broken
+        # import (e.g. wrong relative module name) raises here.
+        from figrecipe._django.handlers import HANDLERS
+
+        # Assert
+        assert isinstance(HANDLERS, dict) and len(HANDLERS) > 0
+
+    def test_files_handler_imports_dpi_helper(self, _django_ready):
+        # Arrange -- Django is set up via the fixture.
+        # Act -- the DPI fix added `from .core import _dpi_from_request` to
+        # files.py; guard the exact module path that regressed.
+        from figrecipe._django.handlers.files import _dpi_from_request
+
+        # Assert
+        assert callable(_dpi_from_request)


### PR DESCRIPTION
## What
Hotfix for a regression in #200: `files.py` imported `from ._core import _dpi_from_request`, but the module is `core.py` (no underscore). Importing the handlers package raised `ModuleNotFoundError: figrecipe._django.handlers._core` → **the GUI 500'd on every request**.

My #200 tests missed it: nothing in the suite imports `figrecipe._django.handlers` (it needs Django configured), so the broken import only surfaced when the server started.

## Fix
- `from ._core` → `from .core`.
- Add `tests/figrecipe/_django/handlers/test_handlers_import.py`: configures Django and imports the handlers package + `files._dpi_from_request`. Any broken handler import now fails in CI. **Verified: fails on pre-fix code, passes after.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)