### PR TITLE
fix(gui): reproduce composed figures headlessly (no tkinter crash in threads)

### DIFF
--- a/src/figrecipe/_django/apps.py
+++ b/src/figrecipe/_django/apps.py
@@ -11,6 +11,20 @@ class FigRecipeEditorConfig(ScitexAppConfig):
     label = "figrecipe_editor"
     verbose_name = "FigRecipe Editor"
 
+    def ready(self):
+        # The editor server renders figures in Django worker threads. Force the
+        # headless Agg backend so no reproduce/render path can pull in a GUI
+        # backend (tkinter) off the main thread and crash. Best-effort.
+        try:
+            import matplotlib
+
+            matplotlib.use("Agg", force=True)
+        except Exception:
+            pass
+        super_ready = getattr(super(), "ready", None)
+        if callable(super_ready):
+            super_ready()
+
 
 class ScitexAppChatConfig(ScitexAppConfig):
     """AppConfig that registers scitex_app._chat models under 'scitex_app' label.

--- a/src/figrecipe/_reproducer/_mm_compose.py
+++ b/src/figrecipe/_reproducer/_mm_compose.py
@@ -29,13 +29,20 @@ def reproduce_mm_composed(record):
 
     Returns ``(wrapped_fig, axes_list)`` mirroring ``reproduce_from_record``.
     """
-    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure
 
     from .._recorder import Recorder
     from .._wrappers import RecordingAxes, RecordingFigure
     from ._core import _replay_call
 
-    fig = plt.figure(figsize=record.figsize, dpi=record.dpi)
+    # Build the figure WITHOUT pyplot: plt.figure() asks matplotlib for a GUI
+    # figure manager, which under the GUI editor's Django worker thread tries to
+    # load the tkinter backend and crashes ("partially initialized module
+    # 'tkinter'" / "GUI outside main thread"). A bare Figure + Agg canvas is
+    # headless and thread-safe (matching the render path in _editor/_helpers).
+    fig = Figure(figsize=record.figsize, dpi=record.dpi)
+    FigureCanvasAgg(fig)
 
     result_cache: Dict[str, Any] = {}
     mpl_axes: List[Any] = []

--- a/tests/figrecipe/_reproducer/test__mm_compose_headless.py
+++ b/tests/figrecipe/_reproducer/test__mm_compose_headless.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Guard: mm-composed reproduction is headless (no pyplot / GUI backend).
+
+The GUI editor reproduces composed recipes in Django worker threads. If the
+reproducer builds its figure via ``plt.figure()``, matplotlib tries to load a
+GUI figure manager (tkinter) off the main thread and crashes
+("partially initialized module 'tkinter'"). The crash is environment-dependent
+(only when a GUI backend is the default), so it slips past tests on Agg-default
+machines. These guards are portable:
+
+  1. source-level — the module must not import matplotlib.pyplot;
+  2. behavioural — the reproduced figure's canvas is the Agg (headless) canvas.
+"""
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+import figrecipe as fr
+from figrecipe._reproducer import _mm_compose
+
+
+@pytest.fixture
+def composed_recipe(tmp_path):
+    """A 2-panel mm-composition saved to a recipe path."""
+    r_a = tmp_path / "a.yaml"
+    fig_a, ax_a = fr.subplots()
+    ax_a.plot([0, 1, 2], [0, 1, 0], id="la")
+    fr.save(fig_a, r_a, validate=False, verbose=False)
+
+    r_b = tmp_path / "b.yaml"
+    fig_b, ax_b = fr.subplots()
+    ax_b.plot([0, 1, 2], [2, 1, 2], id="lb")
+    fr.save(fig_b, r_b, validate=False, verbose=False)
+
+    sources = {
+        str(r_a): {"xy_mm": (0, 0), "size_mm": (80, 40)},
+        str(r_b): {"xy_mm": (0, 42), "size_mm": (80, 40)},
+    }
+    comp, _ = fr.compose(sources, canvas_size_mm=(82, 84))
+    recipe = tmp_path / "composed.yaml"
+    fr.save(comp, recipe, validate=False, verbose=False)
+    return recipe
+
+
+class TestMmComposeHeadless:
+    def test_module_does_not_import_pyplot(self):
+        # Arrange
+        source = Path(_mm_compose.__file__).read_text(encoding="utf-8")
+        # Act
+        uses_pyplot = "matplotlib.pyplot" in source
+        # Assert -- pyplot would pull a GUI backend in worker threads
+        assert not uses_pyplot
+
+    def test_reproduced_canvas_is_agg(self, composed_recipe):
+        # Arrange
+        wrapped, _ = fr.reproduce(composed_recipe)
+        mpl_fig = wrapped.fig if hasattr(wrapped, "fig") else wrapped
+        # Act
+        canvas_cls = type(mpl_fig.canvas).__name__
+        # Assert -- headless Agg canvas, not a GUI (Tk/Qt) one
+        assert "Agg" in canvas_cls
+
+    def test_reproduces_all_panels(self, composed_recipe):
+        # Arrange
+        wrapped, _ = fr.reproduce(composed_recipe)
+        mpl_fig = wrapped.fig if hasattr(wrapped, "fig") else wrapped
+        # Act
+        n_axes = len(mpl_fig.axes)
+        # Assert -- both panels survived (no collapse)
+        assert n_axes == 2


### PR DESCRIPTION
## What
Loading the composed recipe in the GUI 500'd on `/api/files`:
```
AttributeError: partially initialized module 'tkinter' has no attribute 'mainloop'
```
`reproduce_mm_composed` built its figure with `plt.figure()`, which asks matplotlib for a **GUI figure manager**. In the editor's Django **worker thread** that loads the tkinter backend off the main thread and crashes. It's **environment-dependent** (only when a GUI backend is the default) — which is exactly why it passed on Agg-default test machines (mine) but crashed on the user's figrecipe venv.

## Fix
- `_mm_compose`: build with `matplotlib.figure.Figure` + `FigureCanvasAgg` (headless, thread-safe) — no pyplot. Matches the render path in `_editor/_helpers`.
- `_django/apps.py`: force the **Agg** backend in `AppConfig.ready()` so no reproduce/render path can pull a GUI backend off the main thread (also covers the grid `plt.subplots` path).
- `test__mm_compose_headless.py`: **portable** guards (module must not import pyplot; reproduced canvas is Agg; both panels reproduce). Verified the source guard **fails on pre-fix, passes after**; reproduce verified in a worker thread with no Agg preset.

Python-only fix — `git pull` + restart, no rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)