### PR TITLE
fix(reproducer): coerce sub-panel sequence args to numpy on embed replay (fixes streamplot single-embed)

### DIFF
--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -289,7 +289,10 @@ def reproduce_from_record(
 
 
 def _replay_call(
-    ax: Axes, call: CallRecord, result_cache: Optional[Dict[str, Any]] = None
+    ax: Axes,
+    call: CallRecord,
+    result_cache: Optional[Dict[str, Any]] = None,
+    coerce_sequences: bool = False,
 ) -> Any:
     """Replay a single call on an axes.
 
@@ -301,6 +304,13 @@ def _replay_call(
         The call to replay.
     result_cache : dict, optional
         Cache mapping call_id -> result for resolving references.
+    coerce_sequences : bool
+        If True, promote reconstructed plain-sequence positional args (and
+        sequence kwargs) to numpy arrays via ``coerce_sequence_arg``. Used by
+        the inset/embed replay path, where sub-panel array args round-trip as
+        ruamel ``CommentedSeq`` lists (the data-file loader does not descend
+        into subpanels) and would otherwise reach array-arg plotters like
+        ``streamplot`` as raw lists, failing on ``.shape``.
 
     Returns
     -------
@@ -388,15 +398,23 @@ def _replay_call(
         return None
 
     # Reconstruct args
-    from ._reconstruct import reconstruct_kwargs, reconstruct_value
+    from ._reconstruct import (
+        coerce_sequence_arg,
+        reconstruct_kwargs,
+        reconstruct_value,
+    )
 
     args = []
     for arg_data in call.args:
         value = reconstruct_value(arg_data, result_cache)
+        if coerce_sequences:
+            value = coerce_sequence_arg(value)
         args.append(value)
 
     # Get kwargs and reconstruct arrays
     kwargs = reconstruct_kwargs(call.kwargs)
+    if coerce_sequences:
+        kwargs = {k: coerce_sequence_arg(v) for k, v in kwargs.items()}
 
     # These methods are inherently numeric/datetime, but a recipe may store the
     # value as a string -- an ISO datetime (datetime axes) or a stringified

--- a/src/figrecipe/_reproducer/_reconstruct.py
+++ b/src/figrecipe/_reproducer/_reconstruct.py
@@ -49,6 +49,34 @@ def reconstruct_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+def coerce_sequence_arg(value: Any) -> Any:
+    """Coerce a plain Python sequence to a numpy array for replay.
+
+    Used by the inset/embed replay path. Sub-panel array args are inlined into
+    the host YAML (the data-file loader does not descend into subpanels), so
+    they round-trip as ruamel ``CommentedSeq`` lists rather than numpy arrays.
+    Plotters like ``streamplot``/``contour``/``imshow`` call ``.shape`` on their
+    inputs and raise on a raw list; promoting such sequences to ``np.asarray``
+    makes any array-arg plotter work through nesting.
+
+    Only homogeneous *numeric* sequences are promoted: if ``np.asarray`` would
+    yield an object dtype (e.g. a per-element color list mixing tuples and
+    ``'none'``, or inhomogeneous boxplot groups), the original sequence is
+    returned unchanged so matplotlib can interpret each entry on its own --
+    mirroring the defensive promotion in ``reconstruct_kwargs``/``reconstruct_value``.
+    """
+    if isinstance(value, np.ndarray):
+        return value
+    if isinstance(value, (list, tuple)) and len(value) > 0:
+        try:
+            arr = np.asarray(value)
+        except (TypeError, ValueError):
+            return value
+        if arr.dtype != object:
+            return arr
+    return value
+
+
 def reconstruct_value(
     arg_data: Dict[str, Any], result_cache: Optional[Dict[str, Any]] = None
 ) -> Any:

--- a/src/figrecipe/_reproducer/_replay_insets.py
+++ b/src/figrecipe/_reproducer/_replay_insets.py
@@ -110,15 +110,19 @@ def replay_subpanels(parent_mpl_ax, axes_record, depth: int = 0, style=None) -> 
 
         inset_ax = parent_mpl_ax.inset_axes(bounds, **inset_kwargs)
 
-        # Replay the inset's own plotting calls.
+        # Replay the inset's own plotting calls. Coerce sequence args to numpy:
+        # sub-panel array args are inlined into the host YAML (the data-file
+        # loader does not descend into subpanels) and reload as ruamel
+        # CommentedSeq lists; without coercion an array-arg plotter such as
+        # streamplot fails on ``.shape``.
         for call in child_ax_rec.calls:
-            result = _replay_call(inset_ax, call, result_cache)
+            result = _replay_call(inset_ax, call, result_cache, coerce_sequences=True)
             if result is not None:
                 result_cache[call.id] = result
 
         # Replay the inset's decorations (set_xlabel, etc.).
         for call in child_ax_rec.decorations:
-            result = _replay_call(inset_ax, call, result_cache)
+            result = _replay_call(inset_ax, call, result_cache, coerce_sequences=True)
             if result is not None:
                 result_cache[call.id] = result
 

--- a/src/figrecipe/_wrappers/_axes_embed.py
+++ b/src/figrecipe/_wrappers/_axes_embed.py
@@ -68,12 +68,15 @@ def _draw_and_record_source(parent_rax, inset_rax, src_ax_rec) -> None:
 
     mpl_ax = inset_rax._ax
     cache: dict = {}
+    # coerce_sequences mirrors the inset replay path (_replay_insets): sub-panel
+    # array args that round-trip as plain lists are promoted to numpy so array-arg
+    # plotters (streamplot/contour/imshow) draw the same live and on reproduce.
     for call in list(src_ax_rec.calls):
-        result = _replay_call(mpl_ax, call, cache)
+        result = _replay_call(mpl_ax, call, cache, coerce_sequences=True)
         if result is not None:
             cache[call.id] = result
     for call in list(src_ax_rec.decorations):
-        result = _replay_call(mpl_ax, call, cache)
+        result = _replay_call(mpl_ax, call, cache, coerce_sequences=True)
         if result is not None:
             cache[call.id] = result
 

--- a/tests/integration/test_all_plotters_nested_roundtrip.py
+++ b/tests/integration/test_all_plotters_nested_roundtrip.py
@@ -27,18 +27,15 @@ robust against freetype/font-version pixel flakiness, same level as
 ``test_reproducibility_matrix.py``.
 
 XFAILED plotters (nesting):
-  - ``streamplot`` (single embed): the inset/embed replay path does not coerce
-    the YAML-deserialized streamplot coordinate arrays (loaded as ruamel
-    ``CommentedSeq``) back to numpy before ``Axes.streamplot`` accesses
-    ``.shape``. The embedded sub-panel therefore fails to redraw on reproduce
+  - (none) ``streamplot`` single embed was previously xfailed: the inset/embed
+    replay path did not coerce the YAML-deserialized streamplot coordinate arrays
+    (loaded as ruamel ``CommentedSeq``) back to numpy before ``Axes.streamplot``
+    accessed ``.shape``, so the embedded sub-panel failed to redraw on reproduce
     (``UserWarning: Failed to replay streamplot: 'CommentedSeq' object has no
-    attribute 'shape'``) and validation fails (MSE ~1639 >> threshold 100, the
-    diff concentrated exactly in the embedded sub-panel's region). NOTE: the SAME
-    streamplot round-trips fine standalone (pixel-perfect suite) AND through
-    ``fr.compose`` AND through embed-OF-a-composed-recipe — the gap is specific
-    to embedding a single streamplot recipe directly. Marked ``strict=False`` so
-    a future source-side fix (coerce list args in the inset replay path) flips it
-    green without editing this test.
+    attribute 'shape'``) and validation failed (MSE ~1639). FIXED: the inset/embed
+    replay path now coerces reconstructed sequence args to numpy via
+    ``coerce_sequence_arg`` (``_reproducer/_reconstruct.py``), so any array-arg
+    plotter round-trips through a single embed; ``streamplot`` now passes here.
 """
 
 import tempfile
@@ -60,17 +57,9 @@ from figrecipe.styles._finalize import finalize_special_plots, finalize_ticks
 _MM_PER_INCH = 25.4
 
 # Plotters expected to FAIL the SINGLE-embed round-trip, each with a reason.
-SINGLE_EMBED_XFAIL = {
-    "streamplot": (
-        "embed/inset replay does not coerce YAML-loaded streamplot arrays "
-        "(ruamel CommentedSeq) to numpy before Axes.streamplot needs .shape; "
-        "embedded sub-panel fails to redraw on reproduce "
-        "(UserWarning: Failed to replay streamplot: 'CommentedSeq' object has "
-        "no attribute 'shape') -> validation MSE ~1639 >> 100. Standalone, "
-        "compose, and embed-of-composed all round-trip; only direct single "
-        "embed of a streamplot recipe regresses."
-    ),
-}
+# Empty: ``streamplot`` was fixed (inset/embed replay now coerces reconstructed
+# sequence args to numpy via ``coerce_sequence_arg``); see the module docstring.
+SINGLE_EMBED_XFAIL: dict = {}
 
 
 def _embed_params():


### PR DESCRIPTION
## Problem (surfaced by the all-plotters nested round-trip matrix, #216)

Embedding a saved `streamplot` recipe as a single managed sub-panel via `ax.embed` failed to reproduce: `UserWarning: Failed to replay streamplot: 'CommentedSeq' object has no attribute 'shape'` → the embedded sub-panel never redrew → validation MSE ~1639. (xfail'd in #216.)

## Root cause

The data-file loader (`_serializer/_load._resolve_data_references`) only descends into top-level `axes[...].calls`, **not** into `subpanels`. So a sub-panel's coordinate arrays round-trip as ruamel `CommentedSeq` lists (not numpy), and `Axes.streamplot` calls `.shape` on them. Standalone / `fr.compose` / embed-of-composed all worked (their data goes to CSV files the loader resolves to ndarrays) — only the direct single-embed path didn't coerce.

## Fix

`coerce_sequence_arg()` in `_reproducer/_reconstruct.py` promotes plain list/tuple args to `np.asarray` (leaving object-dtype/heterogeneous/empty sequences as-is); `_replay_call` gains a `coerce_sequences` flag used by the sub-panel replay paths (`_replay_insets.replay_subpanels` + `_axes_embed._draw_and_record_source`). General (not streamplot-specific); main replay path unchanged.

## Verification
- The `streamplot` single-embed xfail is **removed** and now passes as a normal test.
- No regressions: `_reproducer` 70 passed; `test_embed_reproduction.py` + `test_inset_reproduction.py` 9 passed; composition + compose-of-composed streamplot pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
