### PR TITLE
fix(reproducer): honour explicit imshow ticks on replay (NeuroVista Fig02 panel b)

### DIFF
--- a/src/figrecipe/_reproducer/_replay_axes.py
+++ b/src/figrecipe/_reproducer/_replay_axes.py
@@ -66,35 +66,53 @@ def finalize_imshow_axes(ax, ax_record, style: Optional[Dict[str, Any]]) -> None
     suppression whenever the axes carries an axis label (its ``is_specgram``
     heuristic) -- so a *labelled* ``imshow`` (e.g. a comodulogram with
     ``set_xyt``) reproduced WITH the numeric ticks the original hid, failing
-    reproducibility validation.
+    reproducibility validation. The faithful discriminator is the recorded
+    call name -- exactly what the live wrapper keys on -- so suppression runs
+    only for an axes that actually has an ``imshow`` call, never for a genuine
+    ``ax.specgram`` (which the live wrapper never touched).
 
-    The faithful discriminator is the recorded call name -- exactly what the
-    live wrapper keys on -- not the presence of a label: suppress only for an
-    axes that actually has an ``imshow`` call, never for a genuine
-    ``ax.specgram`` (which the live wrapper never touched). Only ticks/spines
-    are hidden here; axis labels are left intact because any label present was
-    re-set by ``set_xlabel``/``set_ylabel`` decorations recorded AFTER the
-    imshow (the original kept them too).
+    Crucially this must honour the live render's *order*. The live wrapper
+    suppresses chrome DURING the imshow call, so a user ``set_xticks`` /
+    ``set_yticks`` issued AFTER imshow overrides the suppression and DOES show
+    in the saved figure (a comodulogram whose author deliberately labels the
+    Hz bands). On replay those tick calls are decorations already replayed
+    before this post-pass, so clearing unconditionally would wipe the user's
+    explicit ticks -- live shows them, reproduce hid them, and the recipe then
+    fails its own pixel validation. So suppress only the axis dimension the
+    recipe did NOT explicitly tick; an explicit ``set_xticks([])`` likewise
+    counts as user-controlled and is left exactly as the decoration set it.
+    Spines are never restored by a tick decoration, so they follow
+    ``show_axes`` regardless. Axis labels are left intact (any present were
+    re-set by ``set_xlabel``/``set_ylabel`` decorations, matching the live
+    figure).
 
     Parameters
     ----------
     ax :
         Target matplotlib axes (raw, post-replay).
     ax_record : AxesRecord
