### PR TITLE
fix(recorder): coerce numpy scalars to native before str() fallback

### DIFF
--- a/src/figrecipe/_recorder/_utils.py
+++ b/src/figrecipe/_recorder/_utils.py
@@ -159,7 +159,19 @@ def _process_array_list(
 
 
 def _process_scalar(name: str, value: Any, is_serializable_func) -> Dict[str, Any]:
-    """Process scalar or other value."""
+    """Process scalar or other value.
+
+    NumPy scalar types are coerced to their Python equivalents first. This
+    matters because ``np.floating`` subclasses ``float`` (so it survives the
+    serializable check below) but ``np.integer`` does NOT subclass ``int`` --
+    without this an ``np.int64`` (e.g. an ``np.arange`` index passed to
+    ``ax.text``/``ax.bar``) would fall through to ``str(value)`` and serialize
+    as e.g. ``'0'``. On replay that string then hits a category-unit converter
+    and raises ``ConversionError: Failed to convert value(s) to axis units``.
+    ``.item()`` turns any numpy scalar into the matching native Python number.
+    """
+    if isinstance(value, np.generic):
+        value = value.item()
     try:
         return {
             "name": name,

--- a/tests/figrecipe/_recorder/test__utils.py
+++ b/tests/figrecipe/_recorder/test__utils.py
@@ -1,20 +1,83 @@
-"""Smoke import mirror for figrecipe._recorder._utils.
+"""Tests for figrecipe._recorder._utils.
 
-Auto-generated subpackage mirror placeholder; replace with real tests
-as the module matures. Satisfies the src<->tests mirror audit rule.
+Covers the numpy-scalar coercion in ``_process_scalar`` (regression for a
+NeuroVista Fig 2 bug: ``np.int64`` positions were serialized as the string
+``'0'`` and broke replay on a category-unit axis).
 """
 
-
+import numpy as np
 import pytest
+
+from figrecipe._recorder._utils import _process_scalar
+
+
+def _is_native(value):
+    """Mimic the recorder's serializability check: native JSON/YAML scalars only.
+
+    ``np.generic`` instances are deliberately NOT native here -- without
+    coercion they fall through to ``str(value)`` in ``_process_scalar``.
+    """
+    return isinstance(value, (bool, int, float, str)) and not isinstance(
+        value, np.generic
+    )
 
 
 def test_import__recorder__utils_module():
     # Arrange
-    # Arrange
-    # Act
-    # Assert
-    module_path = 'figrecipe._recorder._utils'
+    module_path = "figrecipe._recorder._utils"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+class TestProcessScalarNumpyCoercion:
+    """``_process_scalar`` must coerce numpy scalars to native Python numbers."""
+
+    def test_numpy_int_serialized_value_equals_zero(self):
+        # Arrange
+        value = np.int64(0)
+        # Act
+        out = _process_scalar("x", value, _is_native)
+        # Assert
+        assert out["data"] == 0
+
+    def test_numpy_int_serialized_as_python_int(self):
+        # Arrange
+        value = np.int64(0)
+        # Act
+        out = _process_scalar("x", value, _is_native)
+        # Assert
+        assert isinstance(out["data"], int)
+
+    def test_numpy_int_not_serialized_as_string(self):
+        # Arrange
+        value = np.int64(0)
+        # Act
+        out = _process_scalar("x", value, _is_native)
+        # Assert
+        assert not isinstance(out["data"], str)
+
+    def test_numpy_float_serialized_as_python_float(self):
+        # Arrange
+        value = np.float64(0.93)
+        # Act
+        out = _process_scalar("y", value, _is_native)
+        # Assert
+        assert isinstance(out["data"], float)
+
+    def test_numpy_bool_serialized_as_python_bool(self):
+        # Arrange
+        value = np.bool_(True)
+        # Act
+        out = _process_scalar("flag", value, _is_native)
+        # Assert
+        assert out["data"] is True
+
+    def test_native_string_passes_through_unchanged(self):
+        # Arrange
+        value = "label"
+        # Act
+        out = _process_scalar("s", value, _is_native)
+        # Assert
+        assert out["data"] == "label"


### PR DESCRIPTION
## What
`_process_scalar` now coerces numpy scalars (`np.generic`) to native Python via `.item()` before the `str()` fallback.

## Why
`np.floating` subclasses `float` (so it passed the serializable check), but `np.integer` does **not** subclass `int` — so an `np.int64` (e.g. an `np.arange` index passed to `ax.text`/`ax.bar`) fell through to `str(value)` and serialized as the **string** `'0'`. On replay that `'0'` hits a `StrCategoryConverter` and raises `ConversionError: Failed to convert value(s) to axis units`. It only surfaced when composing recipes via `plt.compose` (the composed figure failed save-time validate-reproduce); each panel reproduced fine standalone.

## Fix
3-line coercion in `_process_scalar` (`numpy` already imported). General correctness — any numpy-int position now serializes numerically instead of as a string.

## Tests
`tests/figrecipe/_recorder/test__utils.py`: np.int / np.float / np.bool coercion + native-string passthrough (7 pass).

Surfaced by NeuroVista Fig 2 (panel c bar labels) dogfooding the recorder; details in `GITIGNORED/HANDOFF/FROM_NEUROVISTA.md` (Update 2026-06-17d). Scope: recorder numpy-scalar only — the branch name also references a `fr.Diagram` text fix that is handed off separately.