### PR TITLE
test: isolate matplotlib rcParams per test (root fix for spine-mixin xdist flake; supersedes #222 band-aid)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,31 @@ matplotlib.use("Agg")
 
 
 @pytest.fixture(autouse=True)
+def _isolate_matplotlib_rcparams():
+    """Snapshot ``matplotlib.rcParams`` before each test and restore them after.
+
+    ``rcParams`` is global, mutable process state. Tests that apply a house
+    style (e.g. ``figrecipe.apply_brand_style("scitex.plt")`` /
+    ``configure_mpl``) push ``axes.spines.top``/``axes.spines.right = False``
+    (and other keys) onto it and do not undo the change, so the mutation leaks
+    into whatever test runs next in the same process. Under pytest-xdist each
+    worker runs many modules in arbitrary order, so a leaked spine rcParam made
+    the spine-mixin tests (which build a plain ``plt.subplots()`` axes and
+    assume matplotlib's stock all-spines-visible default) flaky — they pass in
+    isolation but fail when a style test lands first on the same worker.
+
+    Snapshotting the *current* values (not ``rcdefaults()``) preserves the
+    figrecipe/session baseline while undoing only per-test mutations, making the
+    whole suite order- and xdist-independent.
+    """
+    snapshot = matplotlib.rcParams.copy()
+    try:
+        yield
+    finally:
+        matplotlib.rcParams.update(snapshot)
+
+
+@pytest.fixture(autouse=True)
 def _close_figures():
     """Close all matplotlib figures after each test to prevent memory leaks."""
     yield

--- a/tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py
+++ b/tests/figrecipe/_wrappers/test__axes_style_mixin_spines.py
@@ -21,29 +21,12 @@ import pytest  # noqa: E402
 
 from figrecipe._wrappers._axes_style_mixin import AxesStyleMixin  # noqa: E402
 
-
-@pytest.fixture(autouse=True)
-def _pristine_rcparams():
-    """Test against matplotlib's stock spine defaults, not leaked global state.
-
-    These tests assert spine visibility on a *plain* ``plt.subplots()`` axes
-    and assume the matplotlib default (all four spines visible). But importing
-    / configuring figrecipe pushes ``axes.spines.top`` / ``axes.spines.right``
-    = False onto the GLOBAL ``matplotlib.rcParams`` (see
-    ``figrecipe._configure_mpl``), so whether a fresh axes starts with top/right
-    visible depends on whether a style/config test ran earlier in the same
-    process. Under pytest-xdist (each worker runs many modules in arbitrary
-    order) that made ``test_*_list_*`` / ``test_toggle_*`` flaky. Reset rcParams
-    to stock defaults before each test (and restore after) so the mixin is
-    exercised in isolation and the suite is order-independent.
-    """
-    saved = matplotlib.rcParams.copy()
-    matplotlib.rcdefaults()
-    matplotlib.use("Agg")  # rcdefaults resets the backend too; keep headless
-    try:
-        yield
-    finally:
-        matplotlib.rcParams.update(saved)
+# NOTE: rcParams isolation is provided process-wide by the autouse
+# ``_isolate_matplotlib_rcparams`` fixture in ``tests/conftest.py`` (it
+# snapshots ``matplotlib.rcParams`` before each test and restores them after),
+# so these tests see a fresh axes with matplotlib's stock spine defaults
+# regardless of test order / xdist worker. A module-local rcParams reset is no
+# longer needed.
 
 
 class _StubAxesWrapper(AxesStyleMixin):


### PR DESCRIPTION
## Problem (genuine bug surfaced by the live SIF CI, py3.11)

`test__axes_style_mixin_spines.py::test_hide_spines_list_hides_exactly_requested_sides` and `::test_toggle_spines_toggles_only_listed_sides` failed on py3.11 under xdist (`AssertionError: {'top': False,...'right': False} == {'top': True,...'right': True}`) — yet passed serially and under xdist **in isolation**. A cross-file global-state leak.

**Root cause:** `tests/figrecipe/test__brand_style.py::test_apply_brand_style_is_idempotent` calls `apply_brand_style("scitex.plt")` **in-process** (its siblings use subprocesses), which runs `configure_mpl` → sets `rcParams["axes.spines.top"]=False` / `["axes.spines.right"]=False` globally and never restores. When it lands before the spine tests on an xdist worker, their fresh `plt.subplots()` axes (in `_make_ax()`) inherit hidden top/right → assertions about top/right staying visible fail.

## Fix (authentic — supersedes the #222 band-aid)

`#222` added a module-local `_pristine_rcparams` (`rcdefaults()`) fixture that masked the leak **only** for the spine file. This replaces that band-aid with the root fix:

- **`tests/conftest.py`**: autouse `_isolate_matplotlib_rcparams` that **snapshots `matplotlib.rcParams` before each test and restores after** (snapshot-of-current, not `rcdefaults()`, so the figrecipe/session style baseline is preserved and only per-test mutations are undone). Makes the whole suite order- and xdist-independent.
- Removed the now-redundant module-local band-aid from `test__axes_style_mixin_spines.py`.

No band-aid: no xfail/skip, no MSE/threshold change, no test reordering — the leaking mutation simply no longer escapes its test.

## Verification

- Deterministic repro (`pytest test__brand_style.py test__axes_style_mixin_spines.py`, serial): **2 failed → 16 passed** with the fix.
- No regressions: `_wrappers/`+`styles/`+`_reproducer/` `-n auto` → 259 passed; `+ _scitex_compat/ + _serializer/` → 386 passed, 48 skipped. No test depended on a leaked rcParam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