-        The recorded axes -- inspected for an ``imshow`` call.
+        The recorded axes -- inspected for an ``imshow`` call and for explicit
+        tick decorations.
     style : dict or None
         The recipe's (flat) style. ``imshow_show_axes`` gates suppression.
     """
-    from ..styles._plot_styles import apply_imshow_axes_visibility
-
     has_imshow = any(c.function == "imshow" for c in ax_record.calls)
     if not has_imshow:
         return
 
     show_axes = (style or {}).get("imshow_show_axes", True)
-    # show_labels=True: never clear labels post-replay (decorations restored
-    # them, matching the live render); only ticks/spines follow show_axes.
-    apply_imshow_axes_visibility(ax, show_axes, show_labels=True)
+    if show_axes:
+        return
+
+    decorations = ax_record.decorations
+    if not any(c.function == "set_xticks" for c in decorations):
+        ax.set_xticks([])
+        ax.set_xticklabels([])
+    if not any(c.function == "set_yticks" for c in decorations):
+        ax.set_yticks([])
+        ax.set_yticklabels([])
+    for spine in ax.spines.values():
+        spine.set_visible(False)
 
 
 __all__ = ["replay_axes_calls", "finalize_imshow_axes"]

--- a/tests/integration/test_imshow_tick_reproduction.py
+++ b/tests/integration/test_imshow_tick_reproduction.py
@@ -34,3 +34,28 @@ def test_labelled_imshow_reproduces_without_extra_ticks(tmp_path):
     fr.save(fig, str(tmp_path / "comodulogram.png"))
     # Assert
     assert not list(tmp_path.glob("*-not-reproduced.*"))
+
+
+def test_imshow_with_explicit_ticks_reproduces_keeping_them(tmp_path):
+    # The live imshow wrapper hides ticks DURING imshow, so user set_xticks
+    # AFTER imshow override it and DO show. On replay those tick calls are
+    # decorations replayed before the post-pass, so suppressing unconditionally
+    # wiped them (live showed ticks, reproduce hid them) and validation failed.
+    # Reproduce must honour explicit ticks on a suppressed-style imshow
+    # (NeuroVista Fig 02 panel b -- author labels the Hz bands deliberately).
+    # Arrange
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.imshow(
+        np.linspace(0, 1, 225).reshape(15, 15),
+        origin="lower",
+        aspect="auto",
+        extent=(2.0, 30.0, 60.0, 180.0),
+        cmap="hot",
+    )
+    ax.set_xyt("phase f (Hz)", "amp f (Hz)", "comodulogram")
+    ax.set_xticks([8, 16, 24], labels=["8", "16", "24"])
+    ax.set_yticks([60, 120, 180], labels=["60", "120", "180"])
+    # Act
+    fr.save(fig, str(tmp_path / "comodulogram_ticked.png"))
+    # Assert
+    assert not list(tmp_path.glob("*-not-reproduced.*"))

--- a/tests/integration/test_imshow_tick_reproduction.py
+++ b/tests/integration/test_imshow_tick_reproduction.py
@@ -59,3 +59,52 @@ def test_imshow_with_explicit_ticks_reproduces_keeping_them(tmp_path):
     fr.save(fig, str(tmp_path / "comodulogram_ticked.png"))
     # Assert
     assert not list(tmp_path.glob("*-not-reproduced.*"))
+
+
+def test_imshow_tile_grid_reproduces_edge_ticks(tmp_path):
+    # NeuroVista Fig 02 panel d: a 2-row imshow tile grid where each tile sets
+    # ticks explicitly -- sparse Hz ticks on the bottom row / left column,
+    # set_xticks([]) elsewhere. #224 cleared the edge tiles' explicit ticks on
+    # replay (was green pre-#224 -> MSE 297). Guards that the whole grid
+    # round-trips with the edge ticks preserved and the interior suppressed.
+    # Arrange
+    fig, axes = fr.subplots(
+        nrows=2,
+        ncols=3,
+        axes_width_mm=25,
+        axes_height_mm=25,
+        margin_left_mm=24,
+        margin_bottom_mm=18,
+        space_w_mm=4,
+        space_h_mm=4,
+        panel_labels=False,
+    )
+    grid = np.add.outer(np.linspace(0, 1, 25), np.linspace(0, 1, 25))
+    for r in range(2):
+        for c in range(3):
+            ax = axes[r, c]
+            ax.imshow(
+                grid.T,
+                origin="lower",
+                aspect="auto",
+                extent=(2.0, 30.0, 60.0, 180.0),
+                cmap="viridis",
+                vmin=0.0,
+                vmax=2.0,
+            )
+            if r == 1:
+                ax.set_xticks([8, 16, 24], labels=["8", "16", "24"])
+            else:
+                ax.set_xticks([])
+            if c == 0:
+                ax.set_yticks([60, 120, 180], labels=["60", "120", "180"])
+            else:
+                ax.set_yticks([])
+            if r == 1 and c == 0:
+                ax.set_xlabel("phase f (Hz)")
+            if c == 0:
+                ax.set_ylabel("amp f (Hz)")
+    # Act
+    fr.save(fig, str(tmp_path / "tile_grid.png"))
+    # Assert
+    assert not list(tmp_path.glob("*-not-reproduced.*"))


### PR DESCRIPTION
## What
On replay, honour **explicit** imshow ticks so an author who deliberately labels a suppressed-style `imshow` (e.g. a comodulogram's Hz bands) gets a faithful round-trip.

## Root cause
#224 added `finalize_imshow_axes` to re-suppress imshow ticks on replay (the style sets `imshow_show_axes: false`). But it cleared ticks **unconditionally, as a post-pass after all decorations**. The live `imshow` wrapper suppresses ticks *during* the `imshow` call, so a user `set_xticks([...])` issued **after** `imshow` overrides it and shows in the saved figure. On replay those `set_xticks` run as decorations **before** the post-pass — so clearing wiped the author's ticks:

- **live:** imshow→suppress→`set_xticks` ⇒ ticks shown
- **replay (#224):** imshow→`set_xticks`→suppress ⇒ ticks cleared

Same operations, wrong order → live≠replay → the recipe failed its own pixel validation. **NeuroVista Fig 02 panel b** (PAC comodulogram, deliberately Hz-labelled): MSE ~6900, 51% of pixels changed (constrained-layout repacked the de-ticked axes).

## Fix
`finalize_imshow_axes` now suppresses only the axis dimension the recipe did **not** explicitly tick (an explicit `set_xticks([])` likewise counts as user-controlled). Spines still follow `show_axes`. The no-explicit-tick imshow still suppresses cleanly — the original #224 case is unchanged.

## Verification
- New test `test_imshow_with_explicit_ticks_reproduces_keeping_them` (preserve case) + existing suppress-case test — both pass.
- Real NeuroVista panel b recipe (explicit Hz ticks) now round-trips: **same size, MSE 37.1 < 100 → PASS** (was MSE ~6900, `-not-reproduced.png`).
- `_reproducer/` suite (73) + imshow integration (2) green.
