### PR TITLE
feat(embed): ax.embed(source) — nested recipes, diagrams, composed figures as sub-panels (PR-2)

### DIFF
--- a/src/figrecipe/_wrappers/_axes.py
+++ b/src/figrecipe/_wrappers/_axes.py
@@ -110,6 +110,18 @@ class RecordingAxes(RecordingAxesMethods, AxesStyleMixin, SciTexMixin, DiagramMi
         # For other methods/attributes, return as-is
         return attr
 
+    def embed(self, source, bounds=None, *, ax_key=None, track=True, id=None):
+        """Embed a recipe or diagram as a managed sub-panel that round-trips.
+
+        ``source`` may be a recipe path, image, FigureRecord, diagram recipe,
+        composed multi-panel recipe, or ``(source, ax_key)``. ``bounds`` is an
+        axes-fraction ``[x, y, w, h]`` (defaults to the whole axes). Returns the
+        embedded inset RecordingAxes (or a list for a multi-panel source).
+        """
+        from ._axes_embed import embed_source
+
+        return embed_source(self, source, bounds, ax_key=ax_key, track=track, id=id)
+
     def __dir__(self):
         """Return list of attributes for tab completion.
 

--- a/src/figrecipe/_wrappers/_axes_embed.py
+++ b/src/figrecipe/_wrappers/_axes_embed.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``ax.embed(source, bounds)`` — embed a recipe or diagram as a managed sub-panel.
+
+Builds directly on the inset substrate (``_axes_insets`` / ``_replay_insets``):
+each axes of the parsed *source* is drawn into a managed inset placed at the
+source axes' recorded position within ``bounds``, and the source's recorded
+calls are attached to that inset's child recorder. Serialization and replay are
+then handled by the inset substrate for free (live + loaded paths, finalize).
+
+Supported sources (via ``_composition._source_parser``): a ``.yaml`` recipe, an
+image (with companion recipe), a ``FigureRecord``, a diagram recipe (its axes
+holds a ``diagram`` call), a composed multi-panel recipe (each panel embedded at
+its recorded bbox), or ``(source, ax_key)`` to embed one panel.
+"""
+
+from typing import List, Optional
+
+
+def embed_source(
+    recording_axes,
+    source,
+    bounds: Optional[List[float]] = None,
+    *,
+    ax_key: Optional[str] = None,
+    track: bool = True,
+    id: Optional[str] = None,
+):
+    """Embed *source* into ``recording_axes`` within ``bounds`` (axes fraction)."""
+    from .._composition._crop_aware import panel_rel_bbox
+    from .._composition._source_parser import parse_source_spec_with_key
+
+    if bounds is None:
+        bounds = [0.0, 0.0, 1.0, 1.0]
+    if ax_key is not None:
+        source = (source, ax_key)
+
+    record, sel_key, _path, explicit = parse_source_spec_with_key(source)
+    if explicit:
+        selected = {sel_key: record.axes[sel_key]}
+    else:
+        selected = dict(record.axes)
+    if not selected:
+        raise ValueError("ax.embed: source has no axes to embed")
+
+    insets = []
+    for src_ax_rec in selected.values():
+        # Place this source axes at its recorded position, scaled into `bounds`.
+        rel = panel_rel_bbox(record, src_ax_rec)
+        inset_bounds = [
+            bounds[0] + rel[0] * bounds[2],
+            bounds[1] + rel[1] * bounds[3],
+            rel[2] * bounds[2],
+            rel[3] * bounds[3],
+        ]
+        inset_rax = recording_axes.inset_axes(inset_bounds, track=track, id=id)
+        _draw_and_record_source(recording_axes, inset_rax, src_ax_rec)
+        insets.append(inset_rax)
+
+    return insets[0] if len(insets) == 1 else insets
+
+
+def _draw_and_record_source(parent_rax, inset_rax, src_ax_rec) -> None:
+    """Draw a source AxesRecord into the inset (live) and attach its recorded
+    calls to the inset's child recorder so it round-trips via the inset substrate."""
+    from .._reproducer._core import _replay_call
+    from ..styles._style_applier import finalize_special_plots, finalize_ticks
+
+    mpl_ax = inset_rax._ax
+    cache: dict = {}
+    for call in list(src_ax_rec.calls):
+        result = _replay_call(mpl_ax, call, cache)
+        if result is not None:
+            cache[call.id] = result
+    for call in list(src_ax_rec.decorations):
+        result = _replay_call(mpl_ax, call, cache)
+        if result is not None:
+            cache[call.id] = result
+
+    # Finalize with the PARENT figure's style — matches what replay_subpanels
+    # applies on reproduce, so the live render and the replay agree.
+    style = parent_rax._recorder.figure_record.style or {}
+    finalize_ticks(mpl_ax)
+    finalize_special_plots(mpl_ax, style)
+
+    # Record: attach the source's CallRecords (already serialized) directly to the
+    # inset's child recorder — NOT via record_call (which would re-serialize raw
+    # args). The inset substrate serializes/replays these as the sub-panel.
+    if inset_rax._track:
+        child_axes = inset_rax._recorder.figure_record.axes
+        child_ax_rec = next(iter(child_axes.values()), None)
+        if child_ax_rec is None:
+            child_ax_rec = inset_rax._recorder.figure_record.get_or_create_axes(0, 0)
+        child_ax_rec.calls.extend(src_ax_rec.calls)
+        child_ax_rec.decorations.extend(src_ax_rec.decorations)
+
+
+__all__ = ["embed_source"]

--- a/tests/integration/test_embed_reproduction.py
+++ b/tests/integration/test_embed_reproduction.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Integration tests for ax.embed(source, bounds) — PR-2.
+
+Embeds a recipe / diagram / composed figure as a managed sub-panel that
+round-trips. Each test follows strict AAA layout with exactly ONE assertion.
+"""
+
+import tempfile
+from pathlib import Path
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+
+import figrecipe as fr
+from figrecipe._serializer import load_recipe
+
+
+@pytest.fixture()
+def tmpdir_path():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+def _save_recipe(fig, path):
+    try:
+        fig.save_recipe(path)
+    except ValueError:
+        pass
+    plt.close("all")
+
+
+@pytest.fixture()
+def single_recipe(tmpdir_path):
+    """A saved single-axes recipe to embed."""
+    fig, ax = fr.subplots(axes_width_mm=40, axes_height_mm=30)
+    ax.plot([0, 1, 2], [0, 1, 0])
+    path = tmpdir_path / "src.yaml"
+    _save_recipe(fig, path)
+    return path
+
+
+@pytest.fixture()
+def embedded_recipe(tmpdir_path, single_recipe):
+    """A figure that embeds `single_recipe`, saved to a recipe."""
+    fig, ax = fr.subplots(axes_width_mm=80, axes_height_mm=60)
+    ax.plot([0, 1, 2, 3], [3, 2, 1, 0])
+    ax.embed(str(single_recipe), bounds=[0.55, 0.55, 0.4, 0.4])
+    out = tmpdir_path / "embedded.yaml"
+    _save_recipe(fig, out)
+    return out
+
+
+def test_embed_recorded_as_subpanel(embedded_recipe):
+    # Arrange
+    record = load_recipe(embedded_recipe)
+    parent = next(iter(record.axes.values()), None)
+    # Act
+    has_subpanels = bool(parent is not None and parent.subpanels)
+    # Assert
+    assert has_subpanels
+
+
+def test_embed_reproduces_one_inset(embedded_recipe):
+    # Arrange
+    yaml_path = embedded_recipe
+    # Act
+    _, ax2 = fr.reproduce(yaml_path)
+    n_child = len(ax2._ax.child_axes)
+    plt.close("all")
+    # Assert
+    assert n_child == 1
+
+
+def test_embed_single_recipe_save_no_not_reproduced(tmpdir_path, single_recipe):
+    # Arrange
+    fig, ax = fr.subplots(axes_width_mm=80, axes_height_mm=60)
+    ax.plot([0, 1, 2, 3], [3, 2, 1, 0])
+    ax.embed(str(single_recipe), bounds=[0.55, 0.55, 0.4, 0.4])
+    # Act
+    fr.save(fig, str(tmpdir_path / "embed_save.png"))  # real validation
+    plt.close("all")
+    # Assert
+    assert list(tmpdir_path.glob("*not-reproduced*")) == []
+
+
+def test_embed_diagram_save_no_not_reproduced(tmpdir_path):
+    # Arrange
+    d = fr.Diagram(title="mini", width_mm=80, height_mm=40)
+    d.add_box("a", "A")
+    d.add_box("b", "B")
+    d.add_arrow("a", "b")
+    dfig, dax = fr.subplots(axes_width_mm=80, axes_height_mm=40)
+    dax.diagram(d)
+    _save_recipe(dfig, tmpdir_path / "diag.yaml")
+    fig, ax = fr.subplots(axes_width_mm=90, axes_height_mm=60)
+    ax.plot([0, 1, 2], [0, 1, 0])
+    ax.embed(str(tmpdir_path / "diag.yaml"), bounds=[0.05, 0.5, 0.45, 0.45])
+    # Act
+    fr.save(fig, str(tmpdir_path / "embed_diag.png"))
+    plt.close("all")
+    # Assert
+    assert list(tmpdir_path.glob("*not-reproduced*")) == []
+
+
+def test_embed_composed_creates_multiple_insets(tmpdir_path):
+    # Arrange
+    a, aa = fr.subplots(axes_width_mm=40, axes_height_mm=30)
+    aa.plot([0, 1, 2], [2, 1, 0])
+    b, bb = fr.subplots(axes_width_mm=40, axes_height_mm=30)
+    bb.imshow(np.arange(9).reshape(3, 3))
+    _save_recipe(a, tmpdir_path / "pa.yaml")
+    _save_recipe(b, tmpdir_path / "pb.yaml")
+    comp, _ = fr.compose(
+        {
+            str(tmpdir_path / "pa.yaml"): {"xy_mm": (0, 0), "size_mm": (40, 30)},
+            str(tmpdir_path / "pb.yaml"): {"xy_mm": (0, 33), "size_mm": (40, 30)},
+        },
+        canvas_size_mm=(42, 65),
+    )
+    _save_recipe(comp, tmpdir_path / "comp.yaml")
+    fig, ax = fr.subplots(axes_width_mm=100, axes_height_mm=80)
+    # Act
+    result = ax.embed(str(tmpdir_path / "comp.yaml"), bounds=[0.05, 0.05, 0.5, 0.9])
+    n = len(result) if isinstance(result, list) else 1
+    plt.close("all")
+    # Assert
+    assert n == 2


### PR DESCRIPTION
## What

`ax.embed(source, bounds=[x,y,w,h])` — place a whole figrecipe **source** as a managed sub-panel that round-trips on save/reproduce. PR-2 of the managed-sub-panel design (PR-1 #209 added `inset_axes`); this is the "perfect fix" the operator asked for: nested composed figures + diagrams as sub-panels.

Sources supported (via `_composition._source_parser`):
- a saved `.yaml` recipe (single-axes)
- a **diagram** recipe (its axes holds a `diagram` call)
- a **composed multi-panel** recipe (each panel embedded at its recorded bbox)
- an image (with companion recipe), a `FigureRecord`, or `(source, ax_key)` to embed one panel

## How (reuses the inset substrate — no recorder/reproducer changes)

Each source axes is drawn into a **managed inset** (PR-1) positioned at its recorded bbox within `bounds`, and the source's recorded `CallRecord`s are attached to that inset's child recorder. Serialization + replay (live **and** loaded paths, finalize-for-styling) are then handled by the inset machinery for free. A composed source returns one inset per panel.

New surface only: the `ax.embed` method + `_wrappers/_axes_embed.py`. Reuses `parse_source_spec_with_key`, `panel_rel_bbox`, the inset substrate, `_replay_call`, and `finalize_special_plots`/`finalize_ticks`.

(Note: the source's already-serialized `CallRecord`s are attached **directly** to the child recorder — not via `record_call`, which expects raw args.)

## Verification

- `tests/integration/test_embed_reproduction.py` (5): embedded recipe is recorded as a `subpanel` and reproduces an inset; a **real `fr.save`** of an embedded recipe and of an embedded **diagram** each write no `*-not-reproduced`; a composed source embeds as **multiple** insets.
- **No regressions:** `_reproducer` 65 passed / 0 failed; `integration` 67 passed / 0 failed (62 + 5 new).

Builds on #209 (inset substrate), which is merged to develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
