### PR TITLE
fix(ci): make quality-audit develop-ref step idempotent on push-to-develop

### DIFF
--- a/.github/workflows/figrecipe-quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/figrecipe-quality-audit-on-ubuntu-latest.yml
@@ -43,8 +43,19 @@ jobs:
 
       - name: Ensure local develop ref exists (for --new-only diff)
         run: |
-          git fetch origin develop:develop || \
-            git fetch origin develop && git branch -f develop origin/develop
+          # --new-only stages develop via `git worktree add --detach`, which
+          # needs a local `develop` ref. On push-to-develop, actions/checkout
+          # already created and checked out the develop branch, so both
+          # `git fetch origin develop:develop` ("refusing to fetch into the
+          # checked-out branch") and `git branch -f develop ...` ("cannot force
+          # update the checked-out branch") exit 128. Only materialise the ref
+          # when it is missing — PR events check out a detached merge commit,
+          # so develop does not exist locally there and must be created.
+          if git show-ref --verify --quiet refs/heads/develop; then
+            echo "Local develop ref already exists ($(git rev-parse --short develop)); nothing to do."
+          else
+            git fetch origin develop && git branch develop FETCH_HEAD
+          fi
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Problem

The `quality` workflow (`figrecipe-quality-audit-on-ubuntu-latest.yml`) has failed on **every** push to `develop` (#197–#204), each in ~15–20s — failing fast at the `Ensure local develop ref exists` step (exit 128), before the audit itself runs.

## Root cause

On a push to `develop`, `actions/checkout@v4` checks out `develop` as the **current branch**. The step then ran a fetch-into-develop with a force-branch fallback:

- `fetch origin develop:develop` → `fatal: refusing to fetch into branch 'refs/heads/develop' checked out` (128)
- fallback `branch -f develop origin/develop` → `fatal: cannot force update the branch 'develop' checked out` (128)

So the step always exits 128 on push-to-develop. PR events worked because they check out a *detached* merge commit (no local `develop`, so the fallback created it).

## Fix

Make the step idempotent — only create the ref when it is missing:

- **push-to-develop / scheduled / dispatch:** `develop` already exists → no-op (exit 0). ✅
- **PR events:** detached merge commit → `develop` created from `FETCH_HEAD`, preserving the `--new-only` baseline. ✅

## Verification

- YAML parses (`yaml.safe_load`).
- Both conditional branches simulated locally → exit 0 each.
- This PR's own `quality` check (running on the PR event) exercises the create-from-FETCH_HEAD path and should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
