### PR TITLE
fix(diagram): stack box title/subtitle/content per visual line (no overlap)

### DIFF
--- a/src/figrecipe/_diagram/_diagram/_render.py
+++ b/src/figrecipe/_diagram/_diagram/_render.py
@@ -314,63 +314,12 @@ def render_box(diagram: "Diagram", ax: Axes, bid: str, box: "BoxSpec") -> None:
         diagram._render_info[bid] = {"pos": pos}
         return
 
-    # Build text items: list of (text, fontsize, fontweight, color)
-    is_code = box.shape == "codeblock"
-    items = [(box.title, 11, "bold", title_color)]
-    if box.subtitle:
-        items.append((box.subtitle, 9, "normal", colors["text"]))
-    for line in box.content:
-        if isinstance(line, dict):
-            pfx = {"circle": "\u00b7 ", "dash": "\u2013 ", "arrow": "\u2192 "}.get(
-                box.bullet, ""
-            )
-            items.append(
-                (
-                    pfx + line.get("text", ""),
-                    line.get("fontsize", 8),
-                    line.get("fontweight", "normal"),
-                    line.get("color", colors["text"]),
-                )
-            )
-        else:
-            pfx = {"circle": "\u00b7 ", "dash": "\u2013 ", "arrow": "\u2192 "}.get(
-                box.bullet, ""
-            )
-            items.append(
-                (pfx + str(line), 8 if not is_code else 7, "normal", colors["text"])
-            )
+    # Title / subtitle / content text layout lives in _render_box_text so this
+    # file stays under the 512-line limit (see that module for the per-line
+    # vertical stacking rules).
+    from ._render_box_text import render_box_text
 
-    # Text area = PositionSpec minus padding on all sides
-    inner_h = pos.height_mm - 2 * box.padding_mm
-    n = len(items)
-    gap = min(inner_h / max(n, 1) * 0.85, 6.0) if n > 1 else 0
-    block_h = gap * (n - 1)
-    top_y = pos.y_mm + block_h / 2
-
-    # Only use text background if box has no fill (transparent background)
-    # Otherwise text would be double-highlighted with box fill + text bbox fill
-    _txt_bg = (
-        None
-        if fill and fill != "none"
-        else dict(facecolor="white", edgecolor="none", pad=0.5, alpha=0.85)
-    )
-    ha = "left" if is_code else "center"
-    x_text = (pos.x_mm - pos.width_mm / 2 + box.padding_mm) if is_code else pos.x_mm
-    for i, (text, fsize, fweight, fcolor) in enumerate(items):
-        ax.text(
-            x_text,
-            top_y - i * gap,
-            text,
-            ha=ha,
-            va="center",
-            fontsize=fsize,
-            fontweight=fweight,
-            color=fcolor,
-            fontfamily="monospace" if is_code and i > 0 else "sans-serif",
-            fontstyle="normal",
-            zorder=7,
-            bbox=_txt_bg,
-        )
+    render_box_text(ax, pos, box, fill, title_color, colors)
 
     diagram._render_info[bid] = {"pos": pos}
 

--- a/src/figrecipe/_diagram/_diagram/_render_box_text.py
+++ b/src/figrecipe/_diagram/_diagram/_render_box_text.py
@@ -19,6 +19,13 @@ if TYPE_CHECKING:
 
     from ._core import BoxSpec, PositionSpec
 
