### PR TITLE
fix(reproducer): coerce stringified-numeric axis values on replay (completes #212; salvages #213 tests)

### DIFF
--- a/src/figrecipe/_reproducer/_axis_coerce.py
+++ b/src/figrecipe/_reproducer/_axis_coerce.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Coercion for replayed axis-limit / axis-line values."""
+
+import warnings
+from datetime import datetime
+from typing import Any
+
+
+def coerce_axis_value(value: Any) -> Any:
+    """Coerce a recorded axis-limit / axis-line value back to a usable type.
+
+    ``set_xlim`` / ``set_ylim`` / ``axvline`` / ``axhline`` are inherently
+    numeric or datetime -- a category string is never a valid argument. A recipe
+    can nonetheless carry such a value as a *string*:
+
+    - ISO datetime strings, for datetime axes (recorded that way on purpose); or
+    - a stringified number like ``'0'`` from recipes written before numpy
+      scalars were serialized natively (figrecipe < 0.28.21, see
+      ``_recorder/_utils._process_scalar``).
+
+    matplotlib cannot convert a raw string to axis units on replay and raises
+    "Failed to convert value(s) to axis units". Parse ISO datetimes to
+    ``datetime`` and numeric strings to ``float`` (warning loudly, since the
+    latter only happens for stale recipes); otherwise return ``value`` unchanged.
+    """
+    if not isinstance(value, str):
+        return value
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        pass
+    try:
+        coerced = float(value)
+    except (ValueError, TypeError):
+        return value
+    warnings.warn(
+        f"Coerced stringified numeric axis value {value!r} to float on replay. "
+        "This recipe predates native numpy-scalar serialization; re-record with "
+        "figrecipe >= 0.28.21 to store numeric coordinates as numbers.",
+        stacklevel=2,
+    )
+    return coerced

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -13,24 +13,8 @@ from .._recorder import CallRecord, FigureRecord
 from .._serializer import load_recipe
 from .._utils._bundle import resolve_recipe_path
 from .._utils._grid import parse_grid_id
+from ._axis_coerce import coerce_axis_value
 from ._colorbars import _replay_colorbars
-
-
-def _maybe_parse_datetime(value: Any) -> Any:
-    """Parse an ISO datetime string to a datetime (for datetime-axis limits).
-
-    Recipes record datetime axis limits as ISO strings; matplotlib cannot
-    convert a raw string to axis units on replay. Returns a ``datetime`` when
-    ``value`` parses as one, otherwise returns ``value`` unchanged.
-    """
-    if not isinstance(value, str):
-        return value
-    try:
-        from datetime import datetime
-
-        return datetime.fromisoformat(value)
-    except (ValueError, TypeError):
-        return value
 
 
 def reproduce(
@@ -414,13 +398,14 @@ def _replay_call(
     # Get kwargs and reconstruct arrays
     kwargs = reconstruct_kwargs(call.kwargs)
 
-    # Axis-limit methods on a datetime axis recorded their bounds as ISO
-    # datetime strings; matplotlib can't convert a raw string to axis units on
-    # replay (raises "Failed to convert value(s) to axis units"). Parse such
-    # strings back to datetime so the recorded limits are reapplied.
+    # These methods are inherently numeric/datetime, but a recipe may store the
+    # value as a string -- an ISO datetime (datetime axes) or a stringified
+    # number like '0' from stale recipes. matplotlib can't convert a raw string
+    # to axis units on replay ("Failed to convert value(s) to axis units"), so
+    # coerce it back to datetime/float before reapplying the recorded value.
     if method_name in ("set_xlim", "set_ylim", "axvline", "axhline"):
-        args = [_maybe_parse_datetime(a) for a in args]
-        kwargs = {k: _maybe_parse_datetime(v) for k, v in kwargs.items()}
+        args = [coerce_axis_value(a) for a in args]
+        kwargs = {k: coerce_axis_value(v) for k, v in kwargs.items()}
 
     # Handle special transform markers
     if "transform" in kwargs:

--- a/tests/figrecipe/_recorder/test__utils.py
+++ b/tests/figrecipe/_recorder/test__utils.py
@@ -1,20 +1,83 @@
-"""Smoke import mirror for figrecipe._recorder._utils.
+"""Tests for figrecipe._recorder._utils.
 
-Auto-generated subpackage mirror placeholder; replace with real tests
-as the module matures. Satisfies the src<->tests mirror audit rule.
+Covers the numpy-scalar coercion in ``_process_scalar`` (regression for a
+NeuroVista Fig 2 bug: ``np.int64`` positions were serialized as the string
+``'0'`` and broke replay on a category-unit axis).
 """
 
-
+import numpy as np
 import pytest
+
+from figrecipe._recorder._utils import _process_scalar
+
+
+def _is_native(value):
+    """Mimic the recorder's serializability check: native JSON/YAML scalars only.
+
+    ``np.generic`` instances are deliberately NOT native here -- without
+    coercion they fall through to ``str(value)`` in ``_process_scalar``.
+    """
+    return isinstance(value, (bool, int, float, str)) and not isinstance(
+        value, np.generic
+    )
 
 
 def test_import__recorder__utils_module():
     # Arrange
-    # Arrange
-    # Act
-    # Assert
-    module_path = 'figrecipe._recorder._utils'
+    module_path = "figrecipe._recorder._utils"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+class TestProcessScalarNumpyCoercion:
+    """``_process_scalar`` must coerce numpy scalars to native Python numbers."""
+
+    def test_numpy_int_serialized_value_equals_zero(self):
+        # Arrange
+        value = np.int64(0)
+        # Act
+        out = _process_scalar("x", value, _is_native)
+        # Assert
+        assert out["data"] == 0
+
+    def test_numpy_int_serialized_as_python_int(self):
+        # Arrange
+        value = np.int64(0)
+        # Act
+        out = _process_scalar("x", value, _is_native)
+        # Assert
+        assert isinstance(out["data"], int)
+
+    def test_numpy_int_not_serialized_as_string(self):
+        # Arrange
+        value = np.int64(0)
+        # Act
+        out = _process_scalar("x", value, _is_native)
+        # Assert
+        assert not isinstance(out["data"], str)
+
+    def test_numpy_float_serialized_as_python_float(self):
+        # Arrange
+        value = np.float64(0.93)
+        # Act
+        out = _process_scalar("y", value, _is_native)
+        # Assert
+        assert isinstance(out["data"], float)
+
+    def test_numpy_bool_serialized_as_python_bool(self):
+        # Arrange
+        value = np.bool_(True)
+        # Act
+        out = _process_scalar("flag", value, _is_native)
+        # Assert
+        assert out["data"] is True
+
+    def test_native_string_passes_through_unchanged(self):
+        # Arrange
+        value = "label"
+        # Act
+        out = _process_scalar("s", value, _is_native)
+        # Assert
+        assert out["data"] == "label"

--- a/tests/figrecipe/_reproducer/test__axis_coerce.py
+++ b/tests/figrecipe/_reproducer/test__axis_coerce.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Coercion of replayed axis-limit / axis-line values (figrecipe).
+
+``set_xlim`` / ``set_ylim`` / ``axvline`` / ``axhline`` are inherently numeric or
+datetime. A recipe may still carry the value as a string: an ISO datetime
+(datetime axes) or a stringified number like ``'0'`` from recipes predating
+native numpy-scalar serialization. ``coerce_axis_value`` turns numeric strings
+into ``float`` and ISO strings into ``datetime`` so matplotlib can apply them on
+replay (otherwise ``ConversionError: Failed to convert value(s) to axis units``).
+"""
+
+import datetime as _dt
+
+import pytest
+
+from figrecipe._reproducer._axis_coerce import coerce_axis_value
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_stringified_number_coerced_to_float():
+    # Arrange
+    value = "0"
+    # Act
+    result = coerce_axis_value(value)
+    # Assert
+    assert result == 0.0
+
+
+def test_stringified_number_warns_about_stale_recipe():
+    # Arrange
+    value = "1.5"
+    # Act
+    # Assert
+    with pytest.warns(UserWarning, match="predates native numpy-scalar"):
+        coerce_axis_value(value)
+
+
+def test_iso_datetime_string_parsed_to_datetime():
+    # Arrange
+    value = "2024-01-02"
+    # Act
+    result = coerce_axis_value(value)
+    # Assert
+    assert result == _dt.datetime(2024, 1, 2)
+
+
+def test_non_numeric_string_returned_unchanged():
+    # Arrange
+    value = "category-label"
+    # Act
+    result = coerce_axis_value(value)
+    # Assert
+    assert result == "category-label"
+
+
+def test_numeric_value_passes_through_unchanged():
+    # Arrange
+    value = 1.5
+    # Act
+    result = coerce_axis_value(value)
+    # Assert
+    assert result == 1.5

--- a/tests/integration/test_stale_recipe_axis_coercion.py
+++ b/tests/integration/test_stale_recipe_axis_coercion.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Replay of stale stringified axis limits (figrecipe).
+
+Recipes written before native numpy-scalar serialization (figrecipe < 0.28.21)
+could store a numeric axis limit / line position as the STRING ``'0'`` (an
+``np.int64`` coordinate hit the ``str(value)`` fallback). On replay matplotlib
+cannot convert a raw string to axis units and raises
+``ConversionError: Failed to convert value(s) to axis units`` -- which broke
+reproduce/compose of such recipes (NeuroVista Fig 02 composite). The reproducer
+now coerces stringified numbers on the inherently-numeric axis methods; this
+guards that a stale recipe still reproduces with the recorded numeric limits.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import pytest
+import yaml
+
+import figrecipe as fr
+
+
+@pytest.fixture()
+def stale_string_xlim_recipe(tmp_path):
+    """A recipe whose ``set_xlim`` args were stringified (pre-0.28.21 artifact)."""
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.plot([0, 1, 2], [0.0, 1.0, 4.0])
+    ax.set_xlim(0, 2)
+    try:
+        fr.save(fig, str(tmp_path / "fig.png"))
+    except ValueError:
+        pass
+    plt.close("all")
+    recipe = tmp_path / "fig.yaml"
+    data = yaml.safe_load(recipe.read_text())
+    for ax_entry in data.get("axes", {}).values():
+        for call in ax_entry.get("calls", []) + ax_entry.get("decorations", []):
+            if call.get("function") == "set_xlim":
+                for arg in call.get("args", []):
+                    if "data" in arg:
+                        arg["data"] = str(arg["data"])
+    recipe.write_text(yaml.safe_dump(data))
+    return recipe
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_stale_stringified_xlim_replays_as_numeric_limits(stale_string_xlim_recipe):
+    # Arrange
+    _, rax = fr.reproduce(str(stale_string_xlim_recipe))
+    mpl_ax = getattr(rax, "ax", rax)
+    # Act
+    xlim = mpl_ax.get_xlim()
+    plt.close("all")
+    # Assert
+    assert xlim == (0.0, 2.0)


### PR DESCRIPTION
## Problem (NeuroVista Fig 02 composite — Follow-up 3)

PR #212 fixed numpy-scalar serialization at **record time** so coordinates stop
serializing as the string `'0'`. But that doesn't help recipes **already on disk**:
a pre-0.28.21 recipe still carries `'0'`, and on replay the inherently-numeric
axis methods choke on it:

```
matplotlib.units.ConversionError: Failed to convert value(s) to axis units: '0'
```

NeuroVista correctly traced this to the replay dispatch: `_maybe_parse_datetime('0')`
fails the ISO-datetime parse and returns the raw string, which matplotlib then
rejects. It bit the **composite** because `plt.compose` loads each panel recipe and
re-validates the merged figure on save.

## Fix (replay side — completes #212)

`set_xlim` / `set_ylim` / `axvline` / `axhline` are inherently numeric or datetime —
a category string is never a valid argument. Generalize the replay coercion
(`_maybe_parse_datetime` → `coerce_axis_value`, extracted into
`_reproducer/_axis_coerce.py`): after the ISO-datetime attempt, also coerce a
numeric-looking string to `float`. This is **provably safe** for these four methods
and lets pre-0.28.21 recipes reproduce **without re-recording** (important for panels
whose data is expensive to regenerate). It is **loud, not silent**: a `UserWarning`
fires telling the user the recipe is stale and to re-record with figrecipe ≥ 0.28.21.

The helper was extracted to its own module because `_core.py` is at the 512-line
limit (same pressure #209 hit) — this keeps it under budget and gives the coercion a
mirrored test file.

## Salvaged from #213 (NeuroVista's parallel PR — "both worlds")

NeuroVista independently opened #213 with the *same* record-time `np.generic`
coercion as #212 (already merged) **plus** 6 focused recorder-unit tests. The source
change is redundant, but the tests are net-new coverage at a level #212 didn't add —
so this PR adopts them (`tests/figrecipe/_recorder/test__utils.py`, replacing the
auto-generated placeholder). Credit: @ywatanabe1989 / NeuroVista agent. #213 will be
closed as superseded with its tests preserved here.

## Verification

- `tests/figrecipe/_reproducer/test__axis_coerce.py` (5): numeric string → `float`
  (+ stale-recipe warning), ISO string → `datetime`, category string unchanged,
  numbers pass through.
- `tests/integration/test_stale_recipe_axis_coercion.py` (1): a recipe with a
  **stringified `set_xlim`** reproduces to the recorded numeric limits —
  **fails on develop** with the exact `ConversionError`, **passes with this fix**.
- `tests/figrecipe/_recorder/test__utils.py` (7, salvaged from #213): numpy
  int/float/bool coerce to native; native string passes through.
- No regressions: `_reproducer`, `_recorder`, `integration` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
