### PR TITLE
fix(recorder): serialize numpy scalars as native types (fixes Fig 02 ConversionError '0')

### DIFF
--- a/src/figrecipe/_recorder/_utils.py
+++ b/src/figrecipe/_recorder/_utils.py
@@ -160,6 +160,15 @@ def _process_array_list(
 
 def _process_scalar(name: str, value: Any, is_serializable_func) -> Dict[str, Any]:
     """Process scalar or other value."""
+    # numpy scalars (np.int64, np.float64, np.bool_, …) are not natively
+    # serializable. np.float64 happens to subclass Python float so it slips
+    # through, but np.int64 does NOT subclass int -> it falls to the str(value)
+    # branch and serializes as e.g. '0'. A string coordinate turns the axis into
+    # a category axis and breaks reproduce/compose (ConversionError: Failed to
+    # convert value(s) to axis units: '0'). Coerce any numpy scalar to its native
+    # Python type so coordinates round-trip as numbers.
+    if isinstance(value, np.generic):
+        value = value.item()
     try:
         return {
             "name": name,

--- a/tests/integration/test_numpy_scalar_serialization.py
+++ b/tests/integration/test_numpy_scalar_serialization.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""numpy-scalar argument serialization (figrecipe).
+
+A numpy-int coordinate (e.g. ``ax.text(np.int64(0), ...)`` where the coord comes
+from a numpy array / set_xticks) used to serialize as the STRING ``'0'`` — numpy
+floats slipped through (np.float64 subclasses float) but numpy ints did not, so
+they hit the ``str(value)`` fallback. A string coordinate turns the axis into a
+category axis and breaks reproduce/compose
+(``ConversionError: Failed to convert value(s) to axis units: '0'`` — surfaced by
+NeuroVista Fig 02 panel c). These guard that numpy scalars round-trip as numbers.
+"""
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import yaml
+
+import figrecipe as fr
+
+
+def _text_x(yaml_path):
+    data = yaml.safe_load(Path(yaml_path).read_text())
+    for ax_entry in data.get("axes", {}).values():
+        for call in ax_entry.get("calls", []) + ax_entry.get("decorations", []):
+            if call.get("function") == "text":
+                for arg in call.get("args", []):
+                    if arg.get("name") == "x":
+                        return arg["data"]
+    return None
+
+
+@pytest.fixture()
+def np_int_text_recipe(tmp_path):
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.bar([0, 1], [1.0, 2.0])
+    ax.text(np.int64(0), 1.5, "lbl")
+    out = tmp_path / "npint.png"
+    try:
+        fr.save(fig, str(out))
+    except ValueError:
+        pass
+    plt.close("all")
+    return tmp_path / "npint.yaml"
+
+
+def test_numpy_int_text_x_serialized_as_number(np_int_text_recipe):
+    # Arrange
+    x = _text_x(np_int_text_recipe)
+    # Act
+    is_string = isinstance(x, str)
+    # Assert
+    assert not is_string
+
+
+def test_numpy_int_text_x_replays_as_number(np_int_text_recipe):
+    # Arrange
+    _, rax = fr.reproduce(str(np_int_text_recipe))
+    mpl_ax = getattr(rax, "ax", rax)
+    labels = [t for t in mpl_ax.texts if t.get_text() == "lbl"]
+    # Act
+    replayed_x = labels[0].get_position()[0] if labels else None
+    plt.close("all")
+    # Assert
+    assert not isinstance(replayed_x, str)


### PR DESCRIPTION
## Problem (surfaced by NeuroVista Fig 02 panel c)

`_recorder/_utils.py:_process_scalar` fell back to `str(value)` for non-natively-serializable values:

```python
"data": value if is_serializable_func(value) else str(value)
```

`np.float64` slips through (it subclasses Python `float`), but **`np.int64` does NOT subclass `int`** → a numpy-int argument serialized as the **string `'0'`**.

Fig 02 panel c does `ax.text(xi, top, "3x")` where `xi` comes from a numpy array (`set_xticks(x)`), so `xi` is `np.int64(0)`. The recipe stored `x: '0'` (string), `y: 0.93` (float). On replay/compose, the string coordinate makes matplotlib attach a **category (`StrCategory`) converter** to the axis; mixed with the numeric bar data it raises at draw time:

```
matplotlib.units.ConversionError: Failed to convert value(s) to axis units: '0'
ValueError: Missing category information for StrCategoryConverter
```

The panel tolerated it standalone, but the **composed** figure failed to render — which is why it looked like a "compose+embed" bug but is really a numpy-scalar serialization bug.

## Fix

Coerce any `np.generic` scalar to its native Python type before serialization:

```python
if isinstance(value, np.generic):
    value = value.item()
```

So numpy-int coordinates (and any numpy scalar) round-trip as numbers. Applies to *every* call passing numpy scalars, not just Fig 02.

## Verification

- `tests/integration/test_numpy_scalar_serialization.py` (2): a numpy-int text coordinate **serializes** and **replays** as a number, not `'0'`. Both **error on develop with the exact `ConversionError`**, and **pass with the fix**.
- No regressions: `_reproducer` 65 passed, `integration` 79 passed (incl. the 2 new), `_recorder` 79 passed.

First of three sequential figrecipe fixes for the remaining Fig 02 reproduce gaps (next: diagram figure-size; then imshow tick-suppression on replay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
