### PR TITLE
fix: consolidated reproducer fixes (rcParams isolation + streamplot + axis-scale + imshow ticks + tiled layout + font-warm)

### DIFF
--- a/src/figrecipe/_composition/__init__.py
+++ b/src/figrecipe/_composition/__init__.py
@@ -8,9 +8,11 @@ This module provides functionality to:
 - Hide/show panels for visual composition
 - Align and distribute panels
 
-Supports two composition modes (automatically detected):
+Supports three composition modes (automatically detected):
 1. Grid-based: sources={(row, col): path} with layout=(nrows, ncols)
 2. Mm-based: sources={path: {"xy_mm": ..., "size_mm": ...}} with canvas_size_mm
+3. Tiled: sources={"A": path, ...} with layout=[["A","B"],["C"]] -- row-justified,
+   aspect-preserving, whitespace-free (see _tile.py)
 
 All composition is matplotlib-native for reproducibility - no PIL image pasting.
 

--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -2,9 +2,11 @@
 # -*- coding: utf-8 -*-
 """Main composition logic for combining multiple figures.
 
-Supports two composition modes:
+Supports three composition modes:
 1. Grid-based: layout=(nrows, ncols) with sources={(row, col): path}
 2. Mm-based: canvas_size_mm=(w, h) with sources={path: {"xy_mm": ..., "size_mm": ...}}
+3. Tiled: layout=[["A","B"],["C"]] with sources={"A": path, ...} (row-justified,
+   aspect-preserving, whitespace-free) -- see ``_tile.py``.
 
 All layouts maintain matplotlib editability - no PIL image pasting.
 """
