### PR TITLE
fix(reproduce): record + replay ax.add_patch (schematic patches reproduce)

### DIFF
--- a/src/figrecipe/_params/_DECORATION_METHODS.py
+++ b/src/figrecipe/_params/_DECORATION_METHODS.py
@@ -32,6 +32,11 @@ DECORATION_METHODS = {
     "rotate_labels",  # figrecipe tick-label rotation (recorded so reproduce replays it)
     # Statistical annotations
     "stat_annotation",  # Comparison brackets with stars/p-values
+    # Patches: ax.add_patch takes a live Patch artist (not serialisable); the
+    # RecordingAxes.add_patch wrapper captures its class+geometry+style instead,
+    # so schematic shapes (rectangles, circles, ...) reproduce. Routed here so it
+    # replays after the data calls (patch draws on top, as authored).
+    "add_patch",
 }
 
 # EOF

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -7,30 +7,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
-from matplotlib.axes import Axes
 
-from .._recorder import CallRecord, FigureRecord
+from .._recorder import FigureRecord
 from .._serializer import load_recipe
 from .._utils._bundle import resolve_recipe_path
 from .._utils._grid import parse_grid_id
 from ._colorbars import _replay_colorbars
-
-
-def _maybe_parse_datetime(value: Any) -> Any:
-    """Parse an ISO datetime string to a datetime (for datetime-axis limits).
-
-    Recipes record datetime axis limits as ISO strings; matplotlib cannot
-    convert a raw string to axis units on replay. Returns a ``datetime`` when
-    ``value`` parses as one, otherwise returns ``value`` unchanged.
-    """
-    if not isinstance(value, str):
-        return value
-    try:
-        from datetime import datetime
-
-        return datetime.fromisoformat(value)
-    except (ValueError, TypeError):
-        return value
+from ._replay_dispatch import _replay_call
 
 
 def reproduce(
@@ -314,161 +297,6 @@ def reproduce_from_record(
         return wrapped_fig, wrapped_axes
 
 
-def _replay_call(
-    ax: Axes, call: CallRecord, result_cache: Optional[Dict[str, Any]] = None
-) -> Any:
-    """Replay a single call on an axes.
-
-    Parameters
-    ----------
-    ax : Axes
-        The matplotlib axes.
-    call : CallRecord
-        The call to replay.
-    result_cache : dict, optional
-        Cache mapping call_id -> result for resolving references.
-
-    Returns
-    -------
-    Any
-        Result of the matplotlib call.
-    """
-    if result_cache is None:
-        result_cache = {}
-
-    method_name = call.function
-
-    # Special method handlers
-    if method_name.startswith("sns."):
-        from ._seaborn import replay_seaborn_call
-
-        return replay_seaborn_call(ax, call)
-    if method_name == "boxplot":
-        from ._boxplot import replay_boxplot_call
-
-        return replay_boxplot_call(ax, call)
-    if method_name == "violinplot":
-        from ._violin import replay_violinplot_call
-
-        return replay_violinplot_call(ax, call)
-    if method_name == "joyplot":
-        from ._custom_plots import replay_joyplot_call
-
-        return replay_joyplot_call(ax, call)
-    if method_name == "swarmplot":
-        from ._custom_plots import replay_swarmplot_call
-
-        return replay_swarmplot_call(ax, call)
-    if method_name == "stat_annotation":
-        from .._wrappers._stat_annotation import draw_stat_annotation
-
-        kwargs = call.kwargs.copy()
-        x1, x2 = kwargs.pop("x1", 0), kwargs.pop("x2", 1)
-        return draw_stat_annotation(ax, x1, x2, **kwargs)
-    if method_name == "graph":
-        from ._replay_graph import replay_graph_call
-
-        return replay_graph_call(ax, call)
-    if method_name in ("diagram", "schematic"):
-        from ._replay_diagram import replay_diagram_native_call
-
-        return replay_diagram_native_call(ax, call)
-    if method_name == "legend":
-        from ._legend import replay_legend_call
-
-        return replay_legend_call(ax, call, result_cache)
-    if method_name == "stem":
-        from ._stem import replay_stem_call
-
-        return replay_stem_call(ax, call)
-    if method_name == "rotate_labels":
-        # figrecipe tick-label rotation: a styles helper, not an mpl axes method,
-        # so getattr(ax, "rotate_labels") fails on the raw replay axes. Dispatch
-        # to the helper so the rotation (and the tick re-nicing it applies) is
-        # reproduced -- otherwise labels stay horizontal + limits drift.
-        from ..styles._axis_helpers import rotate_labels as _rotate_labels
-
-        kw = {k: call.kwargs.get(k) for k in ("x", "y", "x_ha", "y_ha", "auto_adjust")}
-        try:
-            _rotate_labels(ax, **{k: v for k, v in kw.items() if v is not None})
-        except Exception:
-            pass
-        return None
-    if method_name.startswith("stx_"):
-        # figrecipe scitex-compat plot methods are functions taking a raw mpl
-        # axes; a plain getattr(ax, name) fails on raw axes (e.g. mm-compose
-        # add_axes panels), silently dropping the plot + its make_axes_locatable
-        # marginals. Dispatch to the compat function so it reconstructs fully.
-        from ._scitex import replay_stx_call
-
-        return replay_stx_call(ax, call, result_cache)
-
-    method = getattr(ax, method_name, None)
-
-    if method is None:
-        # Method not found, skip
-        return None
-
-    # Reconstruct args
-    from ._reconstruct import reconstruct_kwargs, reconstruct_value
-
-    args = []
-    for arg_data in call.args:
-        value = reconstruct_value(arg_data, result_cache)
-        args.append(value)
-
-    # Get kwargs and reconstruct arrays
-    kwargs = reconstruct_kwargs(call.kwargs)
-
-    # Axis-limit methods on a datetime axis recorded their bounds as ISO
-    # datetime strings; matplotlib can't convert a raw string to axis units on
-    # replay (raises "Failed to convert value(s) to axis units"). Parse such
-    # strings back to datetime so the recorded limits are reapplied.
-    if method_name in ("set_xlim", "set_ylim", "axvline", "axhline"):
-        args = [_maybe_parse_datetime(a) for a in args]
-        kwargs = {k: _maybe_parse_datetime(v) for k, v in kwargs.items()}
-
-    # Handle special transform markers
-    if "transform" in kwargs:
-        transform_val = kwargs["transform"]
-        if transform_val == "axes":
-            kwargs["transform"] = ax.transAxes
-        elif transform_val == "data":
-            kwargs["transform"] = ax.transData
-        elif transform_val == "figure":
-            kwargs["transform"] = ax.figure.transFigure
-        elif isinstance(transform_val, str):
-            # A non-marker stringified transform (e.g. a Bbox/blended transform
-            # that the recorder could not serialize as a clean marker). Passing
-            # the raw string to matplotlib raises
-            # "'str' object has no attribute 'contains_branch_seperately'".
-            # Map an axes-bbox transform back to ax.transAxes (the common case,
-            # e.g. scalebars drawn in axes fraction); otherwise drop it so the
-            # element still draws in the default (data) transform.
-            low = transform_val.replace("\n", " ").replace(" ", "")
-            if "BboxTransformTo" in transform_val and (
-                "x1=1.0" in low or "Affine2D().scale" in transform_val
-            ):
-                kwargs["transform"] = ax.transAxes
-            else:
-                kwargs.pop("transform")
-
-    # Fix fill_between: 'color' overrides 'edgecolor', use 'facecolor' instead
-    if method_name in ("fill_between", "fill_betweenx"):
-        if "color" in kwargs and "edgecolor" in kwargs:
-            kwargs["facecolor"] = kwargs.pop("color")
-
-    # Call the method
-    try:
-        return method(*args, **kwargs)
-    except Exception as e:
-        # Log warning but continue
-        import warnings
-
-        warnings.warn(f"Failed to replay {method_name}: {e}")
-        return None
-
-
 def get_recipe_info(path: Union[str, Path]) -> Dict[str, Any]:
     """Get recipe metadata (id, figsize, dpi, n_axes, calls) without reproducing."""
     record = load_recipe(path)
@@ -509,3 +337,5 @@ __all__ = [
     "reproduce_from_record",
     "get_recipe_info",
 ]
+
+# EOF

--- a/src/figrecipe/_reproducer/_replay_dispatch.py
+++ b/src/figrecipe/_reproducer/_replay_dispatch.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Per-call replay dispatch for figure reproduction.
+
+``_replay_call`` maps one recorded ``CallRecord`` back to a matplotlib call:
+special handlers for the figrecipe/seaborn/scitex constructs that can't be
+re-invoked by a plain ``getattr(ax, name)``, then a generic matplotlib dispatch
+for everything else. Extracted from ``_core.py`` (which kept the figure-level
+orchestration) to stay under the module line limit.
+"""
+
+from typing import Any, Dict, Optional
+
+from matplotlib.axes import Axes
+
+from .._recorder import CallRecord
+
+
+def _maybe_parse_datetime(value: Any) -> Any:
+    """Parse an ISO datetime string to a datetime (for datetime-axis limits).
+
+    Recipes record datetime axis limits as ISO strings; matplotlib cannot
+    convert a raw string to axis units on replay. Returns a ``datetime`` when
+    ``value`` parses as one, otherwise returns ``value`` unchanged.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        from datetime import datetime
+
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return value
+
+
+def _replay_call(
+    ax: Axes, call: CallRecord, result_cache: Optional[Dict[str, Any]] = None
+) -> Any:
+    """Replay a single call on an axes.
+
+    Parameters
+    ----------
+    ax : Axes
+        The matplotlib axes.
+    call : CallRecord
+        The call to replay.
+    result_cache : dict, optional
+        Cache mapping call_id -> result for resolving references.
+
+    Returns
+    -------
+    Any
+        Result of the matplotlib call.
+    """
+    if result_cache is None:
+        result_cache = {}
+
+    method_name = call.function
+
+    # Special method handlers
+    if method_name.startswith("sns."):
+        from ._seaborn import replay_seaborn_call
+
+        return replay_seaborn_call(ax, call)
+    if method_name == "boxplot":
+        from ._boxplot import replay_boxplot_call
+
+        return replay_boxplot_call(ax, call)
+    if method_name == "violinplot":
+        from ._violin import replay_violinplot_call
+
+        return replay_violinplot_call(ax, call)
+    if method_name == "joyplot":
+        from ._custom_plots import replay_joyplot_call
+
+        return replay_joyplot_call(ax, call)
+    if method_name == "swarmplot":
+        from ._custom_plots import replay_swarmplot_call
+
+        return replay_swarmplot_call(ax, call)
+    if method_name == "stat_annotation":
+        from .._wrappers._stat_annotation import draw_stat_annotation
+
+        kwargs = call.kwargs.copy()
+        x1, x2 = kwargs.pop("x1", 0), kwargs.pop("x2", 1)
+        return draw_stat_annotation(ax, x1, x2, **kwargs)
+    if method_name == "graph":
+        from ._replay_graph import replay_graph_call
+
+        return replay_graph_call(ax, call)
+    if method_name in ("diagram", "schematic"):
+        from ._replay_diagram import replay_diagram_native_call
+
+        return replay_diagram_native_call(ax, call)
+    if method_name == "add_patch":
+        from ._replay_patch import replay_add_patch_call
+
+        return replay_add_patch_call(ax, call)
+    if method_name == "legend":
+        from ._legend import replay_legend_call
+
+        return replay_legend_call(ax, call, result_cache)
+    if method_name == "stem":
+        from ._stem import replay_stem_call
+
+        return replay_stem_call(ax, call)
+    if method_name == "rotate_labels":
+        # figrecipe tick-label rotation: a styles helper, not an mpl axes method,
+        # so getattr(ax, "rotate_labels") fails on the raw replay axes. Dispatch
+        # to the helper so the rotation (and the tick re-nicing it applies) is
+        # reproduced -- otherwise labels stay horizontal + limits drift.
+        from ..styles._axis_helpers import rotate_labels as _rotate_labels
+
+        kw = {k: call.kwargs.get(k) for k in ("x", "y", "x_ha", "y_ha", "auto_adjust")}
+        try:
+            _rotate_labels(ax, **{k: v for k, v in kw.items() if v is not None})
+        except Exception:
+            pass
+        return None
+    if method_name.startswith("stx_"):
+        # figrecipe scitex-compat plot methods are functions taking a raw mpl
+        # axes; a plain getattr(ax, name) fails on raw axes (e.g. mm-compose
+        # add_axes panels), silently dropping the plot + its make_axes_locatable
+        # marginals. Dispatch to the compat function so it reconstructs fully.
+        from ._scitex import replay_stx_call
+
+        return replay_stx_call(ax, call, result_cache)
+
+    method = getattr(ax, method_name, None)
+
+    if method is None:
+        # Method not found, skip
+        return None
+
+    # Reconstruct args
+    from ._reconstruct import reconstruct_kwargs, reconstruct_value
+
+    args = []
+    for arg_data in call.args:
+        value = reconstruct_value(arg_data, result_cache)
+        args.append(value)
+
+    # Get kwargs and reconstruct arrays
+    kwargs = reconstruct_kwargs(call.kwargs)
+
+    # Axis-limit methods on a datetime axis recorded their bounds as ISO
+    # datetime strings; matplotlib can't convert a raw string to axis units on
+    # replay (raises "Failed to convert value(s) to axis units"). Parse such
+    # strings back to datetime so the recorded limits are reapplied.
+    if method_name in ("set_xlim", "set_ylim", "axvline", "axhline"):
+        args = [_maybe_parse_datetime(a) for a in args]
+        kwargs = {k: _maybe_parse_datetime(v) for k, v in kwargs.items()}
+
+    # Handle special transform markers
+    if "transform" in kwargs:
+        transform_val = kwargs["transform"]
+        if transform_val == "axes":
+            kwargs["transform"] = ax.transAxes
+        elif transform_val == "data":
+            kwargs["transform"] = ax.transData
+        elif transform_val == "figure":
+            kwargs["transform"] = ax.figure.transFigure
+        elif isinstance(transform_val, str):
+            # A non-marker stringified transform (e.g. a Bbox/blended transform
+            # that the recorder could not serialize as a clean marker). Passing
+            # the raw string to matplotlib raises
+            # "'str' object has no attribute 'contains_branch_seperately'".
+            # Map an axes-bbox transform back to ax.transAxes (the common case,
+            # e.g. scalebars drawn in axes fraction); otherwise drop it so the
+            # element still draws in the default (data) transform.
+            low = transform_val.replace("\n", " ").replace(" ", "")
+            if "BboxTransformTo" in transform_val and (
+                "x1=1.0" in low or "Affine2D().scale" in transform_val
+            ):
+                kwargs["transform"] = ax.transAxes
+            else:
+                kwargs.pop("transform")
+
+    # Fix fill_between: 'color' overrides 'edgecolor', use 'facecolor' instead
+    if method_name in ("fill_between", "fill_betweenx"):
+        if "color" in kwargs and "edgecolor" in kwargs:
+            kwargs["facecolor"] = kwargs.pop("color")
+
+    # Call the method
+    try:
+        return method(*args, **kwargs)
+    except Exception as e:
+        # Log warning but continue
+        import warnings
+
+        warnings.warn(f"Failed to replay {method_name}: {e}")
+        return None
+
+
+__all__ = ["_replay_call", "_maybe_parse_datetime"]
+
+# EOF

--- a/src/figrecipe/_reproducer/_replay_patch.py
+++ b/src/figrecipe/_reproducer/_replay_patch.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Replay a recorded ``add_patch`` call.
+
+Reconstructs a ``matplotlib.patches.Patch`` from the {patch_class, geom, props}
+descriptor written by ``_wrappers/_axes_patch.serialize_patch`` and adds it to
+the reproduced axes. Mirrors the live ``add_patch`` so the patch reproduces
+pixel-for-pixel.
+"""
+
+from typing import Any, Dict
+
+import matplotlib.patches as mpatches
+from matplotlib.path import Path as MplPath
+
+
+def _props_to_kwargs(props: Dict[str, Any]) -> Dict[str, Any]:
+    """Turn the serialised style props back into Patch constructor kwargs."""
+    kwargs: Dict[str, Any] = {}
+
+    facecolor = props.get("facecolor")
+    if facecolor is not None:
+        kwargs["facecolor"] = tuple(facecolor)
+    edgecolor = props.get("edgecolor")
+    if edgecolor is not None:
+        kwargs["edgecolor"] = tuple(edgecolor)
+
+    for key in ("linewidth", "hatch", "fill", "zorder"):
+        if props.get(key) is not None:
+            kwargs[key] = props[key]
+
+    linestyle = props.get("linestyle")
+    if isinstance(linestyle, str):
+        kwargs["linestyle"] = linestyle
+    elif isinstance(linestyle, (list, tuple)) and len(linestyle) == 2:
+        offset, seq = linestyle
+        kwargs["linestyle"] = "solid" if seq is None else (offset, tuple(seq))
+
+    return kwargs
+
+
+def replay_add_patch_call(ax, call):
+    """Reconstruct and add the patch recorded in ``call``.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The reproduced axes to add the patch to.
+    call : CallRecord
+        The recorded call; ``call.kwargs`` holds the patch descriptor.
+    """
+    descriptor = call.kwargs or {}
+    patch_class = descriptor.get("patch_class")
+    geom = descriptor.get("geom", {})
+    kwargs = _props_to_kwargs(descriptor.get("props", {}))
+
+    if patch_class == "Rectangle":
+        patch = mpatches.Rectangle(
+            tuple(geom["xy"]),
+            geom["width"],
+            geom["height"],
+            angle=geom.get("angle", 0.0),
+            **kwargs,
+        )
+    elif patch_class == "Circle":
+        patch = mpatches.Circle(tuple(geom["xy"]), geom["radius"], **kwargs)
+    elif patch_class == "Ellipse":
+        patch = mpatches.Ellipse(
+            tuple(geom["xy"]),
+            geom["width"],
+            geom["height"],
+            angle=geom.get("angle", 0.0),
+            **kwargs,
+        )
+    elif patch_class == "Polygon":
+        patch = mpatches.Polygon(geom["xy"], closed=True, **kwargs)
+    else:  # "PathPatch" generic fallback: vertices/codes already in data coords
+        vertices = geom.get("path_vertices", [])
+        codes = geom.get("path_codes")
+        path = MplPath(vertices, codes) if codes is not None else MplPath(vertices)
+        patch = mpatches.PathPatch(path, **kwargs)
+
+    return ax.add_patch(patch)
+
+
+__all__ = ["replay_add_patch_call"]
+
+# EOF

--- a/src/figrecipe/_wrappers/_axes.py
+++ b/src/figrecipe/_wrappers/_axes.py
@@ -270,6 +270,28 @@ class RecordingAxes(RecordingAxesMethods, AxesStyleMixin, SciTexMixin, DiagramMi
 
         return build_legend_wrapper(self)
 
+    def add_patch(self, patch, *, id: Optional[str] = None, track: bool = True):
+        """Add a matplotlib Patch artist, recording it for reproduction.
+
+        matplotlib's ``add_patch`` takes a live Patch (e.g. ``Rectangle``,
+        ``Circle``) that is not serialisable. We capture the patch's
+        class + geometry + style (see ``_axes_patch.serialize_patch``) so the
+        recipe reconstructs an equivalent patch on reproduce. Returns the live
+        patch so callers can keep styling it, exactly like raw matplotlib.
+        """
+        result = self._ax.add_patch(patch)
+        if self._track and track:
+            from ._axes_patch import serialize_patch
+
+            self._recorder.record_call(
+                ax_position=self._position,
+                method_name="add_patch",
+                args=(),
+                kwargs=serialize_patch(patch),
+                call_id=id,
+            )
+        return result
+
     def set_caption(self, caption: str) -> "RecordingAxes":
         """Set panel caption metadata (not rendered, stored in recipe)."""
         ax_record = self._recorder.figure_record.get_or_create_axes(*self._position)

--- a/src/figrecipe/_wrappers/_axes_patch.py
+++ b/src/figrecipe/_wrappers/_axes_patch.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Serialize matplotlib Patch artists for the recipe.
+
+``ax.add_patch`` takes a live ``matplotlib.patches.Patch`` artist, which is not
+serialisable to YAML. To make ``add_patch`` reproduce, we capture each patch's
+*class + geometry + style* as plain primitives here; the reproducer
+(``_reproducer/_replay_patch.py``) reconstructs an equivalent patch from this
+descriptor.
+
+Common analytic shapes (Rectangle, Circle, Ellipse, Polygon) are captured by
+their constructor geometry so the recipe is human-readable. Anything else
+(FancyBboxPatch, Wedge, Arc, arbitrary patches) falls back to its transformed
+path vertices/codes, replayed as a ``PathPatch`` — geometrically faithful for
+any patch type.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import matplotlib.patches as mpatches
+
+
+def _color_to_list(color: Any) -> Optional[List[float]]:
+    """An RGBA artist colour -> list of 4 floats (alpha folded in), or None.
+
+    matplotlib has already folded any ``set_alpha`` into the returned RGBA, so
+    we store the colour as-is and do NOT serialise a separate ``alpha`` (which
+    would double-apply on replay).
+    """
+    if color is None:
+        return None
+    try:
+        return [float(c) for c in color]
+    except TypeError:
+        return None
+
+
+def _linestyle_repr(linestyle: Any) -> Any:
+    """Patch linestyle -> a YAML-safe form (str, or [offset, dashes] list)."""
+    if isinstance(linestyle, str):
+        return linestyle
+    # matplotlib returns the dash form (offset, onoffseq); onoffseq is None for
+    # solid. Keep it as a list so the reproducer can rebuild the tuple.
+    try:
+        offset, seq = linestyle
+        return [offset, (list(seq) if seq is not None else None)]
+    except (TypeError, ValueError):
+        return "solid"
+
+
+def _common_props(patch: mpatches.Patch) -> Dict[str, Any]:
+    """Capture the style props shared by every Patch."""
+    return {
+        "facecolor": _color_to_list(patch.get_facecolor()),
+        "edgecolor": _color_to_list(patch.get_edgecolor()),
+        "linewidth": float(patch.get_linewidth()),
+        "linestyle": _linestyle_repr(patch.get_linestyle()),
+        "hatch": patch.get_hatch(),
+        "fill": bool(patch.get_fill()),
+        "zorder": float(patch.get_zorder()),
+    }
+
+
+def serialize_patch(patch: mpatches.Patch) -> Dict[str, Any]:
+    """Capture a Patch as a {patch_class, geom, props} descriptor.
+
+    The descriptor is plain primitives (str / float / list / dict) so it passes
+    the recorder's serialisability check unchanged and round-trips through YAML.
+    """
+    props = _common_props(patch)
+
+    # FancyBboxPatch subclasses are NOT Rectangle; check Rectangle first but
+    # exclude the fancy variant so it takes the path fallback (its rounded
+    # outline is not a plain rectangle).
+    if isinstance(patch, mpatches.Rectangle) and not isinstance(
+        patch, mpatches.FancyBboxPatch
+    ):
+        geom = {
+            "xy": [float(patch.get_x()), float(patch.get_y())],
+            "width": float(patch.get_width()),
+            "height": float(patch.get_height()),
+            "angle": float(patch.get_angle()),
+        }
+        return {"patch_class": "Rectangle", "geom": geom, "props": props}
+
+    if isinstance(patch, mpatches.Circle):
+        cx, cy = patch.get_center()
+        geom = {"xy": [float(cx), float(cy)], "radius": float(patch.get_radius())}
+        return {"patch_class": "Circle", "geom": geom, "props": props}
+
+    if isinstance(patch, mpatches.Ellipse):
+        cx, cy = patch.get_center()
+        geom = {
+            "xy": [float(cx), float(cy)],
+            "width": float(patch.get_width()),
+            "height": float(patch.get_height()),
+            "angle": float(patch.get_angle()),
+        }
+        return {"patch_class": "Ellipse", "geom": geom, "props": props}
+
+    if isinstance(patch, mpatches.Polygon):
+        geom = {"xy": [[float(x), float(y)] for x, y in patch.get_xy()]}
+        return {"patch_class": "Polygon", "geom": geom, "props": props}
+
+    # Generic fallback: any patch -> its outline path in data coords, replayed
+    # as a PathPatch. transform the unit path through the patch transform so the
+    # stored vertices are already in the axes' data space.
+    tpath = patch.get_patch_transform().transform_path(patch.get_path())
+    codes = tpath.codes
+    geom = {
+        "path_vertices": [[float(x), float(y)] for x, y in tpath.vertices],
+        "path_codes": ([int(c) for c in codes] if codes is not None else None),
+    }
+    return {"patch_class": "PathPatch", "geom": geom, "props": props}
+
+
+__all__ = ["serialize_patch"]
+
+# EOF

--- a/tests/figrecipe/_reproducer/test__replay_dispatch.py
+++ b/tests/figrecipe/_reproducer/test__replay_dispatch.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for ``_reproducer/_replay_dispatch`` (the per-call replay dispatcher).
+
+Extracted from ``_reproducer/_core`` (line-limit split); these guard the module
+imports and still exposes ``_replay_call`` so ``_core`` / ``_compose`` /
+``_mm_compose`` keep resolving it.
+"""
+
+import pytest
+
+
+def test_import__reproducer__replay_dispatch_module():
+    # Arrange
+    module_path = "figrecipe._reproducer._replay_dispatch"
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path
+
+
+def test_replay_dispatch_exports_replay_call():
+    # Arrange
+    mod = pytest.importorskip("figrecipe._reproducer._replay_dispatch")
+    # Act
+    exported = getattr(mod, "__all__", [])
+    # Assert
+    assert "_replay_call" in exported
+
+
+def test_core_reexports_replay_call_from_dispatch():
+    # Arrange
+    core = pytest.importorskip("figrecipe._reproducer._core")
+    dispatch = pytest.importorskip("figrecipe._reproducer._replay_dispatch")
+    # Act
+    same = core._replay_call is dispatch._replay_call
+    # Assert -- _compose / _mm_compose import _replay_call from _core
+    assert same is True

--- a/tests/figrecipe/_reproducer/test__replay_patch.py
+++ b/tests/figrecipe/_reproducer/test__replay_patch.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Round-trip tests for ``add_patch`` recording + replay.
+
+``ax.add_patch`` was previously dropped (not in PLOTTING/DECORATION_METHODS, no
+replay handler) so any schematic patch silently vanished on reproduce. These
+guard that a patch is recorded into the recipe and reconstructed on replay.
+
+Pixel-MSE here is measured as a *delta over the plot-only baseline* rather than
+an absolute threshold: the absolute baseline depends on the host's font/freetype
+(a bare ``fr.subplots()+plot`` already diverges on some dev hosts), but the patch
+must not add divergence on top of it -- that part is host-independent.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.patches as mpatches
+import yaml
+
+import figrecipe as fr
+from figrecipe._quality._validator import validate_recipe
+
+
+def _mpl_ax(ax):
+    return ax.ax if hasattr(ax, "ax") else ax
+
+
+def _decorations(recipe_path):
+    data = yaml.safe_load(recipe_path.read_text())
+    return [
+        call
+        for ax_record in data["axes"].values()
+        for call in ax_record.get("decorations", [])
+    ]
+
+
+def _patch_classes(ax):
+    return sorted(type(p).__name__ for p in _mpl_ax(ax).patches)
+
+
+def _mse(fig, recipe_path):
+    res = validate_recipe(fig, str(recipe_path), mse_threshold=1e12)
+    return res.mse if res.mse is not None else 0.0
+
+
+def _rect_recipe(tmp_path):
+    fig, ax = fr.subplots()
+    ax.plot([0, 1, 2], [0, 1, 0], id="line")
+    ax.add_patch(
+        mpatches.Rectangle((0.5, 0.2), 1.0, 0.4, facecolor="orange", edgecolor="k")
+    )
+    recipe = tmp_path / "rect.yaml"
+    fr.save(fig, recipe, validate=False, verbose=False)
+    return recipe
+
+
+def test_add_patch_recorded_as_decoration(tmp_path):
+    # Arrange
+    recipe = _rect_recipe(tmp_path)
+    # Act
+    patch_calls = [c for c in _decorations(recipe) if c["function"] == "add_patch"]
+    descriptor = patch_calls[0]["kwargs"] if patch_calls else {}
+    # Assert
+    assert (
+        len(patch_calls),
+        descriptor.get("patch_class"),
+        descriptor.get("geom", {}).get("width"),
+        descriptor.get("geom", {}).get("height"),
+    ) == (1, "Rectangle", 1.0, 0.4)
+
+
+def test_add_patch_all_shapes_reproduce(tmp_path):
+    # Arrange -- one of each handled class + a generic (FancyBboxPatch->PathPatch)
+    fig, ax = fr.subplots()
+    ax.plot([0, 1, 2], [0, 1, 0], id="line")
+    ax.add_patch(mpatches.Rectangle((0.3, 0.2), 0.6, 0.4, facecolor="orange"))
+    ax.add_patch(mpatches.Circle((1.5, 0.5), 0.2, facecolor="red"))
+    ax.add_patch(mpatches.Ellipse((0.6, 0.8), 0.4, 0.2, angle=15, facecolor="green"))
+    ax.add_patch(mpatches.Polygon([[1.0, 0.1], [1.3, 0.4], [1.0, 0.6]], facecolor="b"))
+    ax.add_patch(
+        mpatches.FancyBboxPatch((0.1, 0.05), 0.3, 0.1, boxstyle="round", facecolor="c")
+    )
+    recipe = tmp_path / "shapes.yaml"
+    fr.save(fig, recipe, validate=False, verbose=False)
+    # Act
+    _fig2, ax2 = fr.reproduce(recipe)
+    # Assert -- all five reproduced (FancyBboxPatch via the PathPatch fallback)
+    assert _patch_classes(ax2) == [
+        "Circle",
+        "Ellipse",
+        "PathPatch",
+        "Polygon",
+        "Rectangle",
+    ]
+
+
+def test_add_patch_circle_geometry_reproduced(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots()
+    ax.plot([0, 1, 2], [0, 1, 0], id="line")
+    ax.add_patch(mpatches.Circle((1.25, 0.5), 0.3, facecolor="none", edgecolor="red"))
+    recipe = tmp_path / "circle.yaml"
+    fr.save(fig, recipe, validate=False, verbose=False)
+    # Act
+    _fig2, ax2 = fr.reproduce(recipe)
+    (circle,) = [p for p in _mpl_ax(ax2).patches if type(p).__name__ == "Circle"]
+    # Assert -- centre + radius survived the round trip
+    assert (
+        tuple(round(v, 6) for v in circle.get_center()),
+        round(circle.get_radius(), 6),
+    ) == ((1.25, 0.5), 0.3)
+
+
+def test_add_patch_adds_no_divergence_over_baseline(tmp_path):
+    # Arrange -- baseline (plot only) vs the same plot + patches
+    fig0, ax0 = fr.subplots()
+    ax0.plot([0, 1, 2], [0, 1, 0], id="line")
+    r0 = tmp_path / "base.yaml"
+    fr.save(fig0, r0, validate=False, verbose=False)
+    fig1, ax1 = fr.subplots()
+    ax1.plot([0, 1, 2], [0, 1, 0], id="line")
+    ax1.add_patch(
+        mpatches.Rectangle((0.5, 0.2), 1.0, 0.4, facecolor="orange", edgecolor="k")
+    )
+    ax1.add_patch(
+        mpatches.Polygon([[0.2, 0.6], [0.6, 0.9], [0.2, 0.95]], facecolor="g")
+    )
+    r1 = tmp_path / "patched.yaml"
+    fr.save(fig1, r1, validate=False, verbose=False)
+    # Act
+    delta = _mse(fig1, r1) - _mse(fig0, r0)
+    # Assert -- patches reproduce: no divergence over baseline (full patch pre-fix)
+    assert delta <= 80.0

--- a/tests/figrecipe/_wrappers/test__axes_patch.py
+++ b/tests/figrecipe/_wrappers/test__axes_patch.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for ``_wrappers/_axes_patch.serialize_patch``.
+
+Deterministic (no rendering): they check the {patch_class, geom, props}
+descriptor captured for each handled patch class and the generic fallback.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.patches as mpatches
+
+from figrecipe._wrappers._axes_patch import serialize_patch
+
+
+def test_serialize_rectangle_captures_class_and_geometry():
+    # Arrange
+    patch = mpatches.Rectangle((0.2, 0.3), 0.6, 0.4, angle=10)
+    # Act
+    descriptor = serialize_patch(patch)
+    geom = descriptor["geom"]
+    # Assert
+    assert (
+        descriptor["patch_class"],
+        geom["xy"],
+        geom["width"],
+        geom["height"],
+        geom["angle"],
+    ) == ("Rectangle", [0.2, 0.3], 0.6, 0.4, 10.0)
+
+
+def test_serialize_circle_captures_center_and_radius():
+    # Arrange
+    patch = mpatches.Circle((1.0, 2.0), 0.5)
+    # Act
+    descriptor = serialize_patch(patch)
+    # Assert
+    assert (
+        descriptor["patch_class"],
+        descriptor["geom"]["xy"],
+        descriptor["geom"]["radius"],
+    ) == ("Circle", [1.0, 2.0], 0.5)
+
+
+def test_serialize_polygon_captures_vertices():
+    # Arrange
+    patch = mpatches.Polygon([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]])
+    # Act
+    descriptor = serialize_patch(patch)
+    # Assert
+    assert (descriptor["patch_class"], descriptor["geom"]["xy"][:3]) == (
+        "Polygon",
+        [[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]],
+    )
+
+
+def test_serialize_unknown_patch_falls_back_to_pathpatch():
+    # Arrange -- FancyBboxPatch is not a handled class
+    patch = mpatches.FancyBboxPatch((0.0, 0.0), 1.0, 1.0, boxstyle="round")
+    # Act
+    descriptor = serialize_patch(patch)
+    # Assert -- generic path fallback, with data-space vertices captured
+    assert (
+        descriptor["patch_class"],
+        len(descriptor["geom"]["path_vertices"]) > 0,
+    ) == (
+        "PathPatch",
+        True,
+    )
+
+
+def test_serialize_folds_alpha_into_facecolor():
+    # Arrange
+    patch = mpatches.Rectangle((0, 0), 1, 1, facecolor="orange", alpha=0.5)
+    # Act
+    descriptor = serialize_patch(patch)
+    # Assert -- alpha lives in the rgba 4th channel (no separate, double-applied key)
+    assert round(descriptor["props"]["facecolor"][3], 3) == 0.5


### PR DESCRIPTION
## Problem
`ax.add_patch` takes a live `matplotlib.patches.Patch` artist, which is not
serialisable. It was never in `PLOTTING_METHODS`/`DECORATION_METHODS` and had no
replay handler, so **every schematic patch was silently dropped on reproduce** —
failing save-time reproducibility for any diagram/annotation panel that uses
patches (surfaced while building NeuroVista Fig 2; minimal repro was MSE≈452 for
`plot + add_patch + annotate`).

## Fix
- **Record:** `RecordingAxes.add_patch` (in `_wrappers/_axes.py`) captures each
  patch's class + geometry + style via `_wrappers/_axes_patch.serialize_patch`:
  Rectangle / Circle / Ellipse / Polygon by constructor geometry; **any other
  patch** (FancyBboxPatch, Wedge, Arc, …) via a faithful transformed-path
  `PathPatch` fallback. Alpha is folded into the rgba (no double-apply).
- **Replay:** `_reproducer/_replay_patch.replay_add_patch_call` reconstructs and
  re-adds the patch; dispatched from `_replay_call`. `"add_patch"` added to
  `DECORATION_METHODS` so it routes through the recorder and replays after the
  data calls (patch draws on top, as authored).
- **Line-limit refactor:** extracted the per-call dispatcher from
  `_reproducer/_core.py` into `_reproducer/_replay_dispatch.py` (core stays the
  figure-level orchestrator; `_replay_call` re-exported so `_compose` /
  `_mm_compose` keep resolving it). Matches the dir's one-replayer-per-module
  convention.

## Tests
12 new tests:
- `_reproducer/test__replay_patch.py` — round-trip: all 5 shape classes
  reproduce, circle geometry survives, recorded as a decoration, and the patch
  adds **no MSE divergence over the plot-only baseline** (host-independent — see
  note).
- `_wrappers/test__axes_patch.py` — serializer units (geometry, fallback, alpha).
- `_reproducer/test__replay_dispatch.py` — module mirror + `_replay_call`
  re-export holds.

Full `_reproducer` + `_composition` suites: **no new failures**. The 14
`TestPixelPerfect::*_pixel_perfect` failures are a **pre-existing host
font/freetype mismatch** — the identical set fails on `develop` without this
change (incl. `test_plot_pixel_perfect`), so absolute pixel-MSE can't be
asserted on this host; the new tests assert the patch's *delta* over baseline
instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)