### PR TITLE
feat(reproducer): capture + replay full rcParams for pixel-identical reproduction

### DIFF
--- a/src/figrecipe/_recorder/_core.py
+++ b/src/figrecipe/_recorder/_core.py
@@ -208,6 +208,12 @@ class FigureRecord:
     layout: Optional[Dict[str, float]] = None
     # Style parameters
     style: Optional[Dict[str, Any]] = None
+    # Full active rcParams captured as primitives -- the delta from
+    # matplotlib.rcParamsDefault at figure-build time. Restored via rc_context
+    # on replay so a recipe reproduces pixel-identically even when the render
+    # depended on a loaded theme (SCITEX_STYLE) or a globally-set rcParam that
+    # is NOT in figrecipe's curated ``style`` block. ``None`` on legacy recipes.
+    rcparams: Optional[Dict[str, Any]] = None
     # Constrained layout flag
     constrained_layout: bool = False
     # Figure-level decorations (suptitle, supxlabel, supylabel)
@@ -276,6 +282,9 @@ class FigureRecord:
         # Add style if set
         if self.style is not None:
             result["figure"]["style"] = self.style
+        # Add the full captured rcParams delta (primitives) if set
+        if self.rcparams:
+            result["figure"]["rcparams"] = self.rcparams
         # Add constrained_layout if True
         if self.constrained_layout:
             result["figure"]["constrained_layout"] = True
@@ -338,6 +347,7 @@ class FigureRecord:
             ncols=fig_data.get("ncols"),
             layout=fig_data.get("layout"),
             style=fig_data.get("style"),