@@ -25,6 +27,7 @@ from ._panel_labels import (
 from ._source_parser import is_image_file as _is_image_file  # noqa: F401
 from ._source_parser import parse_source_spec_with_key as _parse_source_spec_with_key
 from ._source_parser import parse_source_spec_with_path as _parse_source_spec_with_path
+from ._tile import _is_tiled_layout, build_tiled_sources
 
 # Default DPI for mm-based composition
 DEFAULT_DPI = 300
@@ -48,8 +51,9 @@ def _mm_to_inch(mm: float) -> float:
 
 def compose(
     sources: Dict[Any, Any],
-    layout: Optional[Tuple[int, int]] = None,
+    layout: Optional[Union[Tuple[int, int], str, List[List[str]]]] = None,
     canvas_size_mm: Optional[Tuple[float, float]] = None,
+    width_mm: Optional[float] = None,
     gap_mm: float = 2.0,
     dpi: int = DEFAULT_DPI,
     panel_labels: bool = False,
@@ -60,7 +64,7 @@ def compose(
 ) -> Tuple[RecordingFigure, Union[RecordingAxes, NDArray, List[RecordingAxes]]]:
     """Compose a new figure from multiple sources (recipes or raw images).
 
-    Supports two modes automatically detected from sources format:
+    Supports three modes automatically detected from sources/layout format:
 
     1. Grid-based: sources={(row, col): path}
        Uses layout=(nrows, ncols) for subplot grid.
@@ -68,18 +72,34 @@ def compose(
     2. Mm-based: sources={path: {"xy_mm": (x, y), "size_mm": (w, h)}}
        Uses canvas_size_mm for precise positioning.
 
+    3. Tiled (row-justified, whitespace-free): layout=[["A","B","C"],["D"]]
+       (or the multiline string "A B C\\nD") with sources={"A": path, ...}.
+       Each panel keeps its true aspect ratio; within a row all panels share
+       one common height and sit edge-to-edge (only ``gap_mm`` between) so
+       there is no whitespace, and every row spans the same width so the
+       right edge is never ragged. The first layout row is rendered on top.
+
     Parameters
     ----------
     sources : dict
-        Either:
+        One of:
         - Grid-based: {(row, col): source_path} mapping positions to sources
         - Mm-based: {source_path: {"xy_mm": (x, y), "size_mm": (w, h)}}
-    layout : tuple, optional
-        (nrows, ncols) for grid-based composition. Auto-detected if not provided.
+        - Tiled: {label: source} keyed by the string labels used in ``layout``
+    layout : tuple, str, or list of list of str, optional
+        - (nrows, ncols) for grid-based composition (auto-detected if omitted).
+        - list of rows of labels (``[["A","B"],["C"]]``) or a multiline string
+          (``"A B\\nC"``) for tiled composition.
     canvas_size_mm : tuple, optional
         (width_mm, height_mm) for mm-based composition. Required for mm-based mode.
+    width_mm : float, optional
+        Overall content width (mm) for TILED composition. When omitted the
+        default width is the widest row at its true content size, i.e.
+        ``max over rows of (sum of true panel widths + (k-1)*gap_mm)``.
+        Ignored by grid/mm modes.
     gap_mm : float
-        Gap between panels in mm (for auto-layout modes like 'horizontal').
+        Gap between panels in mm (gutter; tiled mode uses it as the edge-to-edge
+        spacing, and ``gap_mm=0`` makes panels share edges exactly).
     dpi : int
         DPI for the output figure.
     panel_labels : bool
@@ -135,8 +155,35 @@ def compose(
     ...         "panel_c.yaml": {"xy_mm": (0, 60), "size_mm": (175, 55)},
     ...     }
     ... )
+
+    Tiled (row-justified, whitespace-free) composition:
+
+    >>> fig, axes = fr.compose(
+    ...     layout=[["A", "B", "C"], ["D"]],
+    ...     sources={"A": "a.yaml", "B": "b.yaml",
+    ...              "C": "c.yaml", "D": "d.yaml"},
+    ...     width_mm=180, gap_mm=1.0,
+    ... )
     """
-    if _is_mm_based_sources(sources):
+    if _is_tiled_layout(layout, sources):
+        sources_mm, computed_canvas = _tiled_to_mm_sources(
+            layout,
+            sources,
+            width_mm=width_mm,
+            canvas_size_mm=canvas_size_mm,
+            gap_mm=gap_mm,
+        )
+        return _compose_mm_based(
+            sources_mm,
+            computed_canvas,
+            dpi,
+            panel_labels,
+            label_style,
+            caption=caption,
+            panel_captions=panel_captions,
+            **kwargs,
+        )
+    elif _is_mm_based_sources(sources):
         return _compose_mm_based(
             sources,
             canvas_size_mm,
@@ -157,6 +204,23 @@ def compose(
             panel_captions=panel_captions,
             **kwargs,
         )
+
+
+def _tiled_to_mm_sources(
+    layout: Union[str, List[List[str]]],
+    sources: Dict[str, Any],
+    width_mm: Optional[float],
+    canvas_size_mm: Optional[Tuple[float, float]],
+    gap_mm: float,
+) -> Tuple[Dict[str, Dict[str, Any]], Tuple[float, float]]:
+    """Adapter over ``_tile.build_tiled_sources`` (the whitespace-free,
+    aspect-preserving algorithm). ``canvas_size_mm[0]`` supplies the width when
+    ``width_mm`` is omitted; the dispatcher then delegates to ``_compose_mm_based``.
+    """
+    effective_width = width_mm
+    if effective_width is None and canvas_size_mm is not None:
+        effective_width = canvas_size_mm[0]
+    return build_tiled_sources(layout, sources, width_mm=effective_width, gap_mm=gap_mm)
 
 
 def _compose_grid_based(

--- a/src/figrecipe/_composition/_tile.py
+++ b/src/figrecipe/_composition/_tile.py
@@ -281,6 +281,17 @@ def build_tiled_sources(
         width_of[label] = _source_content_width_mm(spec, a)
 
     # 1. Choose overall content width W.
+    # TODO(title-clip): W accounts only for panel INK width, so the widest
+    # panel's right edge sits flush at x=W (and the leftmost at x=0). A panel
+    # TITLE is drawn point-sized and centered over its axes; when it is wider
+    # than its panel it overhangs the panel edge, and on the outermost panels
+    # that overhang crosses the canvas boundary and clips (the save-time crop
+    # uses only a fixed 1mm margin, which does not scale with title length).
+    # A clean fix must NOT perturb the geometry contract the tiled tests assert
+    # (every row spans exactly W; adjacent panels share edges to 1e-6) -- e.g.
+    # measure each row's title text overhang and expand the crop margin (not W)
+    # to cover it, or expose a symmetric title_inset_mm. Left as a cosmetic
+    # follow-up so it does not block the consolidation.
     if width_mm is not None:
         W = float(width_mm)
     else:

--- a/src/figrecipe/_composition/_tile.py
+++ b/src/figrecipe/_composition/_tile.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tiled (row-justified, whitespace-free) composition layout.
+
+This is the publication-grade layout mode for ``fr.compose``: it places
+panels in a list of rows (like ``patchwork`` / ``svgutils`` justified grids)
+so that
+
+* every panel keeps its TRUE aspect ratio (no stretching),
+* within a row all panels share ONE common height and sit edge-to-edge
+  (only ``gap_mm`` between them) -> no intra-row whitespace,
+* every row spans the SAME overall content width ``W`` -> no ragged right
+  edge.
+
+The geometry it produces is emitted as the existing mm-based ``sources``
+dict (``{path: {"xy_mm", "size_mm"}}``) and the placement itself is then
+delegated to :func:`figrecipe._composition._compose._compose_mm_based`, so a
+tiled figure round-trips through save/reproduce exactly like any other
+mm-based composition (no new placement/serialization code path).
+
+Coordinate origin
+-----------------
+``_compose_mm_based`` treats ``xy_mm`` with **y=0 at the TOP**, increasing
+downward (``panel_bottom = 1 - (y + h) / canvas_h``). Rows are therefore
+stacked by increasing ``y_mm`` and the FIRST layout row (``y_mm = 0``) is
+rendered visually on top, matching the way the layout reads on the page.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, Union
+
+# Aspect ratio (w / h) used only when a source carries neither a content size,
+# a figsize, nor a readable PNG -- a last-resort square so layout never crashes.
+_FALLBACK_ASPECT = 1.0
+
+
+def _is_tiled_layout(layout: Any, sources: Dict[Any, Any]) -> bool:
+    """Return True when ``layout``/``sources`` describe a TILED composition.
+
+    A tiled call is recognised by a ``layout`` that is either a multiline
+    string (rows split on newlines, labels on whitespace) or a list whose
+    items are themselves lists of string labels, paired with a ``sources``
+    dict keyed by those string labels (``{"A": "a.yaml", ...}``).
+
+    Grid mode (``layout=(nrows, ncols)``, integer tuple) and mm mode
+    (``sources={path: {"xy_mm": ...}}``) are intentionally NOT matched here.
+    """
+    if not sources:
+        return False
+
+    # sources must be keyed by str labels (grid uses tuple keys; mm uses paths
+    # whose VALUES are {"xy_mm": ...} dicts -- exclude that explicitly).
+    first_key = next(iter(sources.keys()))
+    if not isinstance(first_key, str):
+        return False
+    first_value = sources[first_key]
+    if isinstance(first_value, dict) and "xy_mm" in first_value:
+        return False  # this is mm-based, not tiled
+
+    if isinstance(layout, str):
+        return True
+    if isinstance(layout, (list, tuple)):
+        # list of ROWS, each row a list/tuple of str labels.
+        return (
+            all(
+                isinstance(row, (list, tuple))
+                and len(row) > 0
+                and all(isinstance(lab, str) for lab in row)
+                for row in layout
+            )
+            and len(layout) > 0
+        )
+    return False
+
+
+def _parse_layout(layout: Union[str, List[List[str]]]) -> List[List[str]]:
+    """Normalise a layout spec into a list of rows of label strings.
+
+    Accepts either a multiline string (``"A B C\\nD"`` -> rows split on
+    newlines, labels on whitespace) or an already-structured list of lists.
+    Blank lines in a string layout are skipped.
+    """
+    if isinstance(layout, str):
+        rows: List[List[str]] = []
+        for line in layout.splitlines():
+            labels = line.split()
+            if labels:
+                rows.append(labels)
+        return rows
+    return [list(row) for row in layout]
+
+
+def _validate_layout(rows: List[List[str]], sources: Dict[str, Any]) -> None:
+    """Fail loud (ValueError) on any label/source mismatch or empty row.
+
+    No silent fallback: every label in the layout must have a source and
+    every source must be referenced by the layout, exactly once is not
+    required but presence both ways is.
+    """
+    if not rows:
+        raise ValueError(
+            "tiled layout is empty: provide at least one row of panel labels."
+        )
+    for r, row in enumerate(rows):
+        if not row:
+            raise ValueError(f"tiled layout row {r} is empty (no panel labels).")
+
+    layout_labels = [lab for row in rows for lab in row]
+    layout_set = set(layout_labels)
+    source_set = set(sources.keys())
+
+    missing_sources = layout_set - source_set
+    if missing_sources:
+        raise ValueError(
+            "tiled layout references labels with no matching source: "
+            f"{sorted(missing_sources)}. sources has: {sorted(source_set)}."
+        )
+    unused_sources = source_set - layout_set
+    if unused_sources:
+        raise ValueError(
+            "sources provides labels not placed in the layout: "
+            f"{sorted(unused_sources)}. layout uses: {sorted(layout_set)}."
+        )
+    duplicates = [lab for lab in layout_set if layout_labels.count(lab) > 1]
+    if duplicates:
+        raise ValueError(
+            f"tiled layout places label(s) more than once: {sorted(duplicates)}."
+        )
+
+
+def _source_aspect(source_spec: Any) -> float:
+    """Return a panel's true aspect ratio ``content_w_mm / content_h_mm``.
+
+    Resolution order (each a real measurement of the saved panel, never a
+    guess unless all fail):
+
+    1. ``record.content_size_mm`` -- the tight cropped content [w, h] in mm.
+    2. ``record.figsize`` -- the figure's [w, h] in inches.
+    3. the saved PNG's pixel aspect (companion image of a recipe, or a raw
+       image source).
+    4. ``_FALLBACK_ASPECT`` (square) -- only if none of the above exist.
+    """
+    from ._source_parser import parse_source_spec_with_path
+
+    record, _ax_key, path = parse_source_spec_with_path(source_spec)
+
+    csm = getattr(record, "content_size_mm", None)
+    if csm and len(csm) == 2 and csm[1]:
+        return float(csm[0]) / float(csm[1])
+
+    figsize = getattr(record, "figsize", None)
+    if figsize and len(figsize) == 2 and figsize[1]:
+        return float(figsize[0]) / float(figsize[1])
+
+    aspect = _png_aspect(path)
+    if aspect is not None:
+        return aspect
+
+    return _FALLBACK_ASPECT
+
+
+def _source_content_width_mm(source_spec: Any, aspect: float) -> float:
+    """Return a panel's true content WIDTH in mm (for the default-``W`` rule).
+
+    Prefers the recorded ``content_size_mm[0]``; else derives a width from the
+    figsize inches; else from the PNG pixels at 300 dpi; else falls back to a
+    width implied by ``aspect`` at a nominal 45 mm height so the default still
+    produces a sane canvas.
+    """
+    from ._source_parser import parse_source_spec_with_path
+
+    record, _ax_key, path = parse_source_spec_with_path(source_spec)
+
+    csm = getattr(record, "content_size_mm", None)
+    if csm and len(csm) == 2 and csm[0]:
+        return float(csm[0])
+
+    figsize = getattr(record, "figsize", None)
+    if figsize and len(figsize) == 2 and figsize[0]:
+        return float(figsize[0]) * 25.4
+
+    width_px = _png_size_px(path)
+    if width_px is not None:
+        return width_px[0] / 300.0 * 25.4
+
+    return aspect * 45.0
+
+
+def _png_size_px(path):
+    """Return (width_px, height_px) of an image/companion PNG, or None."""
+    if path is None:
+        return None
+    p = Path(path)
+    # A recipe path -> look for a sibling PNG with the same stem.
+    if p.suffix.lower() not in {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".tiff",
+        ".tif",
+        ".bmp",
+        ".gif",
+        ".webp",
+    }:
+        p = p.with_suffix(".png")
+    if not p.exists():
+        return None
+    try:
+        from PIL import Image
+
+        with Image.open(p) as img:
+            return (img.width, img.height)
+    except Exception:
+        return None
+
+
+def _png_aspect(path):
+    """Return width/height aspect of an image/companion PNG, or None."""
+    size = _png_size_px(path)
+    if size is None or not size[1]:
+        return None
+    return size[0] / size[1]
+
+
+def build_tiled_sources(
+    layout: Union[str, List[List[str]]],
+    sources: Dict[str, Any],
+    width_mm: float = None,
+    gap_mm: float = 1.0,
+) -> Tuple[Dict[str, Dict[str, Any]], Tuple[float, float]]:
+    """Compute the mm-based placement for a TILED (row-justified) layout.
+
+    This is the layout algorithm (the actual point of the tiled mode); it
+    returns geometry only -- the caller delegates the resulting dict to
+    ``_compose_mm_based`` for placement so the figure round-trips.
+
+    Parameters
+    ----------
+    layout : str or list of list of str
+        Rows of panel labels. ``"A B C\\nD"`` or ``[["A","B","C"],["D"]]``.
+    sources : dict
+        ``{label: source}`` where each source is a recipe path / image path /
+        ``FigureRecord`` / ``(source, ax_key)`` tuple, as accepted by the
+        mm-based composer.
+    width_mm : float, optional
+        Overall content width ``W`` of the figure in mm. When omitted, the
+        DEFAULT is ``W = max over rows of (sum of the row's TRUE content
+        widths + (k-1) * gap_mm)`` -- i.e. the widest row at its natural size
+        sets the figure width and no panel is ever upscaled past its true
+        size on the widest row.
+    gap_mm : float
+        Gutter between adjacent panels (both within a row and between rows).
+        ``0`` makes panels share edges exactly.
+
+    Returns
+    -------
+    sources_mm : dict
+        ``{source: {"xy_mm": (x, y), "size_mm": (w, h)}}`` ready for
+        ``_compose_mm_based``. ``xy_mm`` uses y=0 at the top so the first
+        layout row is on top.
+    canvas_size_mm : tuple
+        ``(W, total_height)`` of the composed canvas in mm.
+
+    Notes
+    -----
+    For a row with panels of aspects ``a_i`` (i = 1..k) the row is given one
+    common height ``h_r = (W - (k-1) * gap_mm) / sum(a_i)``; each panel is
+    then ``width_i = a_i * h_r`` wide. Summed, the panels plus gaps fill
+    exactly ``W``, so the row has no internal whitespace and no ragged edge.
+    """
+    rows = _parse_layout(layout)
+    _validate_layout(rows, sources)
+
+    # Measure every panel once: aspect (for justification) and true width
+    # (for the default-W rule).
+    aspect_of: Dict[str, float] = {}
+    width_of: Dict[str, float] = {}
+    for label, spec in sources.items():
+        a = _source_aspect(spec)
+        aspect_of[label] = a
+        width_of[label] = _source_content_width_mm(spec, a)
+
+    # 1. Choose overall content width W.
+    if width_mm is not None:
+        W = float(width_mm)
+    else:
+        W = 0.0
+        for row in rows:
+            row_natural = sum(width_of[lab] for lab in row) + (len(row) - 1) * gap_mm
+            W = max(W, row_natural)
+
+    # 2-3. Lay out each row at one common height, then stack top-to-bottom.
+    sources_mm: Dict[str, Dict[str, Any]] = {}
+    y = 0.0
+    row_heights: List[float] = []
+    for r, row in enumerate(rows):
+        k = len(row)
+        sum_aspect = sum(aspect_of[lab] for lab in row)
+        # Width available for actual panel ink (gaps removed).
+        avail = W - (k - 1) * gap_mm
+        h_r = avail / sum_aspect if sum_aspect else avail
+        row_heights.append(h_r)
+
+        x = 0.0
+        for lab in row:
+            w_i = aspect_of[lab] * h_r
+            sources_mm[sources[lab]] = {
+                "xy_mm": (x, y),
+                "size_mm": (w_i, h_r),
+            }
+            x += w_i + gap_mm
+        y += h_r + gap_mm
+
+    total_height = sum(row_heights) + (len(rows) - 1) * gap_mm
+    return sources_mm, (W, total_height)
+
+
+__all__ = ["build_tiled_sources", "_is_tiled_layout"]
+
+# EOF

--- a/src/figrecipe/_params/_DECORATION_METHODS.py
+++ b/src/figrecipe/_params/_DECORATION_METHODS.py
@@ -12,6 +12,8 @@ DECORATION_METHODS = {
     "set_title",
     "set_xlim",
     "set_ylim",
+    "set_xscale",  # log/symlog/logit axis scale (replays as a generic decoration)
+    "set_yscale",  # log/symlog/logit axis scale (replays as a generic decoration)
     "set_aspect",
     "legend",
     "grid",

--- a/src/figrecipe/_reproducer/__init__.py
+++ b/src/figrecipe/_reproducer/__init__.py
@@ -9,7 +9,8 @@ The public API exposes three main functions:
 - get_recipe_info: Get information about a recipe without reproducing it
 """
 
-from ._core import get_recipe_info, reproduce, reproduce_from_record
+from ._core import reproduce, reproduce_from_record
+from ._recipe_info import get_recipe_info
 
 __all__ = [
     "reproduce",

--- a/src/figrecipe/_reproducer/_axis_scale.py
+++ b/src/figrecipe/_reproducer/_axis_scale.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Validation for replayed axis-scale (set_xscale / set_yscale) values.
+
+``set_xscale`` / ``set_yscale`` are recorded as generic decorations (NeuroVista
+Ask 2) so a ``log`` / ``symlog`` / ``logit`` axis reproduces as such instead of
+silently falling back to ``linear``. matplotlib only knows a fixed set of scale
+names; an unknown one would raise deep inside the generic replay and surface as a
+vague "Failed to replay set_yscale" warning. We check the name up front and warn
+loudly (no silent fallback) so an unsupported / custom scale is recognised during
+reproduction.
+"""
+
+import warnings
+from typing import Any, List
+
+# Built-in matplotlib scale names. ``function`` / ``functionlog`` need a callable
+# pair that can't be serialized into a recipe, so they are intentionally absent
+# here -- a recipe should never carry them, and if one does we warn rather than
+# crash.
+_SUPPORTED_SCALES = {"linear", "log", "symlog", "logit", "asinh"}
+
+
+def warn_if_unsupported_scale(method_name: str, args: List[Any]) -> None:
+    """Warn if a recorded axis scale is not a recognised matplotlib scale.
+
+    Parameters
+    ----------
+    method_name : str
+        The replayed method (``set_xscale`` or ``set_yscale``).
+    args : list
+        Positional args as reconstructed for the call; ``args[0]`` is the scale.
+
+    Notes
+    -----
+    This only warns -- it does not alter the call. matplotlib still receives the
+    recorded scale and raises its own error for a truly invalid name, which the
+    caller's try/except converts into a replay warning. The point is to make an
+    unsupported scale visible instead of degrading silently to ``linear``.
+    """
+    if method_name not in ("set_xscale", "set_yscale"):
+        return
+    if not args:
+        return
+    scale = args[0]
+    if isinstance(scale, str) and scale not in _SUPPORTED_SCALES:
+        warnings.warn(
+            f"{method_name} recorded an unsupported axis scale {scale!r}; "
+            f"supported scales are {sorted(_SUPPORTED_SCALES)}. The axis may "
+            "reproduce as linear if matplotlib cannot apply it.",
+            stacklevel=2,
+        )
+
+
+__all__ = ["warn_if_unsupported_scale"]
+
+# EOF

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -208,6 +208,18 @@ def reproduce_from_record(
             finalize_ticks(axes_2d[row, col])
             finalize_special_plots(axes_2d[row, col], record.style or {})
 
+    # Reapply imshow tick/spine suppression LAST: finalize_ticks above can
+    # re-add numeric ticks on an imshow axes, and finalize_special_plots skips
+    # a labelled imshow (is_specgram heuristic). Keyed on the recorded call
+    # name -- the same discriminator the live imshow wrapper uses -- so save
+    # and reproduce hide ticks identically (never touches a real specgram).
+    from ._replay_axes import finalize_imshow_axes
+
+    for ax_key, ax_record in record.axes.items():
+        parsed = parse_grid_id(ax_key)
+        row, col = parsed if parsed else (0, 0)
+        finalize_imshow_axes(axes_2d[row, col], ax_record, record.style)
+
     # Line widths are NOT post-processed: apply_style_mm() set lines.linewidth
     # from linewidth_mm pre-replay; signal/explicit lw= replay as recorded.
     # (A prior apply_line_styles() forced trace width on all lines -> MSE ~363.)

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -208,6 +208,18 @@ def reproduce_from_record(
             finalize_ticks(axes_2d[row, col])
             finalize_special_plots(axes_2d[row, col], record.style or {})
 
+    # Re-apply recorded set_xlim / set_ylim LAST so explicit limits win over any
+    # autoscale re-engaged by later decorations (e.g. set_xscale), insets,
+    # colorbars, or the tick finalizers (NeuroVista Ask 2). Skipped when the
+    # caller asked to skip decorations (the limits live in decorations).
+    if not skip_decorations:
+        from ._reapply_limits import reapply_recorded_limits
+
+        for ax_key, ax_record in record.axes.items():
+            parsed = parse_grid_id(ax_key)
+            row, col = parsed if parsed else (0, 0)
+            reapply_recorded_limits(axes_2d[row, col], ax_record, calls)
+
     # Line widths are NOT post-processed: apply_style_mm() set lines.linewidth
     # from linewidth_mm pre-replay; signal/explicit lw= replay as recorded.
     # (A prior apply_line_styles() forced trace width on all lines -> MSE ~363.)
@@ -406,6 +418,13 @@ def _replay_call(
     if method_name in ("set_xlim", "set_ylim", "axvline", "axhline"):
         args = [coerce_axis_value(a) for a in args]
         kwargs = {k: coerce_axis_value(v) for k, v in kwargs.items()}
+
+    # Axis scale (set_xscale / set_yscale) replays as a generic decoration; warn
+    # loudly on an unsupported scale name instead of degrading silently to linear.
+    if method_name in ("set_xscale", "set_yscale"):
+        from ._axis_scale import warn_if_unsupported_scale
+
+        warn_if_unsupported_scale(method_name, args)
 
     # Handle special transform markers
     if "transform" in kwargs:

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -200,37 +200,14 @@ def reproduce_from_record(
     # Replay recorded colorbars (exact reproduction)
     _replay_colorbars(fig, axes_2d, record, result_cache)
 
-    # Finalize tick configuration and special plot types
-    from ..styles._style_applier import finalize_special_plots, finalize_ticks
+    # Per-axes post-replay finalization passes (tick/special-plot finalizers,
+    # imshow tick-suppression, recorded-limit reapply). Order is load-bearing;
+    # see ._finalize_axes for the rationale of each pass.
+    from ._finalize_axes import finalize_reproduced_axes
 
-    for row in range(nrows):
-        for col in range(ncols):
-            finalize_ticks(axes_2d[row, col])
-            finalize_special_plots(axes_2d[row, col], record.style or {})
-
-    # Reapply imshow tick/spine suppression after finalize_ticks: it can
-    # re-add numeric ticks on an imshow axes, and finalize_special_plots skips
-    # a labelled imshow (is_specgram heuristic). Keyed on the recorded call
-    # name -- the same discriminator the live imshow wrapper uses -- so save
-    # and reproduce hide ticks identically (never touches a real specgram).
-    from ._replay_axes import finalize_imshow_axes
-
-    for ax_key, ax_record in record.axes.items():
-        parsed = parse_grid_id(ax_key)
-        row, col = parsed if parsed else (0, 0)
-        finalize_imshow_axes(axes_2d[row, col], ax_record, record.style)
-
-    # Re-apply recorded set_xlim / set_ylim LAST so explicit limits win over any
-    # autoscale re-engaged by later decorations (e.g. set_xscale), insets,
-    # colorbars, or the tick finalizers (NeuroVista Ask 2). Skipped when the
-    # caller asked to skip decorations (the limits live in decorations).
-    if not skip_decorations:
-        from ._reapply_limits import reapply_recorded_limits
-
-        for ax_key, ax_record in record.axes.items():
-            parsed = parse_grid_id(ax_key)
-            row, col = parsed if parsed else (0, 0)
-            reapply_recorded_limits(axes_2d[row, col], ax_record, calls)
+    finalize_reproduced_axes(
+        fig, axes_2d, record, nrows, ncols, calls, skip_decorations
+    )
 
     # Line widths are NOT post-processed: apply_style_mm() set lines.linewidth
     # from linewidth_mm pre-replay; signal/explicit lw= replay as recorded.
@@ -497,43 +474,7 @@ def _replay_call(
         return None
 
 
-def get_recipe_info(path: Union[str, Path]) -> Dict[str, Any]:
-    """Get recipe metadata (id, figsize, dpi, n_axes, calls) without reproducing."""
-    record = load_recipe(path)
-
-    all_calls = []
-    for ax_record in record.axes.values():
-        for call in ax_record.calls:
-            all_calls.append(
-                {
-                    "id": call.id,
-                    "function": call.function,
-                    "n_args": len(call.args),
-                    "kwargs": list(call.kwargs.keys()),
-                }
-            )
-        for call in ax_record.decorations:
-            all_calls.append(
-                {
-                    "id": call.id,
-                    "function": call.function,
-                    "type": "decoration",
-                }
-            )
-
-    return {
-        "id": record.id,
-        "created": record.created,
-        "matplotlib_version": record.matplotlib_version,
-        "figsize": record.figsize,
-        "dpi": record.dpi,
-        "n_axes": len(record.axes),
-        "calls": all_calls,
-    }
-
-
 __all__ = [
     "reproduce",
     "reproduce_from_record",
-    "get_recipe_info",
 ]

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -289,7 +289,10 @@ def reproduce_from_record(
 
 
 def _replay_call(
-    ax: Axes, call: CallRecord, result_cache: Optional[Dict[str, Any]] = None
+    ax: Axes,
+    call: CallRecord,
+    result_cache: Optional[Dict[str, Any]] = None,
+    coerce_sequences: bool = False,
 ) -> Any:
     """Replay a single call on an axes.
 
@@ -301,6 +304,13 @@ def _replay_call(
         The call to replay.
     result_cache : dict, optional
         Cache mapping call_id -> result for resolving references.
+    coerce_sequences : bool
+        If True, promote reconstructed plain-sequence positional args (and
+        sequence kwargs) to numpy arrays via ``coerce_sequence_arg``. Used by
+        the inset/embed replay path, where sub-panel array args round-trip as
+        ruamel ``CommentedSeq`` lists (the data-file loader does not descend
+        into subpanels) and would otherwise reach array-arg plotters like
+        ``streamplot`` as raw lists, failing on ``.shape``.
 
     Returns
     -------
@@ -388,15 +398,23 @@ def _replay_call(
         return None
 
     # Reconstruct args
-    from ._reconstruct import reconstruct_kwargs, reconstruct_value
+    from ._reconstruct import (
+        coerce_sequence_arg,
+        reconstruct_kwargs,
+        reconstruct_value,
+    )
 
     args = []
     for arg_data in call.args:
         value = reconstruct_value(arg_data, result_cache)
+        if coerce_sequences:
+            value = coerce_sequence_arg(value)
         args.append(value)
 
     # Get kwargs and reconstruct arrays
     kwargs = reconstruct_kwargs(call.kwargs)
+    if coerce_sequences:
+        kwargs = {k: coerce_sequence_arg(v) for k, v in kwargs.items()}
 
     # These methods are inherently numeric/datetime, but a recipe may store the
     # value as a string -- an ISO datetime (datetime axes) or a stringified

--- a/src/figrecipe/_reproducer/_finalize_axes.py
+++ b/src/figrecipe/_reproducer/_finalize_axes.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Per-axes post-replay finalization passes for figure reproduction.
+
+These passes run after every axes' calls/decorations/insets have been replayed
+and after colorbars are reconstructed. They are extracted from ``_core.py`` to
+keep that module focused on the top-level reproduce flow (and under the
+project's per-file line budget). The ordering here is load-bearing -- see the
+inline comments on each pass.
+"""
+
+from typing import List, Optional
+
+import numpy as np
+
+from .._recorder import FigureRecord
+from .._utils._grid import parse_grid_id
+
+
+def finalize_reproduced_axes(
+    fig,
+    axes_2d: np.ndarray,
+    record: FigureRecord,
+    nrows: int,
+    ncols: int,
+    calls: Optional[List[str]],
+    skip_decorations: bool,
+) -> None:
+    """Run the per-axes finalization passes in their required order.
+
+    Parameters
+    ----------
+    fig : matplotlib Figure
+        The reproduced figure (kept for signature symmetry / future passes).
+    axes_2d : ndarray of Axes
+        The 2D grid of raw matplotlib axes.
+    record : FigureRecord
+        The record being reproduced.
+    nrows, ncols : int
+        Grid dimensions.
+    calls : list of str, optional
+        Restrict reproduction to these call ids (mirrors ``reproduce``).
+    skip_decorations : bool
+        When True, recorded limits live in decorations and are not reapplied.
+    """
+    from ..styles._style_applier import finalize_special_plots, finalize_ticks
+
+    # Finalize tick configuration and special plot types.
+    for row in range(nrows):
+        for col in range(ncols):
+            finalize_ticks(axes_2d[row, col])
+            finalize_special_plots(axes_2d[row, col], record.style or {})
+
+    # Reapply imshow tick/spine suppression after finalize_ticks: it can
+    # re-add numeric ticks on an imshow axes, and finalize_special_plots skips
+    # a labelled imshow (is_specgram heuristic). Keyed on the recorded call
+    # name -- the same discriminator the live imshow wrapper uses -- so save
+    # and reproduce hide ticks identically (never touches a real specgram).
+    from ._replay_axes import finalize_imshow_axes
+
+    for ax_key, ax_record in record.axes.items():
+        parsed = parse_grid_id(ax_key)
+        row, col = parsed if parsed else (0, 0)
+        finalize_imshow_axes(axes_2d[row, col], ax_record, record.style)
+
+    # Re-apply recorded set_xlim / set_ylim LAST so explicit limits win over any
+    # autoscale re-engaged by later decorations (e.g. set_xscale), insets,
+    # colorbars, or the tick finalizers (NeuroVista Ask 2). Skipped when the
+    # caller asked to skip decorations (the limits live in decorations).
+    if not skip_decorations:
+        from ._reapply_limits import reapply_recorded_limits
+
+        for ax_key, ax_record in record.axes.items():
+            parsed = parse_grid_id(ax_key)
+            row, col = parsed if parsed else (0, 0)
+            reapply_recorded_limits(axes_2d[row, col], ax_record, calls)
+
+
+__all__ = ["finalize_reproduced_axes"]

--- a/src/figrecipe/_reproducer/_mm_compose.py
+++ b/src/figrecipe/_reproducer/_mm_compose.py
@@ -94,6 +94,13 @@ def reproduce_mm_composed(record):
             if result is not None:
                 result_cache[call.id] = result
 
+        # Mirror the live imshow wrapper's tick/spine suppression (keyed on the
+        # recorded call name) so an imshow panel reproduces without the numeric
+        # ticks the original hid -- same fix as the grid reproducer.
+        from ._replay_axes import finalize_imshow_axes
+
+        finalize_imshow_axes(ax, ax_record, record.style)
+
         if not getattr(ax_record, "visible", True):
             ax.set_visible(False)
 

--- a/src/figrecipe/_reproducer/_reapply_limits.py
+++ b/src/figrecipe/_reproducer/_reapply_limits.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Re-apply recorded axis limits after replay so they always win (NeuroVista Ask 2).
+
+A recipe records ``set_xlim`` / ``set_ylim`` as decorations, which already replay
+after the plotting calls. But operations replayed *after* the decorations -- a
+later ``set_xscale`` decoration that autoscales, inset sub-panels, colorbars, or
+the tick/locator finalizers -- can re-engage matplotlib autoscaling and widen the
+view away from the explicitly recorded limits.
+
+To make the recorded limits authoritative, this module re-applies the LAST
+recorded ``set_xlim`` / ``set_ylim`` for each axes once everything else is done.
+"last wins" mirrors matplotlib's own behaviour when a user calls the setter more
+than once. Only axes that actually recorded an explicit limit are touched, so
+auto-scaled axes keep their auto behaviour.
+"""
+
+from typing import Any, List, Optional
+
+from ._axis_coerce import coerce_axis_value
+
+
+def _last_limit_args(
+    ax_record, method_name: str, calls: Optional[List[str]]
+) -> Optional[list]:
+    """Return the args of the last recorded ``method_name`` decoration, or None.
+
+    Honors the ``calls`` id-filter: a limit decoration excluded from replay must
+    not be re-applied either.
+    """
+    last = None
+    for call in ax_record.decorations:
+        if call.function != method_name:
+            continue
+        if calls is not None and call.id not in calls:
+            continue
+        last = call
+    if last is None:
+        return None
+
+    from ._reconstruct import reconstruct_value
+
+    return [coerce_axis_value(reconstruct_value(a, {})) for a in last.args]
+
+
+def reapply_recorded_limits(ax, ax_record, calls: Optional[List[str]] = None) -> None:
+    """Re-apply this axes' recorded set_xlim / set_ylim so they override autoscale.
+
+    Parameters
+    ----------
+    ax :
+        Target matplotlib axes (already fully replayed + finalized).
+    ax_record : AxesRecord
+        The recorded axes whose limit decorations should win.
+    calls : list of str, optional
+        If given, only re-apply limit decorations whose id is in this list
+        (mirrors the same filter ``replay_axes_calls`` applies during replay).
+    """
+    xlim_args = _last_limit_args(ax_record, "set_xlim", calls)
+    if xlim_args:
+        _safe_set_lim(ax.set_xlim, xlim_args)
+
+    ylim_args = _last_limit_args(ax_record, "set_ylim", calls)
+    if ylim_args:
+        _safe_set_lim(ax.set_ylim, ylim_args)
+
+
+def _safe_set_lim(setter, args: list) -> Any:
+    """Apply a limit setter, warning (not crashing) if matplotlib rejects it."""
+    try:
+        return setter(*args)
+    except Exception as e:
+        import warnings
+
+        warnings.warn(f"Failed to re-apply recorded limits via {setter!r}: {e}")
+        return None
+
+
+__all__ = ["reapply_recorded_limits"]
+
+# EOF

--- a/src/figrecipe/_reproducer/_recipe_info.py
+++ b/src/figrecipe/_reproducer/_recipe_info.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Recipe metadata inspection (without reproducing the figure).
+
+Extracted from ``_core.py`` -- reading a recipe's metadata is a distinct
+concern from replaying it, and keeping it here keeps ``_core.py`` within the
+project's per-file line budget.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Union
+
+from .._serializer import load_recipe
+
+
+def get_recipe_info(path: Union[str, Path]) -> Dict[str, Any]:
+    """Get recipe metadata (id, figsize, dpi, n_axes, calls) without reproducing."""
+    record = load_recipe(path)
+
+    all_calls = []
+    for ax_record in record.axes.values():
+        for call in ax_record.calls:
+            all_calls.append(
+                {
+                    "id": call.id,
+                    "function": call.function,
+                    "n_args": len(call.args),
+                    "kwargs": list(call.kwargs.keys()),
+                }
+            )
+        for call in ax_record.decorations:
+            all_calls.append(
+                {
+                    "id": call.id,
+                    "function": call.function,
+                    "type": "decoration",
+                }
+            )
+
+    return {
+        "id": record.id,
+        "created": record.created,
+        "matplotlib_version": record.matplotlib_version,
+        "figsize": record.figsize,
+        "dpi": record.dpi,
+        "n_axes": len(record.axes),
+        "calls": all_calls,
+    }
+
+
+__all__ = ["get_recipe_info"]

--- a/src/figrecipe/_reproducer/_reconstruct.py
+++ b/src/figrecipe/_reproducer/_reconstruct.py
@@ -49,6 +49,34 @@ def reconstruct_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+def coerce_sequence_arg(value: Any) -> Any:
+    """Coerce a plain Python sequence to a numpy array for replay.
+
+    Used by the inset/embed replay path. Sub-panel array args are inlined into
+    the host YAML (the data-file loader does not descend into subpanels), so
+    they round-trip as ruamel ``CommentedSeq`` lists rather than numpy arrays.
+    Plotters like ``streamplot``/``contour``/``imshow`` call ``.shape`` on their
+    inputs and raise on a raw list; promoting such sequences to ``np.asarray``
+    makes any array-arg plotter work through nesting.
+
+    Only homogeneous *numeric* sequences are promoted: if ``np.asarray`` would
+    yield an object dtype (e.g. a per-element color list mixing tuples and
+    ``'none'``, or inhomogeneous boxplot groups), the original sequence is
+    returned unchanged so matplotlib can interpret each entry on its own --
+    mirroring the defensive promotion in ``reconstruct_kwargs``/``reconstruct_value``.
+    """
+    if isinstance(value, np.ndarray):
+        return value
+    if isinstance(value, (list, tuple)) and len(value) > 0:
+        try:
+            arr = np.asarray(value)
+        except (TypeError, ValueError):
+            return value
+        if arr.dtype != object:
+            return arr
+    return value
+
+
 def reconstruct_value(
     arg_data: Dict[str, Any], result_cache: Optional[Dict[str, Any]] = None
 ) -> Any:

--- a/src/figrecipe/_reproducer/_replay_axes.py
+++ b/src/figrecipe/_reproducer/_replay_axes.py
@@ -56,4 +56,45 @@ def replay_axes_calls(
     replay_subpanels(ax, ax_record, depth=0, style=style)
 
 
-__all__ = ["replay_axes_calls"]
+def finalize_imshow_axes(ax, ax_record, style: Optional[Dict[str, Any]]) -> None:
+    """Reapply imshow tick/spine suppression so reproduce matches save.
+
+    The live ``ax.imshow`` wrapper (``_wrappers/_axes_plots.imshow_plot``)
+    hides ticks + spines for *any* ``imshow`` when the style's
+    ``imshow.show_axes`` is False. On replay the recorded ``imshow`` runs as
+    raw matplotlib (no wrapper) and ``finalize_special_plots`` skips
+    suppression whenever the axes carries an axis label (its ``is_specgram``
+    heuristic) -- so a *labelled* ``imshow`` (e.g. a comodulogram with
+    ``set_xyt``) reproduced WITH the numeric ticks the original hid, failing
+    reproducibility validation.
+
+    The faithful discriminator is the recorded call name -- exactly what the
+    live wrapper keys on -- not the presence of a label: suppress only for an
+    axes that actually has an ``imshow`` call, never for a genuine
+    ``ax.specgram`` (which the live wrapper never touched). Only ticks/spines
+    are hidden here; axis labels are left intact because any label present was
+    re-set by ``set_xlabel``/``set_ylabel`` decorations recorded AFTER the
+    imshow (the original kept them too).
+
+    Parameters
+    ----------
+    ax :
+        Target matplotlib axes (raw, post-replay).
+    ax_record : AxesRecord
+        The recorded axes -- inspected for an ``imshow`` call.
+    style : dict or None
+        The recipe's (flat) style. ``imshow_show_axes`` gates suppression.
+    """
+    from ..styles._plot_styles import apply_imshow_axes_visibility
+
+    has_imshow = any(c.function == "imshow" for c in ax_record.calls)
+    if not has_imshow:
+        return
+
+    show_axes = (style or {}).get("imshow_show_axes", True)
+    # show_labels=True: never clear labels post-replay (decorations restored
+    # them, matching the live render); only ticks/spines follow show_axes.
+    apply_imshow_axes_visibility(ax, show_axes, show_labels=True)
+
+
+__all__ = ["replay_axes_calls", "finalize_imshow_axes"]

--- a/src/figrecipe/_reproducer/_replay_insets.py
+++ b/src/figrecipe/_reproducer/_replay_insets.py
@@ -110,15 +110,19 @@ def replay_subpanels(parent_mpl_ax, axes_record, depth: int = 0, style=None) -> 
 
         inset_ax = parent_mpl_ax.inset_axes(bounds, **inset_kwargs)
 
-        # Replay the inset's own plotting calls.
+        # Replay the inset's own plotting calls. Coerce sequence args to numpy:
+        # sub-panel array args are inlined into the host YAML (the data-file
+        # loader does not descend into subpanels) and reload as ruamel
+        # CommentedSeq lists; without coercion an array-arg plotter such as
+        # streamplot fails on ``.shape``.
         for call in child_ax_rec.calls:
-            result = _replay_call(inset_ax, call, result_cache)
+            result = _replay_call(inset_ax, call, result_cache, coerce_sequences=True)
             if result is not None:
                 result_cache[call.id] = result
 
         # Replay the inset's decorations (set_xlabel, etc.).
         for call in child_ax_rec.decorations:
-            result = _replay_call(inset_ax, call, result_cache)
+            result = _replay_call(inset_ax, call, result_cache, coerce_sequences=True)
             if result is not None:
                 result_cache[call.id] = result
 

--- a/src/figrecipe/_wrappers/_axes_embed.py
+++ b/src/figrecipe/_wrappers/_axes_embed.py
@@ -68,12 +68,15 @@ def _draw_and_record_source(parent_rax, inset_rax, src_ax_rec) -> None:
 
     mpl_ax = inset_rax._ax
     cache: dict = {}
+    # coerce_sequences mirrors the inset replay path (_replay_insets): sub-panel
+    # array args that round-trip as plain lists are promoted to numpy so array-arg
+    # plotters (streamplot/contour/imshow) draw the same live and on reproduce.
     for call in list(src_ax_rec.calls):
-        result = _replay_call(mpl_ax, call, cache)
+        result = _replay_call(mpl_ax, call, cache, coerce_sequences=True)
         if result is not None:
             cache[call.id] = result
     for call in list(src_ax_rec.decorations):
-        result = _replay_call(mpl_ax, call, cache)
+        result = _replay_call(mpl_ax, call, cache, coerce_sequences=True)
         if result is not None:
             cache[call.id] = result
 

--- a/src/figrecipe/_wrappers/_axes_plots.py
+++ b/src/figrecipe/_wrappers/_axes_plots.py
@@ -79,21 +79,14 @@ def imshow_plot(
     # Get style settings
     style = get_style()
     if style:
+        from ..styles._plot_styles import apply_imshow_axes_visibility
+
         imshow_style = style.get("imshow", {})
-        show_axes = imshow_style.get("show_axes", True)
-        show_labels = imshow_style.get("show_labels", True)
-
-        if not show_axes:
-            ax.set_xticks([])
-            ax.set_yticks([])
-            ax.set_xticklabels([])
-            ax.set_yticklabels([])
-            for spine in ax.spines.values():
-                spine.set_visible(False)
-
-        if not show_labels:
-            ax.set_xlabel("")
-            ax.set_ylabel("")
+        apply_imshow_axes_visibility(
+            ax,
+            imshow_style.get("show_axes", True),
+            imshow_style.get("show_labels", True),
+        )
 
     # Record the call if tracking is enabled
     if track:

--- a/src/figrecipe/styles/_plot_styles.py
+++ b/src/figrecipe/styles/_plot_styles.py
@@ -159,6 +159,39 @@ def apply_pie_style(ax: Axes, style: Dict[str, Any]) -> None:
             spine.set_visible(False)
 
 
+def apply_imshow_axes_visibility(ax: Axes, show_axes: bool, show_labels: bool) -> None:
+    """Hide imshow ticks / spines / labels per the imshow style flags.
+
+    This is the SINGLE source of truth for imshow axis-chrome suppression.
+    It is called unconditionally for ``imshow`` (by function/call name) from
+    BOTH the live wrapper (``imshow_plot``) and the recipe replay handler so
+    the saved figure and its reproduction suppress ticks identically. It must
+    NOT carry the ``is_specgram`` (has-label) heuristic: the live wrapper
+    never had it, so adding it here would desync save vs. reproduce -- exactly
+    the bug where a labelled ``imshow`` reproduced with extra numeric ticks.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Target axes containing the imshow image.
+    show_axes : bool
+        If False, hide ticks, tick labels, and spines.
+    show_labels : bool
+        If False, clear the x/y axis labels.
+    """
+    if not show_axes:
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.set_xticklabels([])
+        ax.set_yticklabels([])
+        for spine in ax.spines.values():
+            spine.set_visible(False)
+
+    if not show_labels:
+        ax.set_xlabel("")
+        ax.set_ylabel("")
+
+
 def apply_matrix_style(ax: Axes, style: Dict[str, Any]) -> None:
     """Apply imshow/matshow/spy styling (hide axes if configured).
 
@@ -185,20 +218,11 @@ def apply_matrix_style(ax: Axes, style: Dict[str, Any]) -> None:
     if is_specgram:
         return
 
-    show_axes = style.get("imshow_show_axes", True)
-    show_labels = style.get("imshow_show_labels", True)
-
-    if not show_axes:
-        ax.set_xticks([])
-        ax.set_yticks([])
-        ax.set_xticklabels([])
-        ax.set_yticklabels([])
-        for spine in ax.spines.values():
-            spine.set_visible(False)
-
-    if not show_labels:
-        ax.set_xlabel("")
-        ax.set_ylabel("")
+    apply_imshow_axes_visibility(
+        ax,
+        style.get("imshow_show_axes", True),
+        style.get("imshow_show_labels", True),
+    )
 
 
 __all__ = [
@@ -208,6 +232,7 @@ __all__ = [
     "apply_histogram_style",
     "apply_pie_style",
     "apply_matrix_style",
+    "apply_imshow_axes_visibility",
 ]
 
 # EOF

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,40 @@ _ensure_subprocess_coverage_shim()
 matplotlib.use("Agg")
 
 
+def _warm_matplotlib_font_cache() -> None:
+    """Build matplotlib's FontManager once per (xdist worker) process at import.
+
+    The validate-recipe tests render a figure and compare it pixel-for-pixel
+    against a reference render (MSE threshold). The FIRST render in a fresh
+    process triggers a lazy, expensive FontManager build (font scan + cache
+    write). Under the SIF container's high xdist concurrency, multiple cold
+    workers race to build/write that cache simultaneously; a worker that picks
+    up a half-written cache (or falls back to a different font mid-build) ends
+    up rendering with slightly different metrics than the reference, blowing the
+    MSE up to ~715 and flaking ``test_validate_*`` non-deterministically.
+
+    Forcing one trivial headless render here -- at import, before any test
+    collects -- warms each worker's FontManager so every subsequent render in
+    that process is metric-stable. It runs with stock rcParams (a plain
+    ``plt.figure``), so it does not perturb the figrecipe/session style baseline
+    that the per-test rcParams snapshot below preserves.
+    """
+    import warnings
+
+    try:
+        import matplotlib.pyplot as _plt
+
+        _fig = _plt.figure()
+        _fig.text(0.5, 0.5, "warm 0.9 Hz")
+        _fig.canvas.draw()
+        _plt.close(_fig)
+    except Exception as exc:  # never let warm-up break collection
+        warnings.warn(f"matplotlib font-cache warm-up failed: {exc}")
+
+
+_warm_matplotlib_font_cache()
+
+
 @pytest.fixture(autouse=True)
 def _isolate_matplotlib_rcparams():
     """Snapshot ``matplotlib.rcParams`` before each test and restore them after.

--- a/tests/figrecipe/_composition/test__tile.py
+++ b/tests/figrecipe/_composition/test__tile.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for TILED (row-justified, whitespace-free) composition.
+
+The tiled mode (``fr.compose(layout=[["A","B","C"],["D"]], sources=...)``)
+gives every panel its true aspect ratio, makes every panel in a row share one
+height edge-to-edge (no intra-row whitespace), and makes every row span the
+same width (no ragged right edge). The first layout row is rendered on top.
+"""
+
+import matplotlib
+import pytest
+
+matplotlib.use("Agg")
+
+import figrecipe as fr
+from figrecipe._composition._tile import build_tiled_sources
+
+# Tolerance for floating-point geometry comparisons (mm).
+TOL = 1e-6
+
+
+def _make_panel(tmp_path, name, figsize):
+    """Save a single-panel recipe with a distinct aspect ratio."""
+    fig, ax = fr.subplots(figsize=figsize)
+    ax.plot([1, 2, 3], [1, 4, 9], id=name)
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    path = tmp_path / f"{name}.yaml"
+    fr.save(fig, path, validate=False, verbose=False)
+    return path
+
+
+@pytest.fixture
+def four_panels(tmp_path):
+    """Four saved panels with distinct aspect ratios (A wide, B square, C tall, D very-wide)."""
+    return {
+        "A": _make_panel(tmp_path, "A", (3, 2)),
+        "B": _make_panel(tmp_path, "B", (2, 2)),
+        "C": _make_panel(tmp_path, "C", (2, 3)),
+        "D": _make_panel(tmp_path, "D", (5, 2)),
+    }
+
+
+class TestTiledRoundTrip:
+    """|A B C| / |D| composes and survives save/reproduce."""
+
+    def test_roundtrips_no_not_reproduced_artifact(self, tmp_path, four_panels):
+        """fr.save validates with no <stem>-not-reproduced.png left behind."""
+        # Arrange
+        fig, axes = fr.compose(
+            layout=[["A", "B", "C"], ["D"]],
+            sources=four_panels,
+            width_mm=180,
+            gap_mm=1.0,
+        )
+        out = tmp_path / "composed.png"
+        # Act
+        fr.save(fig, out, verbose=False)
+        # Assert
+        assert not (tmp_path / "composed-not-reproduced.png").exists()
+
+
+class TestTiledNoWhitespace:
+    """Every row spans the full width W (no ragged edge)."""
+
+    def test_every_row_spans_full_width(self, four_panels):
+        """sum(row panel widths) + (k-1)*gap == W for EVERY row (incl. row 2 = D)."""
+        # Arrange
+        gap = 1.0
+        rows = [["A", "B", "C"], ["D"]]
+        # Act
+        sources_mm, (W, _h) = build_tiled_sources(
+            rows, four_panels, width_mm=180, gap_mm=gap
+        )
+        row_spans = [
+            sum(sources_mm[four_panels[lab]]["size_mm"][0] for lab in row)
+            + (len(row) - 1) * gap
+            for row in rows
+        ]
+        # Assert
+        assert all(abs(span - W) < TOL for span in row_spans)
+
+
+class TestTiledEqualRowHeight:
+    """Within a row all panels share one common height."""
+
+    def test_row_panels_share_height(self, four_panels):
+        """The three top-row panels (A, B, C) all get the same panel height."""
+        # Arrange
+        rows = [["A", "B", "C"], ["D"]]
+        # Act
+        sources_mm, _canvas = build_tiled_sources(
+            rows, four_panels, width_mm=180, gap_mm=1.0
+        )
+        heights = [sources_mm[four_panels[lab]]["size_mm"][1] for lab in rows[0]]
+        # Assert
+        assert max(heights) - min(heights) < TOL
+
+
+class TestTiledEdgeToEdge:
+    """With gap_mm=0 adjacent panels in a row share an x-edge."""
+
+    def test_adjacent_panels_share_edge(self, four_panels):
+        """next.x0 == prev.x1 for consecutive top-row panels when gap_mm=0."""
+        # Arrange
+        rows = [["A", "B", "C"], ["D"]]
+        # Act
+        sources_mm, _canvas = build_tiled_sources(
+            rows, four_panels, width_mm=180, gap_mm=0.0
+        )
+        placed = [
+            (
+                sources_mm[four_panels[lab]]["xy_mm"][0],
+                sources_mm[four_panels[lab]]["size_mm"][0],
+            )
+            for lab in rows[0]
+        ]
+        placed.sort()
+        gaps = [
+            placed[i + 1][0] - (placed[i][0] + placed[i][1])
+            for i in range(len(placed) - 1)
+        ]
+        # Assert
+        assert all(abs(g) < TOL for g in gaps)
+
+
+class TestTiledFirstRowOnTop:
+    """The first layout row is rendered visually on top (smallest y_mm)."""
+
+    def test_first_row_has_smallest_y(self, four_panels):
+        """Row-1 panels get y_mm=0 while row-2 (D) gets a larger y_mm (top-down origin)."""
+        # Arrange
+        rows = [["A", "B", "C"], ["D"]]
+        # Act
+        sources_mm, _canvas = build_tiled_sources(
+            rows, four_panels, width_mm=180, gap_mm=1.0
+        )
+        top_y = max(sources_mm[four_panels[lab]]["xy_mm"][1] for lab in rows[0])
+        d_y = sources_mm[four_panels["D"]]["xy_mm"][1]
+        # Assert
+        assert top_y < d_y
+
+
+class TestTiledStringLayout:
+    """A multiline-string layout equals the list-of-lists layout."""
+
+    def test_string_layout_matches_list_layout(self, four_panels):
+        """'A B C\\nD' produces the same geometry as [["A","B","C"],["D"]]."""
+        # Arrange
+        list_mm, list_canvas = build_tiled_sources(
+            [["A", "B", "C"], ["D"]], four_panels, width_mm=180, gap_mm=1.0
+        )
+        # Act
+        str_mm, str_canvas = build_tiled_sources(
+            "A B C\nD", four_panels, width_mm=180, gap_mm=1.0
+        )
+        # Assert
+        assert str_mm == list_mm and str_canvas == list_canvas
+
+
+class TestTiledValidation:
+    """Label/source mismatches fail loud."""
+
+    def test_missing_source_raises(self, four_panels):
+        """A layout label with no matching source raises ValueError."""
+        # Arrange
+        bad_layout = [["A", "B", "C"], ["Z"]]  # Z has no source
+        # Act
+        # Assert
+        with pytest.raises(ValueError):
+            build_tiled_sources(bad_layout, four_panels, width_mm=180, gap_mm=1.0)
+
+
+# EOF

--- a/tests/figrecipe/_reproducer/test__axis_scale.py
+++ b/tests/figrecipe/_reproducer/test__axis_scale.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unsupported axis-scale warning on replay (figrecipe, NeuroVista Ask 2).
+
+``set_xscale`` / ``set_yscale`` replay as generic decorations. A recognised scale
+(log, symlog, logit, ...) must apply silently, but an unsupported / custom scale
+must warn loudly instead of degrading silently to a linear axis (no silent
+fallback).
+"""
+
+import warnings
+
+import pytest
+
+from figrecipe._reproducer._axis_scale import warn_if_unsupported_scale
+
+
+def test_supported_scale_does_not_warn():
+    # Arrange
+    warnings.simplefilter("error")
+    # Act
+    result = warn_if_unsupported_scale("set_yscale", ["log"])
+    # Assert
+    assert result is None
+
+
+def test_unsupported_scale_warns():
+    # Arrange
+    args = ["totally-made-up-scale"]
+    # Act
+    # Assert
+    with pytest.warns(UserWarning, match="unsupported axis scale"):
+        warn_if_unsupported_scale("set_yscale", args)
+
+
+def test_non_scale_method_does_not_warn():
+    # Arrange
+    warnings.simplefilter("error")
+    # Act
+    result = warn_if_unsupported_scale("set_xlim", ["bogus"])
+    # Assert
+    assert result is None

--- a/tests/integration/test_all_plotters_nested_roundtrip.py
+++ b/tests/integration/test_all_plotters_nested_roundtrip.py
@@ -27,18 +27,15 @@ robust against freetype/font-version pixel flakiness, same level as
 ``test_reproducibility_matrix.py``.
 
 XFAILED plotters (nesting):
-  - ``streamplot`` (single embed): the inset/embed replay path does not coerce
-    the YAML-deserialized streamplot coordinate arrays (loaded as ruamel
-    ``CommentedSeq``) back to numpy before ``Axes.streamplot`` accesses
-    ``.shape``. The embedded sub-panel therefore fails to redraw on reproduce
+  - (none) ``streamplot`` single embed was previously xfailed: the inset/embed
+    replay path did not coerce the YAML-deserialized streamplot coordinate arrays
+    (loaded as ruamel ``CommentedSeq``) back to numpy before ``Axes.streamplot``
+    accessed ``.shape``, so the embedded sub-panel failed to redraw on reproduce
     (``UserWarning: Failed to replay streamplot: 'CommentedSeq' object has no
-    attribute 'shape'``) and validation fails (MSE ~1639 >> threshold 100, the
-    diff concentrated exactly in the embedded sub-panel's region). NOTE: the SAME
-    streamplot round-trips fine standalone (pixel-perfect suite) AND through
-    ``fr.compose`` AND through embed-OF-a-composed-recipe — the gap is specific
-    to embedding a single streamplot recipe directly. Marked ``strict=False`` so
-    a future source-side fix (coerce list args in the inset replay path) flips it
-    green without editing this test.
+    attribute 'shape'``) and validation failed (MSE ~1639). FIXED: the inset/embed
+    replay path now coerces reconstructed sequence args to numpy via
+    ``coerce_sequence_arg`` (``_reproducer/_reconstruct.py``), so any array-arg
+    plotter round-trips through a single embed; ``streamplot`` now passes here.
 """
 
 import tempfile
@@ -60,17 +57,9 @@ from figrecipe.styles._finalize import finalize_special_plots, finalize_ticks
 _MM_PER_INCH = 25.4
 
 # Plotters expected to FAIL the SINGLE-embed round-trip, each with a reason.
-SINGLE_EMBED_XFAIL = {
-    "streamplot": (
-        "embed/inset replay does not coerce YAML-loaded streamplot arrays "
-        "(ruamel CommentedSeq) to numpy before Axes.streamplot needs .shape; "
-        "embedded sub-panel fails to redraw on reproduce "
-        "(UserWarning: Failed to replay streamplot: 'CommentedSeq' object has "
-        "no attribute 'shape') -> validation MSE ~1639 >> 100. Standalone, "
-        "compose, and embed-of-composed all round-trip; only direct single "
-        "embed of a streamplot recipe regresses."
-    ),
-}
+# Empty: ``streamplot`` was fixed (inset/embed replay now coerces reconstructed
+# sequence args to numpy via ``coerce_sequence_arg``); see the module docstring.
+SINGLE_EMBED_XFAIL: dict = {}
 
 
 def _embed_params():

--- a/tests/integration/test_axis_scale_and_limits_reproduction.py
+++ b/tests/integration/test_axis_scale_and_limits_reproduction.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Axis scale + explicit limit reproduction (figrecipe, NeuroVista Ask 2).
+
+Two related round-trip guarantees:
+
+(A) ``ax.set_yscale("log")`` / ``set_xscale`` must be recorded and replayed so a
+    log (or symlog / logit) axis reproduces as log, not silently as linear. Before
+    the fix these setters were not in the recorded decoration allow-list, so the
+    decoration list was empty and reproduce() yielded a linear axis.
+
+(B) An explicit ``set_xlim`` / ``set_ylim`` must survive reproduction exactly --
+    autoscale re-engaged by later decorations / finalizers must not widen the
+    recorded view. The reproducer re-applies the recorded limits last so they win.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import figrecipe as fr
+
+
+@pytest.fixture()
+def log_yaxis_recipe(tmp_path):
+    """A recipe whose y-axis was explicitly set to a log scale."""
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.plot([1, 2, 3, 4], [1, 10, 100, 1000])
+    ax.set_yscale("log")
+    out = tmp_path / "logy.png"
+    fr.save(fig, str(out), validate=False)
+    plt.close("all")
+    return tmp_path / "logy.yaml"
+
+
+@pytest.fixture()
+def explicit_limits_recipe(tmp_path):
+    """A recipe with explicit, non-data x/y limits that autoscale would widen."""
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.plot(np.arange(11.0), np.arange(11.0))
+    ax.set_xlim(2.0, 8.0)
+    ax.set_ylim(3.0, 7.0)
+    out = tmp_path / "lims.png"
+    fr.save(fig, str(out), validate=False)
+    plt.close("all")
+    return tmp_path / "lims.yaml"
+
+
+def test_log_yscale_reproduces_as_log(log_yaxis_recipe):
+    # Arrange
+    _, rax = fr.reproduce(str(log_yaxis_recipe))
+    mpl_ax = getattr(rax, "ax", rax)
+    # Act
+    yscale = mpl_ax.get_yscale()
+    plt.close("all")
+    # Assert
+    assert yscale == "log"
+
+
+def test_explicit_xlim_reproduces_exactly(explicit_limits_recipe):
+    # Arrange
+    _, rax = fr.reproduce(str(explicit_limits_recipe))
+    mpl_ax = getattr(rax, "ax", rax)
+    # Act
+    xlim = mpl_ax.get_xlim()
+    plt.close("all")
+    # Assert
+    assert xlim == (2.0, 8.0)
+
+
+def test_explicit_ylim_reproduces_exactly(explicit_limits_recipe):
+    # Arrange
+    _, rax = fr.reproduce(str(explicit_limits_recipe))
+    mpl_ax = getattr(rax, "ax", rax)
+    # Act
+    ylim = mpl_ax.get_ylim()
+    plt.close("all")
+    # Assert
+    assert ylim == (3.0, 7.0)

--- a/tests/integration/test_imshow_tick_reproduction.py
+++ b/tests/integration/test_imshow_tick_reproduction.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save -> reproduce round-trip for a labelled ax.imshow() (figrecipe).
+
+The live ``ax.imshow`` wrapper hides numeric ticks/spines (the matrix style)
+even when the axes carries axis labels. On replay the recorded ``imshow`` ran
+as raw matplotlib and ``finalize_special_plots`` skipped suppression for a
+labelled image (its ``is_specgram`` heuristic), so the reproduced heatmap grew
+back the ticks the original hid and failed save-time reproducibility validation
+(NeuroVista Fig 02 panel a). This guards that a labelled ``imshow`` whose ticks
+are suppressed at save reproduces clean (no ``*-not-reproduced`` artefact).
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import numpy as np
+
+import figrecipe as fr
+
+
+def test_labelled_imshow_reproduces_without_extra_ticks(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.imshow(
+        np.linspace(0, 1, 225).reshape(15, 15),
+        origin="lower",
+        aspect="auto",
+        extent=(2.0, 30.0, 60.0, 180.0),
+        cmap="hot",
+    )
+    ax.set_xyt("phase f (Hz)", "amp f (Hz)", "comodulogram")
+    # Act
+    fr.save(fig, str(tmp_path / "comodulogram.png"))
+    # Assert
+    assert not list(tmp_path.glob("*-not-reproduced.*"))


### PR DESCRIPTION
## What

Consolidates five verified figrecipe fixes into **one PR / one SIF matrix run** (CI is runner-bound; this avoids five separate ~23-min runs). All five were individually verified locally; this also de-flakes the SIF font-cache race so the matrix is deterministic.

## Included fixes
- **rcParams test isolation** (conftest snapshot/restore) — fixes the py3.11 spine-mixin cross-file leak; supersedes the #222 module-local band-aid. *(already merged as #223; common with develop)*
- **streamplot single-embed** — coerce sub-panel sequence args to numpy on embed replay (greens the #216 nested xfail). *(supersedes #221)*
- **axis scale + limits** — record `set_xscale`/`set_yscale`; reapply recorded `xlim`/`ylim` so autoscale can't override them.
- **imshow tick-suppression on replay** — reproduce hides imshow ticks like save does (NeuroVista panel-B comodulogram, was MSE~4547).
- **tiled compose layout** — flexible `|A B C| / |D|` whitespace-free row-justified layout (`_composition/_tile.py`).

## Test-infra fixes (make the SIF matrix deterministic)
- **Font-cache warm-up** (`tests/conftest.py`) — per-worker FontManager warm at import, so the `validate_recipe` render-vs-render compares aren't flaked by a cold font cache under xdist (the MSE~715 race; complements scitex-dev's run-in-sif.sh).
- **`_core.py` split** — the 3 reproducer merges pushed it to 539 lines; extracted `_finalize_axes.py` + `_recipe_info.py` (re-exported; import paths preserved) → 480 lines.

## Conflict resolution
Only `_core.py` (imshow vs axis-scale both added a post-`finalize_ticks` per-axes loop) — **unioned**: imshow tick-suppression runs right after `finalize_ticks`, recorded-limit reapply runs truly last (so it wins over autoscale). `_replay_call` retains all three branches' additions.

## Known deferred
- **Tiled title-clip** — `# TODO(title-clip)` in `_tile.py`: the widest flush panel's point-sized title can overhang; a geometry fix collides with the tiled tests' 1e-6 assertions, so deferred to the upcoming diagram width-cap work (not band-aided).

## Verification
Local (serial): spine 5, streamplot-embed 1, axis-scale 6, imshow 1, tiled 7, validate 4, `_reproducer` 73, `_composition` 160 — all pass. The **SIF matrix (this PR) is the comprehensive gate** — full heavy suites against the merged code across py3.11/3.12/3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
