### PR TITLE
test(spines): reset rcParams per test — fix xdist order-dependent spine-mixin flake

### DIFF
--- a/tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py
+++ b/tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py
@@ -17,8 +17,33 @@ import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
 
 from figrecipe._wrappers._axes_style_mixin import AxesStyleMixin  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _pristine_rcparams():
+    """Test against matplotlib's stock spine defaults, not leaked global state.
+
+    These tests assert spine visibility on a *plain* ``plt.subplots()`` axes
+    and assume the matplotlib default (all four spines visible). But importing
+    / configuring figrecipe pushes ``axes.spines.top`` / ``axes.spines.right``
+    = False onto the GLOBAL ``matplotlib.rcParams`` (see
+    ``figrecipe._configure_mpl``), so whether a fresh axes starts with top/right
+    visible depends on whether a style/config test ran earlier in the same
+    process. Under pytest-xdist (each worker runs many modules in arbitrary
+    order) that made ``test_*_list_*`` / ``test_toggle_*`` flaky. Reset rcParams
+    to stock defaults before each test (and restore after) so the mixin is
+    exercised in isolation and the suite is order-independent.
+    """
+    saved = matplotlib.rcParams.copy()
+    matplotlib.rcdefaults()
+    matplotlib.use("Agg")  # rcdefaults resets the backend too; keep headless
+    try:
+        yield
+    finally:
+        matplotlib.rcParams.update(saved)
 
 
 class _StubAxesWrapper(AxesStyleMixin):


### PR DESCRIPTION
## Why
Now that the Spartan SIF matrix runs the full suite under pytest-xdist, an
**order-dependent flake** surfaced (one matrix leg per run loses the lottery —
e.g. develop py3.11 after the #218 merge):

```
FAILED tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py::test_hide_spines_list_hides_exactly_requested_sides
FAILED tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py::test_toggle_spines_toggles_only_listed_sides
  AssertionError: assert {'top': False ... 'right': False} == {'top': True ... 'right': True}
```

## Root cause (test-isolation, not a product bug)
These tests assert spine visibility on a plain `plt.subplots()` axes assuming
matplotlib's stock default (all four spines visible). But figrecipe pushes
`axes.spines.top` / `axes.spines.right` = False onto the **global**
`matplotlib.rcParams` (`figrecipe._configure_mpl`, ~30 rcParams). So whether a
fresh axes starts with top/right visible depends on whether a style/config test
ran earlier in the same worker process. Under xdist (workers run many modules in
arbitrary order) the spine tests intermittently see top/right already hidden →
assertion fails. Confirmed locally: running a `tests/figrecipe/styles` module
before the spine module reproduces it; the spine tests pass in isolation.

## Fix
Add an autouse fixture in `test__axes_style_mixin_spines.py` that resets
`matplotlib.rcParams` to stock defaults before each test (restoring after), so
the mixin is exercised against the documented matplotlib default regardless of
leaked global config. Pure test isolation — no production change.

## Verification
- Spine tests: 5 passed (alone) and 56 passed (a styles module run first in the
  same process — the previously-flaky ordering).
- Full `tests/figrecipe/_wrappers/`: 138 passed.