### PR TITLE
fix(diagram): standalone diagram reproduces faithfully (figsize + axes-pin + deterministic content-bbox crop)

### DIFF
--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -28,7 +28,12 @@ from ._save_config import (  # noqa: F401
 )
 
 # Import helpers from separate module
-from ._save_helpers import _capture_axes_bboxes, _capture_content_layout
+from ._save_helpers import (
+    _capture_axes_bboxes,
+    _capture_content_layout,
+    _crop_diagram_to_content_bbox,
+    _is_standalone_diagram_figure,
+)
 from ._save_helpers import (
     save_hitmap as _save_hitmap,
 )
@@ -197,6 +202,22 @@ def save_figure(
     # Check if using constrained_layout - need different save strategy
     use_constrained = fig.fig.get_constrained_layout()
 
+    # Output-format flags (used both to pick the save strategy and to crop).
+    croppable_formats = {".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp"}
+    is_croppable = image_path.suffix.lower() in croppable_formats
+    is_svg = image_path.suffix.lower() == ".svg"
+
+    # Standalone RASTER diagrams enable constrained_layout but must NOT be saved
+    # with bbox_inches="tight": that re-measures the ink at SAVE time, and the
+    # recipe-reproduced render carries a hair more vertical ink than the original,
+    # so the tight box differs -> figure-SIZE mismatch at validate (NeuroVista
+    # Fig 02 panel b). They are instead saved full-canvas below and cropped to the
+    # RECORDED, dpi-independent content_bbox (same box for save and every
+    # reproduce). Composed diagrams, and vector diagram exports (PDF/SVG), keep
+    # the normal tight path.
+    is_diagram = _is_standalone_diagram_figure(fig)
+    use_tight = use_constrained and not (is_diagram and is_croppable)
+
     # Get crop margins from mm_layout
     mm_layout = getattr(fig, "_mm_layout", None)
     crop_margin_left_mm = 1
@@ -214,10 +235,10 @@ def save_figure(
     if _is_opaque_facecolor(facecolor):
         restore_patches = _make_patches_opaque(fig)
 
-    pad_inches = 0.0  # updated below if use_constrained
+    pad_inches = 0.0  # updated below if use_tight
 
     try:
-        if use_constrained:
+        if use_tight:
             # For constrained_layout, use bbox_inches='tight' to crop at save time
             avg_margin_mm = (
                 crop_margin_left_mm
@@ -267,6 +288,7 @@ def save_figure(
                 )
                 # Mark for cropping since we couldn't use bbox_inches="tight"
                 use_constrained = False
+                use_tight = False
         else:
             # Standard save without bbox_inches to preserve mm layout
             fig.fig.savefig(
@@ -280,13 +302,30 @@ def save_figure(
     # Auto-crop using stored crop margins from mm_layout (or explicit parameter)
     # Raster formats: pixel-based content-aware crop (post-processing)
     # SVG: viewBox adjustment via tightbbox query (post-processing, no bbox_inches)
-    # Skip for constrained_layout (already cropped at save time)
-    croppable_formats = {".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp"}
-    is_croppable = image_path.suffix.lower() in croppable_formats
-    is_svg = image_path.suffix.lower() == ".svg"
-
+    # Skip when bbox_inches="tight" already cropped at save time (use_tight).
+    #
+    # Standalone diagrams (saved full-canvas above) crop to the RECORDED,
+    # dpi-independent content_bbox so the save and every reproduce land at
+    # identical pixel dimensions; on failure this returns None and we fall
+    # through to the normal content-aware crop (with a warning).
+    diagram_cropped = False
     crop_offset = None
-    if is_croppable and not use_constrained:
+    if is_diagram and is_croppable:
+        crop_offset = _crop_diagram_to_content_bbox(
+            fig,
+            image_path,
+            crop_margin_mm,
+            (
+                crop_margin_left_mm,
+                crop_margin_right_mm,
+                crop_margin_top_mm,
+                crop_margin_bottom_mm,
+            ),
+            dpi,
+        )
+        diagram_cropped = crop_offset is not None
+
+    if is_croppable and not use_tight and not diagram_cropped:
         if crop_margin_mm is not None:
             # Explicit uniform crop margin
             from .._utils._crop import crop
@@ -311,7 +350,7 @@ def save_figure(
                 return_offset=True,
             )
 
-    elif is_svg and not use_constrained:
+    elif is_svg and not use_tight:
         # SVG: adjust viewBox post-save using tightbbox query (not bbox_inches='tight')
         from .._utils._crop import crop_svg
 
@@ -338,11 +377,13 @@ def save_figure(
         fig.record.mm_layout = fig._mm_layout
 
     # Save hitmap if requested (for GUI editor element selection)
-    # Pass bbox_inches="tight" when the image was saved that way (constrained_layout)
-    # so the hitmap crop matches the saved image exactly (critical for pie/imshow).
+    # Pass bbox_inches="tight" only when the image was actually saved that way
+    # (use_tight) so the hitmap crop matches the saved image exactly (critical
+    # for pie/imshow). Standalone diagrams were saved full-canvas, so they must
+    # NOT use "tight" here (their hitmap is rendered separately regardless).
     if save_hitmap:
-        _hitmap_bbox = "tight" if use_constrained else None
-        _hitmap_pad = pad_inches if use_constrained else 0.0
+        _hitmap_bbox = "tight" if use_tight else None
+        _hitmap_pad = pad_inches if use_tight else 0.0
         _save_hitmap(fig, image_path, dpi, verbose, _hitmap_bbox, _hitmap_pad)
     from ._separate_legend import save_separate_legends as _sl
 

--- a/src/figrecipe/_api/_save_helpers.py
+++ b/src/figrecipe/_api/_save_helpers.py
@@ -14,6 +14,144 @@ from .._utils._grid import grid_id
 _DIVIDER_PLOTTERS = {"stx_scatter_hist"}
 
 
+def _is_standalone_diagram_figure(fig) -> bool:
+    """True for a single-axes figure whose content is a figrecipe Diagram.
+
+    Two code paths produce such a figure and BOTH must be recognised so the save
+    and the reproduce crop to the same recorded ``content_bbox`` (otherwise only
+    one side would, defeating the fix):
+
+    * Live render / the validator's re-save of the ORIGINAL: ``Diagram.render``
+      tags the owned figure with ``_figrecipe_diagram`` (set only when it owns
+      the figure -- composed multi-panel diagrams never set it).
+    * The validator's re-save of the REPRODUCED figure: replay goes through
+      ``replay_diagram_native_call`` (NOT ``ax.diagram``), so the live marker is
+      absent; instead detect a single-axes figure whose sole recorded axes
+      carries a ``function=="diagram"`` call.
+
+    The single-axes guard keeps composed figures (which embed diagrams in a grid)
+    on the normal content-aware crop path -- only the standalone case is
+    size-sensitive to the content-aware crop's per-render ink drift.
+    """
+    if getattr(fig.fig, "_figrecipe_diagram", None) is not None:
+        return True
+
+    if len(fig.fig.get_axes()) != 1:
+        return False
+
+    axes_records = getattr(fig.record, "axes", {})
+    if len(axes_records) != 1:
+        return False
+    only_axes = next(iter(axes_records.values()))
+    return any(c.function == "diagram" for c in only_axes.calls)
+
+
+def crop_to_content_bbox(
+    image_path: Path,
+    content_bbox,
+    margins_mm,
+    dpi: int,
+) -> Optional[dict]:
+    """Crop a saved raster to a RECORDED tight-ink bbox (dpi-independent).
+
+    Diagram figures render with a hair of different text ink between the
+    original save and the recipe-reproduced save, so a pixel-content-aware
+    crop (``_utils._crop.crop``) lands on slightly different boxes -> the two
+    cropped PNGs differ in height and reproducibility validation reports a SIZE
+    mismatch (NeuroVista Fig 02 panel b). Instead, crop both to the SAME bbox
+    captured once at save time (``FigureRecord.content_bbox``), so the original
+    save and every reproduce crop to identical pixel dimensions.
+
+    ``content_bbox`` is ``[l, b, w, h]`` in the *uncropped* figure fraction
+    (matplotlib coords, y=0 at the bottom). It is a FRACTION, so it is applied
+    to the actual saved-image pixel dimensions and therefore stays correct at
+    any dpi (the validator re-saves at dpi=150 while the user's real save may be
+    dpi=300). Margins (``crop_margin_{left,right,top,bottom}_mm``) are added in
+    pixels at ``dpi`` to match the normal crop path.
+
+    Returns the same ``crop_offset`` dict shape as ``_utils._crop.crop`` (so
+    ``_capture_axes_bboxes`` keeps working), or ``None`` on failure (the caller
+    then falls back to the content-aware crop with a warning).
+    """
+    from PIL import Image
+
+    from .._utils._crop import crop, mm_to_pixels
+
+    try:
+        l, b, w, h = (float(v) for v in content_bbox)
+    except (TypeError, ValueError):
+        return None
+
+    with Image.open(image_path) as img:
+        img_w, img_h = img.size
+
+    # content_bbox is matplotlib y-up; PIL crop box is y-down (origin top-left).
+    # top edge in mpl fraction = b + h ; bottom edge = b.
+    left_px = round(l * img_w) - mm_to_pixels(margins_mm["left"], dpi)
+    right_px = round((l + w) * img_w) + mm_to_pixels(margins_mm["right"], dpi)
+    upper_px = round((1.0 - (b + h)) * img_h) - mm_to_pixels(margins_mm["top"], dpi)
+    lower_px = round((1.0 - b) * img_h) + mm_to_pixels(margins_mm["bottom"], dpi)
+
+    if right_px - left_px <= 0 or lower_px - upper_px <= 0:
+        return None
+
+    # Reuse crop()'s explicit-box path: it preserves DPI/PNG-text metadata and
+    # extends the canvas with the detected background when the box exceeds the
+    # image edge (content can overflow the canvas, so this is expected).
+    _, crop_offset = crop(
+        image_path,
+        output_path=image_path,
+        crop_box=(left_px, upper_px, right_px, lower_px),
+        return_offset=True,
+    )
+    return crop_offset
+
+
+def _crop_diagram_to_content_bbox(
+    fig,
+    image_path: Path,
+    crop_margin_mm: Optional[float],
+    crop_margins_mm,
+    dpi: int,
+) -> Optional[dict]:
+    """Crop a standalone-diagram raster to its recorded ``content_bbox``.
+
+    Ensures ``fig.record.content_bbox`` exists BEFORE cropping: on the user's
+    first real save it is still None, so it is computed here from the (uncropped)
+    figure; on the validator's re-save of the original it is already set from the
+    first save, and on a recipe-reproduced figure it is loaded from disk. All
+    three therefore crop to the SAME dpi-independent fraction, so the saved file
+    and every reproduce land at identical pixel dimensions.
+
+    ``crop_margin_mm`` (explicit uniform override) wins over ``crop_margins_mm``
+    (the per-side mm_layout margins, ``(left, right, top, bottom)``).
+
+    Returns a ``crop_offset`` dict, or ``None`` (with a warning) when no
+    ``content_bbox`` is available -- the caller then falls back to the normal
+    content-aware crop so a missing bbox never silently skips cropping.
+    """
+    if getattr(fig.record, "content_bbox", None) is None:
+        _capture_content_layout(fig)
+
+    content_bbox = getattr(fig.record, "content_bbox", None)
+    if content_bbox is None:
+        import warnings
+
+        warnings.warn(
+            "Diagram figure has no content_bbox; falling back to content-aware "
+            "crop (the standalone diagram may reproduce at a different size).",
+            UserWarning,
+        )
+        return None
+
+    ml, mr, mt, mb = crop_margins_mm
+    if crop_margin_mm is not None:
+        ml = mr = mt = mb = crop_margin_mm
+    margins = {"left": ml, "right": mr, "top": mt, "bottom": mb}
+
+    return crop_to_content_bbox(image_path, content_bbox, margins, dpi)
+
+
 def _crop_to_axes_size(
     fig,
     image_path: Path,

--- a/src/figrecipe/_reproducer/_replay_diagram.py
+++ b/src/figrecipe/_reproducer/_replay_diagram.py
@@ -91,6 +91,7 @@ def replay_diagram_native_call(ax: Axes, call: CallRecord) -> Any:
     diagram_data = kwargs.pop("diagram_data", None) or kwargs.pop(
         "schematic_data", None
     )
+    figsize_in = kwargs.pop("figsize_in", None)
 
     if diagram_data is None:
         import warnings
@@ -101,6 +102,17 @@ def replay_diagram_native_call(ax: Axes, call: CallRecord) -> Any:
     # Reconstruct diagram from serialized data
     info = Diagram.from_dict(diagram_data)
 
+    single_axis = len(ax.figure.get_axes()) <= 1
+
+    # Restore the EXACT figure size used at save time, BEFORE rendering. render()
+    # lays out text/boxes against the current figure size and can widen info.xlim
+    # to fit; at save the figure was sized before that, so rendering reproduce at
+    # a different incoming size diverged in both width and the cropped height
+    # (NeuroVista Fig 02 panel b SIZE mismatch). The recorder now stores the true
+    # figsize; pin it first so save and reproduce render identically.
+    if single_axis and figsize_in is not None:
+        ax.figure.set_size_inches(float(figsize_in[0]), float(figsize_in[1]))
+
     # Render to provided axes
     fig, rendered_ax = info.render(ax=ax)
 
@@ -110,10 +122,20 @@ def replay_diagram_native_call(ax: Axes, call: CallRecord) -> Any:
     if len(fig.get_axes()) > 1:
         ax.set_aspect("auto")
         ax.set_facecolor("white")
+    elif figsize_in is not None:
+        # render() may have re-touched the figure size; re-pin to the saved size.
+        fig.set_size_inches(float(figsize_in[0]), float(figsize_in[1]))
     else:
         x_range = info.xlim[1] - info.xlim[0]
         y_range = info.ylim[1] - info.ylim[0]
         fig.set_size_inches(x_range / 25.4, y_range / 25.4)
+
+    # Standalone diagram: pin the axes to fill the figure, matching the recorder
+    # (_wrappers/_axes_diagram). Default subplot margins differ between the save
+    # figure and this rebuilt one, so with aspect="equal" the diagram would
+    # letterbox at a different vertical offset -> different cropped height.
+    if single_axis:
+        rendered_ax.set_position((0.0, 0.0, 1.0, 1.0))
 
     return fig, rendered_ax
 

--- a/src/figrecipe/_wrappers/_axes_diagram.py
+++ b/src/figrecipe/_wrappers/_axes_diagram.py
@@ -117,6 +117,15 @@ def diagram_plot(
     # Render to the provided axes
     fig, rendered_ax = info.render(ax=ax, auto_fix=auto_fix)
 
+    # For a standalone diagram (figure sized to the diagram), pin the axes to
+    # fill the figure. The default subplot margins differ between the save figure
+    # and the figure rebuilt by the reproducer, so with aspect="equal" the
+    # diagram letterboxed at a different vertical offset -> different cropped
+    # height (NeuroVista Fig 02 panel b). A fixed position makes save and
+    # reproduce identical; _reproducer/_replay_diagram applies the same pin.
+    if len(fig.get_axes()) == 1:
+        rendered_ax.set_position((0.0, 0.0, 1.0, 1.0))
+
     # Post-render validations (skipped inside render() when ax is provided)
     # Errors are stored on the figure so fr.save() can save _FAILED figures
     from .._diagram._diagram import _validate as _sv
@@ -128,13 +137,22 @@ def diagram_plot(
             fig._diagram_validation_errors = []
         fig._diagram_validation_errors.append(str(e))
 
-    # Record for reproducibility
+    # Record for reproducibility. Capture the figure's ACTUAL size now -- this is
+    # what savefig will use. render() can widen info.xlim to fit text content, but
+    # the figure was already sized from the pre-widen extent and is not resized
+    # again, so deriving the reproduce figsize from the recorded (post-widen) xlim
+    # produced a larger figure than the original save -> figure-SIZE mismatch at
+    # validate time (NeuroVista Fig 02 panel b). Recording the true figsize lets
+    # the reproducer restore the exact saved size.
     if track:
+        _fw, _fh = fig.get_size_inches()
+        figsize_in = (float(_fw), float(_fh))
         _record_diagram_call(
             recorder,
             position,
             call_id,
             info,
+            figsize_in,
         )
 
     return fig, rendered_ax
@@ -145,6 +163,7 @@ def _record_diagram_call(
     position: Tuple[int, int],
     call_id: Optional[str],
     info,
+    figsize_in: Optional[Tuple[float, float]] = None,
 ) -> None:
     """Record diagram call for reproducibility."""
     from .._recorder import CallRecord
@@ -154,11 +173,14 @@ def _record_diagram_call(
     # Serialize diagram data for recipe
     diagram_data = info.to_dict()
 
+    kwargs = {"diagram_data": diagram_data}
+    if figsize_in is not None:
+        kwargs["figsize_in"] = list(figsize_in)
     record = CallRecord(
         id=final_id,
         function="diagram",
         args=[],
-        kwargs={"diagram_data": diagram_data},
+        kwargs=kwargs,
         ax_position=position,
     )
     ax_record = recorder.figure_record.get_or_create_axes(*position)

--- a/tests/integration/test_diagram_standalone_reproduction.py
+++ b/tests/integration/test_diagram_standalone_reproduction.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save -> reproduce round-trip for a standalone figrecipe Diagram.
+
+A standalone diagram enables constrained_layout and was saved with
+``bbox_inches="tight"``, which re-measures the ink at SAVE time. The recipe-
+reproduced render carries a hair more vertical ink than the original (long box
+labels widen ``info.xlim`` at render time), so the tight box differed and
+reproducibility validation reported a figure-SIZE mismatch -- writing a
+``<stem>-not-reproduced.png`` beside the figure (NeuroVista Fig 02 panel b).
+
+The fix crops standalone diagrams to a RECORDED, dpi-independent ``content_bbox``
+so the original save and every reproduce land at identical pixel dimensions.
+
+This guard uses LONG box labels on purpose: short-label diagrams do not trigger
+the render-time xlim widening and already round-trip on develop, so they would
+not catch the regression.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import figrecipe as fr
+
+
+def _long_label_diagram():
+    """Build a standalone diagram whose long labels widen xlim at render time."""
+    d = fr.Diagram(title="long-label pipeline", width_mm=120, height_mm=40)
+    for key in ("alpha", "beta", "gamma", "delta"):
+        d.add_box(
+            key,
+            f"{key.title()} stage\nwith a long label",
+            subtitle=f"detail for {key}\nspanning two lines",
+            width_mm=22,
+            height_mm=18,
+            padding_mm=2,
+        )
+    d.add_arrow("alpha", "beta")
+    d.add_arrow("beta", "gamma")
+    d.add_arrow("gamma", "delta")
+    d.auto_layout(layout="lr", gap_mm=6)
+    return d
+
+
+def test_standalone_long_label_diagram_reproduces_clean(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots(
+        axes_width_mm=120, axes_height_mm=40, margin_top_mm=14, panel_labels=False
+    )
+    ax.axis("off")
+    ax.set_title("long-label pipeline")
+    ax.diagram(_long_label_diagram(), id="long_label", track=True, auto_fix=True)
+    # Act
+    fr.save(fig, str(tmp_path / "diagram.png"))  # raises if it cannot reproduce
+    # Assert
+    assert not list(tmp_path.glob("*-not-reproduced.*"))


### PR DESCRIPTION
## Problem (NeuroVista Fig 02 panel b)

A standalone `fr.Diagram` panel failed save→reproduce validation with a figure **SIZE mismatch** (e.g. `original (550, 1613) vs reproduced (576, 1613) (HxW)`), so the panel — and any composite that references it — could not round-trip.

## Root cause (two independent layers)

**1. Width + axes geometry.** `Diagram.render()` widens `info.xlim` to fit text content, but the recorder sized the figure from the *pre*-widen extent while recording the *post*-widen `xlim`; the reproducer then rebuilt a wider figure. The standalone diagram axes also landed at a different vertical offset between save and reproduce (default subplot margins differ), so `aspect="equal"` letterboxed differently.

**2. Height (content crop).** Standalone diagrams are cropped to content. The crop recomputed the ink bbox on every render (`get_tightbbox`/pixel detection), and the save-render vs reproduce-render differ by a hair of text ink (box title/subtitle), so the crop landed on a different box → different cropped height.

## Fix

**Layer 1** (`_wrappers/_axes_diagram.py`, `_reproducer/_replay_diagram.py`): record the *actual* figure size (`figsize_in`) on the diagram call and restore it on replay (instead of re-deriving from the render-widened `xlim`); pin the standalone diagram axes to a fixed position so geometry is identical save↔reproduce.

**Layer 2** (`_api/_save.py`, `_api/_save_helpers.py`): detect a standalone raster diagram (live `_figrecipe_diagram` marker **or** a reproduced single-axes figure with a recorded `diagram` call), save it **full-canvas** (not `bbox_inches="tight"`), and crop to the **recorded, dpi-independent `content_bbox`** — the same box for the original save and every reproduce. Falls back (with a warning) to the content-aware crop if no `content_bbox` is available.

**Scope is intentionally narrow:** only standalone *raster* diagrams change. Composed/multi-panel diagrams and vector (PDF/SVG) diagram exports keep the existing path. Non-diagram saves are untouched.

## Verification

- **Panel b now PASSES** (`Reproducibility Validation: PASSED`, no `*-not-reproduced`). Not a false pass: the user-facing PNG (dpi=300) is 3180×1148 and a fresh dpi=300 reproduce is also 3180×1148.
- **Regression test** `tests/integration/test_diagram_standalone_reproduction.py` (long box labels → triggers xlim widening): **fails on develop** (`image SIZE mismatch: original (428,1266) vs reproduced (447,1241)`), **passes here**. AAA + single assertion + no mock.
- **No regressions:** integration + diagram public API **133 passed, 4 skipped** (includes compose/embed/save-validate); reproducer **70**, `_api` **22**, `_diagram` **96** (agent-run). Blast-radius spot checks: plain line plot (content-aware crop), pie (constrained-layout tight save), and diagram-as-SVG all still pass with no artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
