### PR TITLE
feat(reproducer): record+replay ax.add_patch so patches reproduce

### DIFF
--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -351,6 +351,10 @@ def _replay_call(
         from ._violin import replay_violinplot_call
 
         return replay_violinplot_call(ax, call)
+    if method_name == "add_patch":
+        from ._replay_patches import replay_add_patch_call
+
+        return replay_add_patch_call(ax, call)
     if method_name == "joyplot":
         from ._custom_plots import replay_joyplot_call
 

--- a/src/figrecipe/_reproducer/_replay_patches.py
+++ b/src/figrecipe/_reproducer/_replay_patches.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Replay a recorded ``add_patch`` call by rebuilding the patch from its spec.
+
+Counterpart to ``figrecipe/_wrappers/_axes_patches.py`` (the record side).
+"""
+
+from typing import Any, Dict
+
+import matplotlib.patches as mpatches
+
+
+def _resolve_transform(marker: str, ax):
+    """Resolve a serialized transform marker to the target axes' transform."""
+    if marker == "axes":
+        return ax.transAxes
+    if marker == "figure":
+        return ax.figure.transFigure
+    return ax.transData
+
+
+def reconstruct_patch(spec: Dict[str, Any]):
+    """Rebuild a matplotlib patch from a recorded spec (geometry only)."""
+    ptype = spec.get("type")
+    if ptype == "Rectangle":
+        return mpatches.Rectangle(
+            tuple(spec["xy"]),
+            spec["width"],
+            spec["height"],
+            angle=spec.get("angle", 0.0),
+        )
+    if ptype == "Circle":
+        return mpatches.Circle(tuple(spec["center"]), radius=spec["radius"])
+    if ptype == "Ellipse":
+        return mpatches.Ellipse(
+            tuple(spec["center"]),
+            width=spec["width"],
+            height=spec["height"],
+            angle=spec.get("angle", 0.0),
+        )
+    if ptype == "Polygon":
+        return mpatches.Polygon(spec["xy"], closed=spec.get("closed", True))
+    raise ValueError(
+        f"figrecipe cannot reproduce patch type {ptype!r} (recipe written by an "
+        f"incompatible figrecipe version)."
+    )
+
+
+def replay_add_patch_call(ax, call):
+    """Reconstruct the patch from ``call`` and add it to ``ax``."""
+    spec = call.kwargs.get("patch_spec")
+    if not spec:
+        raise ValueError(f"add_patch call {call.id!r} is missing patch_spec")
+
+    patch = reconstruct_patch(spec)
+
+    style = dict(spec.get("style", {}))
+    # Set the transform before add_patch so matplotlib does not override it
+    # with transData (add_patch only sets transData when none is set).
+    transform_marker = style.pop("transform", None)
+    if transform_marker is not None:
+        patch.set_transform(_resolve_transform(transform_marker, ax))
+    for key, value in style.items():
+        setter = getattr(patch, f"set_{key}", None)
+        if setter is not None:
+            setter(value)
+
+    return ax.add_patch(patch)
+
+
+__all__ = ["replay_add_patch_call", "reconstruct_patch"]

--- a/src/figrecipe/_wrappers/_axes.py
+++ b/src/figrecipe/_wrappers/_axes.py
@@ -87,6 +87,13 @@ class RecordingAxes(RecordingAxesMethods, AxesStyleMixin, SciTexMixin, DiagramMi
         if callable(attr) and name == "stem":
             return self._create_stem_wrapper()
 
+        # Route add_patch to a wrapper that records a serializable patch spec
+        # (raw patches are objects that otherwise vanish on replay)
+        if callable(attr) and name == "add_patch":
+            from ._axes_patches import build_add_patch_wrapper
+
+            return build_add_patch_wrapper(self)
+
         # If it's a plotting or decoration method, wrap it
         if callable(attr) and name in (
             self._recorder.PLOTTING_METHODS | self._recorder.DECORATION_METHODS

--- a/src/figrecipe/_wrappers/_axes_patches.py
+++ b/src/figrecipe/_wrappers/_axes_patches.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Record ``ax.add_patch()`` so patches round-trip through a recipe.
+
+A patch is a live matplotlib object, so it is decomposed into a
+YAML-serializable ``patch_spec`` (type + geometry + style) at record time and
+rebuilt on replay (see ``figrecipe/_reproducer/_replay_patches.py``).
+Unsupported patch types FAIL LOUD at call time rather than being silently
+dropped (which would make the figure fail save-time reproducibility).
+"""
+
+from typing import Any, Dict
+
+import matplotlib.colors as mcolors
+import matplotlib.patches as mpatches
+
+# Geometry-clean patch types supported for round-trip. Extend by adding a
+# branch in extract_patch_spec() + _replay_patches.reconstruct_patch().
+SUPPORTED_PATCH_TYPES = ("Rectangle", "Circle", "Ellipse", "Polygon")
+
+# facecolor/edgecolor are captured as RGBA hex (alpha folded in), so the
+# patch-level alpha is intentionally NOT captured separately to avoid
+# double-application (facecolor_alpha * patch_alpha) on replay.
+_STYLE_ATTRS = ("facecolor", "edgecolor", "linewidth", "linestyle", "hatch", "zorder")
+
+
+def _serialize_transform(patch) -> str:
+    """Map a patch's transform to a portable marker (data/axes/figure)."""
+    ax = getattr(patch, "axes", None)
+    transform = patch.get_transform()
+    if ax is not None:
+        if transform is ax.transData:
+            return "data"
+        if transform is ax.transAxes:
+            return "axes"
+        fig = getattr(ax, "figure", None)
+        if fig is not None and transform is fig.transFigure:
+            return "figure"
+    # transAxes reprs as "BboxTransformTo(...)"; treat as the axes marker.
+    if "BboxTransformTo" in repr(transform):
+        return "axes"
+    return "data"
+
+
+def _style_of(patch) -> Dict[str, Any]:
+    style: Dict[str, Any] = {}
+    for attr in _STYLE_ATTRS:
+        getter = getattr(patch, f"get_{attr}", None)
+        if getter is None:
+            continue
+        value = getter()
+        if value is None:
+            continue
+        if attr in ("facecolor", "edgecolor"):
+            try:
+                value = mcolors.to_hex(value, keep_alpha=True)
+            except (ValueError, TypeError):
+                pass
+        elif attr in ("linewidth", "zorder"):
+            value = float(value)
+        style[attr] = value
+    style["transform"] = _serialize_transform(patch)
+    return style
+
+
+def extract_patch_spec(patch) -> Dict[str, Any]:
+    """Decompose a matplotlib patch into a serializable spec.
+
+    Raises ValueError for unsupported patch types (FAIL LOUD).
+    """
+    style = _style_of(patch)
+    # Circle subclasses Ellipse, so it MUST be checked first.
+    if isinstance(patch, mpatches.Circle):
+        cx, cy = patch.center
+        return {
+            "type": "Circle",
+            "center": [float(cx), float(cy)],
+            "radius": float(patch.radius),
+            "style": style,
+        }
+    if isinstance(patch, mpatches.Ellipse):
+        cx, cy = patch.center
+        return {
+            "type": "Ellipse",
+            "center": [float(cx), float(cy)],
+            "width": float(patch.width),
+            "height": float(patch.height),
+            "angle": float(patch.angle),
+            "style": style,
+        }
+    if isinstance(patch, mpatches.Rectangle):
+        x, y = patch.get_xy()
+        return {
+            "type": "Rectangle",
+            "xy": [float(x), float(y)],
+            "width": float(patch.get_width()),
+            "height": float(patch.get_height()),
+            "angle": float(patch.get_angle()),
+            "style": style,
+        }
+    if isinstance(patch, mpatches.Polygon):
+        xy = patch.get_xy()
+        verts = xy.tolist() if hasattr(xy, "tolist") else [list(p) for p in xy]
+        return {
+            "type": "Polygon",
+            "xy": [[float(a), float(b)] for a, b in verts],
+            "closed": bool(patch.get_closed()),
+            "style": style,
+        }
+    raise ValueError(
+        f"figrecipe cannot record patch type {type(patch).__name__!r} for "
+        f"reproduction (it would be dropped on replay). Supported: "
+        f"{', '.join(SUPPORTED_PATCH_TYPES)}. Add a branch in "
+        f"_wrappers/_axes_patches.py:extract_patch_spec() to support it."
+    )
+
+
+def build_add_patch_wrapper(recording_axes):
+    """Build the recording wrapper for ``RecordingAxes.add_patch``."""
+
+    def add_patch(patch, *, id=None, track=True, **kwargs):
+        from ._axes_helpers import record_call_with_color_capture
+
+        result = recording_axes._ax.add_patch(patch)
+        if recording_axes._track and track:
+            # extract_patch_spec FAILS LOUD here on unsupported types, so the
+            # author learns at call time that the patch will not round-trip.
+            record_kwargs = {"patch_spec": extract_patch_spec(patch)}
+            record_kwargs.update(kwargs)
+            record_call_with_color_capture(
+                recording_axes._recorder,
+                recording_axes._position,
+                "add_patch",
+                (),
+                record_kwargs,
+                result,
+                id,
+                recording_axes._result_refs,
+                recording_axes._RESULT_REFERENCING_METHODS,
+                recording_axes._RESULT_REFERENCEABLE_METHODS,
+            )
+        return result
+
+    return add_patch
+
+
+__all__ = ["extract_patch_spec", "build_add_patch_wrapper", "SUPPORTED_PATCH_TYPES"]

--- a/tests/integration/test_add_patch_reproduction.py
+++ b/tests/integration/test_add_patch_reproduction.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save -> reproduce round-trip for ax.add_patch() (figrecipe).
+
+Raw patches were forwarded to matplotlib but never recorded, so they vanished
+on replay and the figure failed save-time reproducibility. These tests guard
+that supported patches (Rectangle/Circle/Ellipse/Polygon) round-trip and that
+unsupported patch types fail loud at call time.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.patches as mpatches
+import pytest
+import yaml
+
+import figrecipe as fr
+
+
+def _patches_of(rax, patch_cls):
+    mpl_ax = getattr(rax, "ax", rax)
+    return [p for p in mpl_ax.patches if type(p) is patch_cls]
+
+
+def _find_patch_spec(recipe_path):
+    with open(recipe_path) as fh:
+        data = yaml.safe_load(fh)
+    for ax_entry in data.get("axes", {}).values():
+        for call in ax_entry.get("calls", []) + ax_entry.get("decorations", []):
+            if call.get("function") == "add_patch":
+                return call["kwargs"]["patch_spec"]
+    return None
+
+
+def _save_and_reproduce(fig, recipe_path):
+    try:
+        fr.save(fig, str(recipe_path))
+    except ValueError:
+        pass  # geometry/recording asserted regardless of MSE-validation outcome
+    yaml_path = str(recipe_path).replace(".png", ".yaml")
+    spec = _find_patch_spec(yaml_path)
+    _, rax = fr.reproduce(yaml_path)
+    return spec, rax
+
+
+@pytest.fixture
+def rectangle_round_trip(tmp_path):
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.add_patch(
+        mpatches.Rectangle(
+            (0.2, 0.3), 0.4, 0.3, facecolor="red", edgecolor="black", linewidth=2
+        )
+    )
+    spec, rax = _save_and_reproduce(fig, tmp_path / "rect.png")
+    return {"spec": spec, "patches": _patches_of(rax, mpatches.Rectangle)}
+
+
+@pytest.fixture
+def circle_round_trip(tmp_path):
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.add_patch(mpatches.Circle((0.5, 0.5), radius=0.2, facecolor="blue"))
+    spec, rax = _save_and_reproduce(fig, tmp_path / "circle.png")
+    return {"spec": spec, "patches": _patches_of(rax, mpatches.Circle)}
+
+
+def test_rectangle_recorded_in_recipe(rectangle_round_trip):
+    # Arrange
+    spec = rectangle_round_trip["spec"]
+    # Act
+    recorded_type = spec["type"] if spec else None
+    # Assert
+    assert recorded_type == "Rectangle"
+
+
+def test_rectangle_reproduced_once(rectangle_round_trip):
+    # Arrange
+    patches = rectangle_round_trip["patches"]
+    # Act
+    count = len(patches)
+    # Assert
+    assert count == 1
+
+
+def test_rectangle_geometry_reproduced(rectangle_round_trip):
+    # Arrange
+    rect = rectangle_round_trip["patches"][0]
+    # Act
+    geometry = (rect.get_x(), rect.get_y(), rect.get_width(), rect.get_height())
+    # Assert
+    assert geometry == pytest.approx((0.2, 0.3, 0.4, 0.3))
+
+
+def test_circle_recorded_in_recipe(circle_round_trip):
+    # Arrange
+    spec = circle_round_trip["spec"]
+    # Act
+    recorded_type = spec["type"] if spec else None
+    # Assert
+    assert recorded_type == "Circle"
+
+
+def test_circle_reproduced_once(circle_round_trip):
+    # Arrange
+    patches = circle_round_trip["patches"]
+    # Act
+    count = len(patches)
+    # Assert
+    assert count == 1
+
+
+def test_circle_geometry_reproduced(circle_round_trip):
+    # Arrange
+    circle = circle_round_trip["patches"][0]
+    # Act
+    geometry = (circle.center[0], circle.center[1], circle.radius)
+    # Assert
+    assert geometry == pytest.approx((0.5, 0.5, 0.2))
+
+
+def test_patch_only_figure_reproduces_clean(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.add_patch(mpatches.Rectangle((0.1, 0.1), 0.5, 0.5, facecolor="green"))
+    # Act
+    fr.save(fig, str(tmp_path / "clean.png"))  # raises if the patch is dropped
+    # Assert
+    assert not list(tmp_path.glob("*-not-reproduced.*"))
+
+
+def test_unsupported_patch_fails_loud(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    arrow = mpatches.FancyArrowPatch((0.1, 0.1), (0.9, 0.9))
+    # Act
+    # adding an unsupported patch type must raise at call time (see Assert)
+    # Assert
+    with pytest.raises(ValueError, match="cannot record patch type"):
+        ax.add_patch(arrow)


### PR DESCRIPTION
## Problem

`ax.add_patch(patch)` was forwarded to matplotlib but never recorded into the recipe, so the patch vanished on replay and the figure failed save-time reproducibility (MSE over threshold → `<stem>-not-reproduced.png`). Surfaced in the NeuroVista handoff (Fig 2 patch panels).

## Fix — record + replay

**Record** (`_wrappers/_axes_patches.py`): a custom `add_patch` wrapper, wired into `RecordingAxes.__getattr__` alongside `bar`/`stem`, decomposes the live patch into a YAML-serializable `patch_spec` (type + geometry + style + transform marker) and records it via the same `record_call_with_color_capture` helper the `annotate` wrapper uses.
- Supported: **Rectangle, Circle, Ellipse, Polygon**.
- Unsupported patch types **fail loud at call time** (`ValueError`) so authors know immediately they won't round-trip — no silent drop.
- facecolor/edgecolor captured as RGBA hex (alpha folded) to avoid double-application.

**Replay** (`_reproducer/_replay_patches.py`): reconstruct the patch from the spec, resolve the transform marker (data/axes/figure), apply styles, `ax.add_patch()`; dispatched in `_replay_call`.

**No impact on internal usage:** figrecipe's own code (diagrams, violins, hitmaps) calls `add_patch` on the *raw* matplotlib axes, not the `RecordingAxes` wrapper, so it is unaffected — verified by the diagram/violin/boxplot tests reproducing unchanged.

## Verification

- New `tests/integration/test_add_patch_reproduction.py` (8 tests): Rectangle/Circle recorded + geometry reproduced, patch-only figure reproduces clean (no `-not-reproduced`), unsupported patch fails loud. **All 8 pass with the fix; all 8 fail on develop** (validated regression guard).
- **No regressions:** `_reproducer` suite 14 failed / 52 passed — *identical* to develop's baseline (the 14 are pre-existing line-width failures fixed by #206, not this PR). `integration` suite 53 passed / 4 skipped / 0 failed.
- Isolated `add_patch` round-trip MSE 2834 → 274 (the rectangle now reproduces; residual is the orthogonal line-width issue addressed in #206).

Branched off develop; `_core.py` edits are in a different region than #206's, so the two merge independently. Insets (the other confirmed gap) will follow as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