+            rcparams=fig_data.get("rcparams"),
             constrained_layout=fig_data.get("constrained_layout", False),
             suptitle=fig_data.get("suptitle"),
             supxlabel=fig_data.get("supxlabel"),

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -118,8 +118,7 @@ def reproduce_from_record(
     axes : RecordingAxes or ndarray of RecordingAxes
         Reproduced axes (wrapped, numpy array for multi-axes).
     """
-    from .._recorder import Recorder
-    from .._wrappers import RecordingAxes, RecordingFigure
+    import matplotlib as mpl
 
     # mm-based composed figures (plt.compose) key their panels "ax_mm_*" and
     # position each via add_axes(bbox); the grid model below can't represent that
@@ -129,6 +128,26 @@ def reproduce_from_record(
 
     if is_mm_composed(record):
         return reproduce_mm_composed(record)
+
+    # Restore the recipe's captured rcParams (a loaded theme like SCITEX_STYLE,
+    # or ANY globally-set rcParam) for the entire grid build, so every artist
+    # renders under the identical environment as the original. rc_context scopes
+    # it -- reproduce never leaks rcParams to the caller.
+    from ..styles._rcparams import apply_recorded_rcparams
+
+    with mpl.rc_context():
+        apply_recorded_rcparams(record.rcparams or {})
+        return _reproduce_grid(record, calls, skip_decorations)
+
+
+def _reproduce_grid(
+    record: FigureRecord,
+    calls: Optional[List[str]] = None,
+    skip_decorations: bool = False,
+):
+    """Build the grid figure (runs inside the caller's rc_context)."""
+    from .._recorder import Recorder
+    from .._wrappers import RecordingAxes, RecordingFigure
 
     # Determine grid size from axes positions
     max_row = 0

--- a/src/figrecipe/_reproducer/_mm_compose.py
+++ b/src/figrecipe/_reproducer/_mm_compose.py
@@ -29,6 +29,21 @@ def reproduce_mm_composed(record):
 
     Returns ``(wrapped_fig, axes_list)`` mirroring ``reproduce_from_record``.
     """
+    import matplotlib as mpl
+
+    # Restore the recipe's captured rcParams (a loaded theme like SCITEX_STYLE,
+    # or ANY globally-set rcParam) for the whole composed build, so every panel
+    # renders under the identical environment. rc_context scopes it -- reproduce
+    # never leaks rcParams to the caller.
+    from ..styles._rcparams import apply_recorded_rcparams
+
+    with mpl.rc_context():
+        apply_recorded_rcparams(getattr(record, "rcparams", None) or {})
+        return _build_mm_composed(record)
+
+
+def _build_mm_composed(record):
+    """Build the composed figure (runs inside the caller's rc_context)."""
     from matplotlib.backends.backend_agg import FigureCanvasAgg
     from matplotlib.figure import Figure
 

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -72,6 +72,17 @@ def save_recipe(
     # Create data directory for large arrays (only for separate format)
     data_dir = path.parent / f"{path.stem}_data"
 
+    # Capture the active rcParams (delta from matplotlib default, as primitives)
+    # so the recipe reproduces under the identical style environment -- a loaded
+    # theme (SCITEX_STYLE) or ANY globally-set rcParam that is not in figrecipe's
+    # curated ``style`` block. Guard on ``is None`` so a reproduced figure being
+    # re-saved keeps its recipe's recorded rcParams (never re-derives them from a
+    # possibly-different live context).
+    if getattr(record, "rcparams", None) is None:
+        from ..styles._rcparams import capture_rcparams_delta
+
+        record.rcparams = capture_rcparams_delta()
+
     # Convert record to dict
     data = record.to_dict()
 

--- a/src/figrecipe/styles/_rcparams.py
+++ b/src/figrecipe/styles/_rcparams.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Capture + restore the full active matplotlib rcParams for faithful replay.
+
+The recipe's curated ``style`` block holds figrecipe's own parameters, but a
+figure can also depend on rcParams set by a loaded theme (e.g. SCITEX_STYLE) or
+set globally by the user -- ``axes.titleweight``, ``font.weight``, ``font.style``,
+tick direction, minor-tick visibility, and so on. Those are NOT in the curated
+block, so without capturing them a fresh-process replay renders with matplotlib
+defaults and diverges from the original (a silent reproduction failure).
+
+This module snapshots the rcParams that differ from ``matplotlib.rcParamsDefault``
+as YAML-safe primitives at figure-build time (the theme is persisted as concrete
+values, not a style name), and restores them inside an ``rc_context`` on replay
+so the figure renders in the identical environment -- pixel-identical, in all
+cases.
+"""
+
+import warnings
+from typing import Any, Dict
+
+import matplotlib as mpl
+
+# rcParams that route OUTPUT or describe the ENVIRONMENT rather than the figure's
+# appearance: replaying them would hijack the reproduce environment, and figure
+# size / dpi are already captured as record.figsize / record.dpi. Excluded by
+# exact key or by "prefix." membership.
+_EXCLUDE_EXACT = frozenset(
+    {
+        "backend",
+        "interactive",
+        "toolbar",
+        "timezone",
+        "datapath",
+        "figure.figsize",
+        "figure.dpi",
+        "savefig.dpi",
+        "savefig.directory",
+        "savefig.format",
+        "docstring.hardcopy",
+        "examples.directory",
+    }
+)
+_EXCLUDE_PREFIXES = (
+    "backend_",
+    "webagg.",
+    "tk.",
+    "macosx.",
+    "keymap.",
+    "animation.",
+)
+
+
+def _excluded(key: str) -> bool:
+    if key in _EXCLUDE_EXACT:
+        return True
+    return any(key.startswith(p) for p in _EXCLUDE_PREFIXES)
+
+
+def _to_primitive(value: Any) -> Any:
+    """Convert an rcParam value to a YAML-safe, round-trippable primitive."""
+    from cycler import Cycler
+
+    if isinstance(value, Cycler):
+        return {
+            "__cycler__": {
+                k: [_to_primitive(x) for x in v] for k, v in value.by_key().items()
+            }
+        }
+    if isinstance(value, (list, tuple)):
+        return [_to_primitive(v) for v in value]
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, (int, float, str)):
+        return value
+    try:
+        import numpy as np
+
+        if isinstance(value, np.generic):
+            return value.item()
+    except Exception:
+        pass
+    return str(value)
+
+
+def capture_rcparams_delta() -> Dict[str, Any]:
+    """Snapshot rcParams that differ from the library default, as primitives."""
+    default = mpl.rcParamsDefault
+    delta: Dict[str, Any] = {}
+    for key in mpl.rcParams:
+        if _excluded(key):
+            continue
+        cur = mpl.rcParams[key]
+        dft = default.get(key)
+        try:
+            same = bool(cur == dft)
+        except (ValueError, TypeError):
+            same = repr(cur) == repr(dft)
+        if not same:
+            delta[key] = _to_primitive(cur)
+    return delta
+
+
+def _from_primitive(value: Any) -> Any:
+    from cycler import cycler
+
+    if isinstance(value, dict) and "__cycler__" in value:
+        by_key = value["__cycler__"]
+        out = None
+        for k, vals in by_key.items():
+            c = cycler(k, list(vals))
+            out = c if out is None else out + c
+        return out
+    return value
+
+
+def apply_recorded_rcparams(rcparams: Dict[str, Any]) -> None:
+    """Apply recorded rcParams onto the live (rc_context-scoped) rcParams.
+
+    Keys are set individually; one matplotlib rejects is WARNED (fail loud), not
+    silently dropped -- a genuinely unreproducible parameter is made visible
+    rather than masked. Call inside ``matplotlib.rc_context()`` so it never leaks
+    to the global state.
+    """
+    if not rcparams:
+        return
+    for key, value in rcparams.items():
+        try:
+            mpl.rcParams[key] = _from_primitive(value)
+        except (KeyError, ValueError) as exc:
+            warnings.warn(
+                f"figrecipe: could not restore rcParam {key!r}={value!r} on "
+                f"replay ({exc}); reproduction may diverge for this parameter.",
+                stacklevel=2,
+            )

--- a/tests/integration/test_reproducibility_completeness.py
+++ b/tests/integration/test_reproducibility_completeness.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Reproducibility completeness: a recipe must reproduce PIXEL-IDENTICALLY in a
+FRESH rcParams context (i.e. a new process).
+
+Core principle (no silent fallback): everything that affected the rendered
+figure must be captured in the recipe AS PRIMITIVES and restored on replay --
+the active theme (e.g. SCITEX_STYLE loaded into rcParams), explicitly-specified
+values, AND any globally-set rcParam. To prove the recipe is self-sufficient
+(not silently leaning on ambient state), each test resets matplotlib.rcParams to
+the library defaults BETWEEN save and reproduce, then asserts the reproduction
+is pixel-identical (MSE == 0) at the same size. Any reliance on an uncaptured
+rcParam surfaces as MSE > 0 -- fail loud, no resize/tolerance fallback.
+
+The autouse rcParams isolation in conftest restores global rcParams after each
+test, so mutating them here is safe.
+"""
+
+import matplotlib as mpl
+
+mpl.use("Agg")
+import numpy as np
+import pytest
+
+import figrecipe as fr
+from figrecipe._utils._image_diff import compare_images
+
+
+def _titled_line_fig():
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.plot([0, 1, 2, 3], [0, 1, 4, 9])
+    ax.set_title("Reproducibility")
+    ax.set_xlabel("phase f (Hz)")
+    ax.set_ylabel("amp f (Hz)")
+    return fig
+
+
+def _imshow_fig():
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.imshow(
+        np.linspace(0, 1, 225).reshape(15, 15),
+        origin="lower",
+        aspect="auto",
+        extent=(2.0, 30.0, 60.0, 180.0),
+        cmap="hot",
+    )
+    ax.set_xyt("phase f (Hz)", "amp f (Hz)", "comodulogram")
+    ax.set_xticks([8, 16, 24], labels=["8", "16", "24"])
+    return fig
+
+
+def _bar_log_fig():
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.bar([0, 1, 2, 3], [10, 1000, 50, 7000])
+    ax.set_yscale("log")
+    ax.set_title("throughput")
+    return fig
+
+
+def _fresh_context_roundtrip_mse(make_fig, rc, tmp_path, dpi=150):
+    """Build under ambient ``rc``, save (record), wipe rcParams to library
+    defaults (simulate a new process), reproduce, and return the pixel MSE
+    between original and reproduction (both rendered at ``dpi`` via the same
+    RecordingFigure.savefig path). Returns +inf on any size mismatch -- a size
+    divergence is a hard failure, never silently compared on a cropped overlap.
+    """
+    mpl.rcParams.update(mpl.rcParamsDefault)
+    mpl.rcParams.update(rc)
+    fig = make_fig()
+    fr.save(fig, str(tmp_path / "orig.png"), validate=False)
+    fig.savefig(str(tmp_path / "o.png"), save_recipe=False, dpi=dpi, verbose=False)
+
+    mpl.rcParams.update(mpl.rcParamsDefault)  # brand-new-process simulation
+    rfig, _ = fr.reproduce(str(tmp_path / "orig.yaml"))
+    rfig.savefig(str(tmp_path / "r.png"), save_recipe=False, dpi=dpi, verbose=False)
+
+    diff = compare_images(str(tmp_path / "o.png"), str(tmp_path / "r.png"))
+    return diff["mse"] if diff["same_size"] else float("inf")
+
+
+# rcParams set globally (e.g. by a theme / SCITEX_STYLE / user) that lie OUTSIDE
+# figrecipe's curated style schema -- the recipe must still capture+restore them.
+GLOBAL_RCPARAMS = [
+    {"axes.titleweight": "bold"},
+    {"font.weight": "bold"},
+    {"font.style": "italic"},
+    {"axes.titlecolor": "#aa0000"},
+    {"lines.linestyle": "--"},
+    {"xtick.minor.visible": True, "ytick.minor.visible": True},
+    {"xtick.direction": "in", "ytick.direction": "in"},
+    {"axes.titlesize": 20.0},
+]
+
+# A bundle standing in for a loaded theme (SCITEX_STYLE-like): several non-default
+# rcParams at once. The recipe must persist these as primitives, not a name.
+THEME_BUNDLE = {
+    "axes.titleweight": "bold",
+    "font.style": "italic",
+    "xtick.direction": "in",
+    "ytick.direction": "in",
+    "axes.titlesize": 18.0,
+}
+
+
+@pytest.mark.parametrize("rc", GLOBAL_RCPARAMS, ids=lambda r: "+".join(sorted(r)))
+def test_global_rcparam_reproduces_pixel_identical(rc, tmp_path):
+    # Arrange
+    make = _titled_line_fig
+    # Act
+    mse = _fresh_context_roundtrip_mse(make, rc, tmp_path)
+    # Assert
+    assert mse == 0.0
+
+
+def test_loaded_theme_reproduces_pixel_identical(tmp_path):
+    # Arrange
+    make = _titled_line_fig
+    # Act
+    mse = _fresh_context_roundtrip_mse(make, THEME_BUNDLE, tmp_path)
+    # Assert
+    assert mse == 0.0
+
+
+def test_imshow_under_global_rcparam_reproduces_pixel_identical(tmp_path):
+    # Arrange
+    rc = {"axes.titleweight": "bold", "font.style": "italic"}
+    # Act
+    mse = _fresh_context_roundtrip_mse(_imshow_fig, rc, tmp_path)
+    # Assert
+    assert mse == 0.0
+
+
+def test_bar_logscale_under_global_rcparam_reproduces_pixel_identical(tmp_path):
+    # Arrange
+    rc = {"axes.titleweight": "bold", "xtick.minor.visible": True}
+    # Act
+    mse = _fresh_context_roundtrip_mse(_bar_log_fig, rc, tmp_path)
+    # Assert
+    assert mse == 0.0
+
+
+def test_default_rcparams_reproduces_pixel_identical(tmp_path):
+    # Arrange
+    make = _titled_line_fig
+    # Act
+    mse = _fresh_context_roundtrip_mse(make, {}, tmp_path)
+    # Assert
+    assert mse == 0.0


### PR DESCRIPTION
## What
Make a recipe reproduce **pixel-identically in a fresh process** by capturing the full active rcParams (a loaded theme like SCITEX_STYLE, or any globally-set rcParam) and restoring them on replay. This is the general reproducibility-completeness guarantee, and it fixes NeuroVista Fig 02 **panel C** (no per-call fontsize → relied on the loaded SCITEX_STYLE → MSE 1274 despite "looking right").

## Root cause
The recipe captured only figrecipe's *curated* `style` block. Any rcParam outside it — `axes.titleweight`, `font.weight`, `font.style`, tick direction/minor-visibility, `axes.titlecolor`, `lines.linestyle`, … — was lost on replay, so a fresh-process reproduce rendered with matplotlib defaults and silently diverged.

## Fix (no band-aid)
- **Capture** (`styles/_rcparams.py`, called in the serializer): the rcParams **delta from `matplotlib.rcParamsDefault`**, serialized as **primitives** into `figure.rcparams` (theme persisted as concrete values, not a name; Cycler handled). Guarded so a reproduced figure keeps its recipe's rcParams.
- **Replay** (`_reproduce_grid` + `_build_mm_composed`): wrap figure construction in `matplotlib.rc_context()` and restore the recorded rcParams first → identical render environment. `rc_context` scopes it (reproduce never leaks rcParams). A param matplotlib rejects on restore is **warned, never silently dropped** (fail loud).
- `FigureRecord.rcparams` field + YAML round-trip; backward-compatible (legacy recipes have `rcparams=None` → no-op).

## Tests (systematic, fail-loud)
`tests/integration/test_reproducibility_completeness.py`: each test saves under ambient rcParams → **resets rcParams to matplotlib defaults** (fresh-process simulation) → reproduces → asserts **pixel-identical (MSE 0)**, returning **+inf on any size mismatch** (no silent resize/tolerance). Covers global rcParams, a SCITEX_STYLE-like theme bundle, imshow, bar+log, line.

- **12/12 pass** (was 9 failing on the leaks).
- No regression: full `_reproducer/` (74) + imshow + axis-scale green locally; the **CI SIF matrix runs the full `_integration/` sweep**.

## Still queued (NeuroVista)
fail-loud size-mismatch validator; session-path (`@stx.session`) integration tests; fr-vs-plt docs; diagram width-cap (panel A).