+# Max pitch between consecutive text rows (mm); keeps tall boxes from spreading
+# their lines too far apart while still letting short boxes breathe.
+_MAX_ROW_GAP_MM = 6.0
+# Fraction of the per-row slot used as the row pitch, so rows do not butt right
+# up against the box padding.
+_ROW_FILL = 0.85
+
 
 def _build_text_items(
     box: "BoxSpec", title_color, colors: Dict
@@ -59,15 +66,30 @@ def render_box_text(
     title_color,
     colors: Dict,
 ) -> None:
-    """Draw a box's title / subtitle / content as vertically stacked rows."""
+    """Draw a box's title / subtitle / content as vertically stacked rows.
+
+    Each item is placed on its own row(s); items whose text contains embedded
+    ``\\n`` occupy as many rows as they have visual lines, so a multi-line
+    title (e.g. ``"Phase\\nfilterbank"``) no longer renders on top of the
+    subtitle or the first content line (NeuroVista Ask 4). Counting items
+    instead of visual lines was the bug: matplotlib stacks a multi-line string
+    as a block taller than a single row, so the next item's row landed inside
+    that block.
+    """
     is_code = box.shape == "codeblock"
     items = _build_text_items(box, title_color, colors)
 
-    # Text area = PositionSpec minus padding on all sides
+    # Number of *visual* rows: an item with N embedded newlines spans N rows.
+    line_counts = [text.count("\n") + 1 for text, _, _, _ in items]
+    n_rows = sum(line_counts)
+
+    # Text area = PositionSpec minus padding on all sides; the row pitch packs
+    # n_rows evenly into it. A single row has no pitch (centred in the box).
     inner_h = pos.height_mm - 2 * box.padding_mm
-    n = len(items)
-    gap = min(inner_h / max(n, 1) * 0.85, 6.0) if n > 1 else 0
-    block_h = gap * (n - 1)
+    row_gap = (
+        min(inner_h / max(n_rows, 1) * _ROW_FILL, _MAX_ROW_GAP_MM) if n_rows > 1 else 0
+    )
+    block_h = row_gap * (n_rows - 1)
     top_y = pos.y_mm + block_h / 2
 
     # Only use text background if box has no fill (transparent background)
@@ -79,21 +101,28 @@ def render_box_text(
     )
     ha = "left" if is_code else "center"
     x_text = (pos.x_mm - pos.width_mm / 2 + box.padding_mm) if is_code else pos.x_mm
-    for i, (text, fsize, fweight, fcolor) in enumerate(items):
+
+    # Walk items top-to-bottom. ``row_cursor`` is the top row index of the
+    # current item; a multi-line item is centred on the rows it occupies so its
+    # own lines stay tight while consecutive items stay separated.
+    row_cursor = 0
+    for (text, fsize, fweight, fcolor), n_lines in zip(items, line_counts):
+        center_row = row_cursor + (n_lines - 1) / 2
         ax.text(
             x_text,
-            top_y - i * gap,
+            top_y - center_row * row_gap,
             text,
             ha=ha,
             va="center",
             fontsize=fsize,
             fontweight=fweight,
             color=fcolor,
-            fontfamily="monospace" if is_code and i > 0 else "sans-serif",
+            fontfamily="monospace" if is_code and row_cursor > 0 else "sans-serif",
             fontstyle="normal",
             zorder=7,
             bbox=txt_bg,
         )
+        row_cursor += n_lines
 
 
 # EOF

--- a/src/figrecipe/_diagram/_diagram/_render_box_text.py
+++ b/src/figrecipe/_diagram/_diagram/_render_box_text.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Text layout for diagram boxes.
+
+Extracted from ``_render.py`` (which sits at the 512-line file limit) so the
+box-text vertical stacking can be maintained on its own. ``render_box`` in
+``_render.py`` is now a thin orchestrator that draws the box shape and then
+delegates the title / subtitle / content text to :func:`render_box_text`.
+
+The vertical budget mirrors :meth:`Diagram._auto_box_height` in ``_core.py``:
+a box reserves vertical space for its title, optional subtitle and each content
+line.
+"""
+
+from typing import TYPE_CHECKING, Dict, List, Tuple
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+    from ._core import BoxSpec, PositionSpec
+
+
+def _build_text_items(
+    box: "BoxSpec", title_color, colors: Dict
+) -> List[Tuple[str, float, str, object]]:
+    """Build the ordered (text, fontsize, fontweight, color) list for a box.
+
+    Title first, optional subtitle, then each content line (dict or str) with
+    the bullet prefix applied.
+    """
+    is_code = box.shape == "codeblock"
+    items: List[Tuple[str, float, str, object]] = [(box.title, 11, "bold", title_color)]
+    if box.subtitle:
+        items.append((box.subtitle, 9, "normal", colors["text"]))
+    bullet_prefixes = {"circle": "· ", "dash": "– ", "arrow": "→ "}
+    for line in box.content:
+        pfx = bullet_prefixes.get(box.bullet, "")
+        if isinstance(line, dict):
+            items.append(
+                (
+                    pfx + line.get("text", ""),
+                    line.get("fontsize", 8),
+                    line.get("fontweight", "normal"),
+                    line.get("color", colors["text"]),
+                )
+            )
+        else:
+            items.append(
+                (pfx + str(line), 8 if not is_code else 7, "normal", colors["text"])
+            )
+    return items
+
+
+def render_box_text(
+    ax: "Axes",
+    pos: "PositionSpec",
+    box: "BoxSpec",
+    fill,
+    title_color,
+    colors: Dict,
+) -> None:
+    """Draw a box's title / subtitle / content as vertically stacked rows."""
+    is_code = box.shape == "codeblock"
+    items = _build_text_items(box, title_color, colors)
+
+    # Text area = PositionSpec minus padding on all sides
+    inner_h = pos.height_mm - 2 * box.padding_mm
+    n = len(items)
+    gap = min(inner_h / max(n, 1) * 0.85, 6.0) if n > 1 else 0
+    block_h = gap * (n - 1)
+    top_y = pos.y_mm + block_h / 2
+
+    # Only use text background if box has no fill (transparent background)
+    # Otherwise text would be double-highlighted with box fill + text bbox fill
+    txt_bg = (
+        None
+        if fill and fill != "none"
+        else dict(facecolor="white", edgecolor="none", pad=0.5, alpha=0.85)
+    )
+    ha = "left" if is_code else "center"
+    x_text = (pos.x_mm - pos.width_mm / 2 + box.padding_mm) if is_code else pos.x_mm
+    for i, (text, fsize, fweight, fcolor) in enumerate(items):
+        ax.text(
+            x_text,
+            top_y - i * gap,
+            text,
+            ha=ha,
+            va="center",
+            fontsize=fsize,
+            fontweight=fweight,
+            color=fcolor,
+            fontfamily="monospace" if is_code and i > 0 else "sans-serif",
+            fontstyle="normal",
+            zorder=7,
+            bbox=txt_bg,
+        )
+
+
+# EOF

--- a/tests/figrecipe/_diagram/_diagram/test__render_box_text.py
+++ b/tests/figrecipe/_diagram/_diagram/test__render_box_text.py
@@ -1,0 +1,81 @@
+"""Per-line vertical stacking for diagram box text (NeuroVista Ask 4).
+
+A box with a multi-line title and a multi-line subtitle used to render the
+subtitle on top of the title because the layout counted *items* rather than
+*visual lines* (an item with an embedded ``\\n`` occupies two rows). These
+tests pin the per-line layout: each text artist lands at a distinct y and
+consecutive multi-line items do not overlap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _render_multiline_box():
+    """Render a box with a 2-line title + 2-line subtitle + 2 content lines.
+
+    Returns the matplotlib axes carrying the rendered text artists.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from figrecipe.diagram import Diagram
+
+    diag = Diagram(title=None, width_mm=60, height_mm=40)
+    diag.add_box(
+        "pha",
+        "Phase\nfilterbank",
+        subtitle="25 bands\n2-30 Hz",
+        content=["line one", "line two"],
+        emphasis="primary",
+        x_mm=30,
+        y_mm=20,
+        width_mm=44,
+        height_mm=34,
+        padding_mm=3.0,
+    )
+    _fig, ax = diag.render()
+    return ax
+
+
+def _text_y(ax, text):
+    """Return the y data coordinate of the artist whose text equals ``text``."""
+    return next(t.get_position()[1] for t in ax.texts if t.get_text() == text)
+
+
+def test_multiline_box_emits_one_text_artist_per_item():
+    # Arrange
+    pytest.importorskip("figrecipe")
+    ax = _render_multiline_box()
+    # Act
+    n_text_artists = len(ax.texts)
+    # Assert
+    assert n_text_artists == 4
+
+
+def test_multiline_box_text_artists_have_distinct_y_positions():
+    # Arrange
+    pytest.importorskip("figrecipe")
+    ax = _render_multiline_box()
+    # Act
+    distinct_y = {round(t.get_position()[1], 3) for t in ax.texts}
+    # Assert
+    assert len(distinct_y) == len(ax.texts)
+
+
+def test_two_line_title_reserves_two_rows_below_itself():
+    # Arrange
+    pytest.importorskip("figrecipe")
+    ax = _render_multiline_box()
+    # The 2-line title pushes the subtitle down by ~2 single-line row pitches,
+    # whereas two single-line content rows sit ~1 pitch apart. Counting items
+    # (the old bug) spaced every item by 1 pitch -> ratio ~1.0 -> the 2-line
+    # title overflowed onto the subtitle.
+    single_row_pitch = _text_y(ax, "line one") - _text_y(ax, "line two")
+    # Act
+    title_to_subtitle = _text_y(ax, "Phase\nfilterbank") - _text_y(
+        ax, "25 bands\n2-30 Hz"
+    )
+    # Assert
+    assert title_to_subtitle == pytest.approx(2 * single_row_pitch, rel=0.05)


### PR DESCRIPTION
## Problem (NeuroVista Ask 4)

Text inside diagram boxes overlapped: the layout counted **items** (title / subtitle / content line) as one row each, but a title or subtitle containing a newline (e.g. `"Phase\nfilterbank"`) is rendered by matplotlib as a multi-line block taller than one row — so the next item's row landed *inside* it (e.g. "filterbank" drew on top of "25 bands"; measured ~12 px baseline overlap).

## Fix

Count **visual rows** (`text.count("\n") + 1` per item) and center each item on the row-span it occupies, packing `n_rows` into the box's inner height (mirrors `Diagram._auto_box_height`'s per-line budget). `_render.py` was at the 512-line limit, so the box-text logic is extracted into a new `_render_box_text.py` (`_render.py` 512 → 461 lines); `render_box` is now a thin orchestrator that delegates the text.

## Verification

- New regression test `tests/figrecipe/_diagram/_diagram/test__render_box_text.py` — `test_two_line_title_reserves_two_rows_below_itself` asserts a 2-line title reserves 2× the single-line row pitch below itself: **fails on develop (ratio 1.0), passes here (2.0)**. AAA + one assert + no mock.
- No regressions: `_diagram` 42 passed; with diagram public API + reproducibility matrix = 64; + the 3 new tests = 109 passed.
- Visual check: a box with a 2-line title + 2-line subtitle + 2 content lines now renders as 6 cleanly separated lines.
- **NeuroVista panel b still validates PASSED** (the #215 diagram fix is intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
