### PR TITLE
fix(save): settle constrained_layout before tight-crop for deterministic reproduction (Fig02c + composite)

### DIFF
--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -248,20 +248,20 @@ def save_figure(
             ) / 4
             pad_inches = avg_margin_mm / 25.4  # mm to inches
 
-            # Pre-flight: draw figure to detect constrained_layout collapse
-            # before attempting bbox_inches="tight" save (which hangs for e.g. quiver
-            # when axes collapse to zero and draw_path loops endlessly on degenerate paths).
-            import warnings as _warnings
+            # Pre-flight: settle constrained_layout to its CONVERGED fixed point
+            # before the bbox_inches="tight" save. constrained_layout solves the
+            # axes rectangle iteratively, so a single draw leaves it part-way and
+            # the tight crop SIZE then depends on how many times the figure was
+            # drawn before saving -- making a recipe unreproducible (the original
+            # fig is drawn far more than a fresh reproduce()-d one, so their tight
+            # crops differ by a few px -> validator SIZE mismatch). Drawing to
+            # convergence makes the saved size a pure function of the content, so
+            # original and reproduced land at identical pixels. The first draw
+            # still surfaces the "collapsed to zero" warning used by the quiver
+            # fallback below (degenerate paths make tight save loop endlessly).
+            from ._save_layout import settle_constrained_layout
 
-            _collapse_detected = False
-            with _warnings.catch_warnings(record=True) as _w:
-                _warnings.simplefilter("always")
-                try:
-                    fig.fig.canvas.draw()
-                except Exception:
-                    pass
-                if any("collapsed to zero" in str(w.message) for w in _w):
-                    _collapse_detected = True
+            _collapse_detected = settle_constrained_layout(fig.fig)
 
             try:
                 if _collapse_detected:

--- a/src/figrecipe/_api/_save_layout.py
+++ b/src/figrecipe/_api/_save_layout.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Deterministic constrained-layout settling for reproducible ``bbox_inches='tight'`` saves.
+
+``constrained_layout`` solves the axes rectangle iteratively: each ``draw()``
+nudges the layout toward a fixed point but does not reach it in one pass. When a
+figure is then saved with ``bbox_inches="tight"`` (which re-measures the ink to
+crop), the saved pixel SIZE is a function of how many draws preceded the save --
+NOT of the figure's content alone.
+
+That makes a recipe unreproducible: the original ``fig`` is drawn many times over
+its build + save, while a freshly ``reproduce()``-d figure is drawn only a few
+times, so the two land on different layout iterates and their tight crops differ
+by a few pixels. The validator then sees a SIZE mismatch (different pixel
+dimensions) and reports the figure as not-reproduced, even though every artist is
+identical (NeuroVista Fig 02 panel c: bar + log y-axis + legend + 5 text()).
+
+``settle_constrained_layout`` removes that history dependence: it draws the
+figure until the axes positions stop moving (within ``tol``), so any figure --
+however many times it was drawn before -- converges to the SAME deterministic
+layout (and therefore the SAME tight-crop size) before saving. The first draw
+still surfaces a ``constrained_layout collapsed to zero`` warning so the existing
+collapse fallback in ``save_figure`` keeps working.
+"""
+
+import warnings
+from typing import Optional
+
+import numpy as np
+
+__all__ = ["settle_constrained_layout"]
+
+
+def settle_constrained_layout(
+    fig,
+    max_iter: int = 10,
+    tol: float = 1e-4,
+) -> bool:
+    """Draw ``fig`` until its constrained_layout axes positions converge.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to settle (must have ``constrained_layout`` enabled for the
+        iteration to matter; on a fixed layout it converges after one draw).
+    max_iter : int
+        Maximum number of draw passes (default 10). Layouts here settle in a few
+        passes; the cap guards against a non-converging/oscillating layout.
+    tol : float
+        Convergence tolerance on the max change of any axes' ``(x0, y0, w, h)``
+        between consecutive draws, in figure-fraction units (default 1e-4 ~=
+        0.1 px on a 1000 px canvas).
+
+    Returns
+    -------
+    bool
+        True if a ``constrained_layout collapsed to zero`` warning was emitted on
+        the FIRST draw (so ``save_figure`` can trigger its non-tight fallback);
+        False otherwise.
+
+    Notes
+    -----
+    Only the first draw is watched for the collapse warning -- that is the same
+    signal the previous single pre-flight ``draw()`` relied on, and re-checking
+    every iteration would spam identical warnings. Convergence is measured on the
+    raw matplotlib axes (``fig.axes``); a figure with no axes converges trivially.
+    """
+    prev: Optional[np.ndarray] = None
+    collapse_detected = False
+
+    for i in range(max_iter):
+        if i == 0:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                try:
+                    fig.canvas.draw()
+                except Exception:
+                    # Mirror the prior pre-flight behaviour: a draw failure is not
+                    # fatal here; the real save below raises and is handled there.
+                    return False
+                if any("collapsed to zero" in str(w.message) for w in caught):
+                    collapse_detected = True
+            if collapse_detected:
+                # Don't keep iterating a collapsed layout; let the caller fall back.
+                return True
+        else:
+            try:
+                fig.canvas.draw()
+            except Exception:
+                break
+
+        cur = np.array([ax.get_position().bounds for ax in fig.axes], dtype=float)
+        if prev is not None and cur.shape == prev.shape:
+            if cur.size == 0 or np.max(np.abs(cur - prev)) < tol:
+                break
+        prev = cur
+
+    return collapse_detected

--- a/tests/integration/test_log_scale_bar_reproduction.py
+++ b/tests/integration/test_log_scale_bar_reproduction.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save -> reproduce round-trip for a bar chart on a log y-axis with text + legend.
+
+This figure (bar x2 + ``set_yscale("log")`` + ``set_ylim`` + legend + several
+``text()`` annotations under constrained_layout) was saved with
+``bbox_inches="tight"``, which re-measures the ink to crop. constrained_layout
+solves the axes rectangle ITERATIVELY -- one draw leaves it part-way -- so the
+tight-crop SIZE depended on how many times the figure had been drawn before the
+save. The original ``fig`` is drawn many times over its build/save while a fresh
+``reproduce()``-d figure is drawn only a few, so the two landed on different
+layout iterates: their tight crops differed by a few pixels and reproducibility
+validation reported a figure-SIZE mismatch, writing a ``<stem>-not-reproduced.png``
+beside the figure (NeuroVista Fig 02 panel c, "throughput bench").
+
+The fix settles constrained_layout to its converged fixed point before the tight
+save, so the saved size is a pure function of the content and the original +
+every reproduce land at identical pixel dimensions.
+
+The log y-axis is load-bearing for this guard: it forces the iterative-layout +
+tight-crop interaction that exposed the non-determinism.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+
+import figrecipe as fr
+
+
+def _build_log_bar_figure():
+    """Build a bar + log-y figure with legend and out-of-axes text annotations."""
+    fig, ax = fr.subplots(axes_width_mm=58, axes_height_mm=42, panel_labels=False)
+    ax.set_title("Throughput", pad=20)
+    floor = 0.0667
+    x = np.array([0, 1, 2])
+    width = 0.38
+    ax.bar(
+        x - width / 2,
+        [0.62, 11.0, 140.0],
+        width=width,
+        bottom=floor,
+        label="CPU",
+    )
+    ax.bar(
+        x + width / 2,
+        [0.2, 0.9, 1.46],
+        width=width,
+        bottom=floor,
+        label="GPU",
+    )
+    ax.set_yscale("log")
+    ax.set_ylim(floor, 420.0)
+    ax.set_xticks(x)
+    ax.set_xticklabels(["small\nbatch=1", "medium\nbatch=10", "large\nbatch=127"])
+    ax.set_ylabel("Wall-clock per window (s)")
+    for xi, yv, s in zip(x, [0.93, 16.5, 210.0], ["3x", "12x", "96x"]):
+        ax.text(xi, yv, s, ha="center", va="bottom", weight="bold", fontsize=6)
+    ax.legend(loc="upper left", frameon=False)
+    ax.text(0.0, -0.34, "illustrative footnote", transform=ax.ax.transAxes, va="top")
+    return fig
+
+
+def test_log_scale_bar_reproduces_clean(tmp_path):
+    # Arrange
+    fig = _build_log_bar_figure()
+    # Act
+    fr.save(fig, str(tmp_path / "throughput.png"))  # raises if it cannot reproduce
+    # Assert
+    assert not list(tmp_path.glob("*-not-reproduced.*"))


### PR DESCRIPTION
## What
Make the tight-crop save **deterministic** under `constrained_layout`, fixing reproduction failures where the figure was pixel-correct but the saved canvas size differed.

## Root cause
`constrained_layout` solves the axes rectangle **iteratively** — a single `draw()` leaves it part-way. The save then crops with `bbox_inches="tight"`, which **re-measures the ink**, so the saved pixel size is a function of *how many times the figure was drawn before saving*. The validator saves the original `fig` (drawn many times during build+save) and a fresh `reproduce()`-d fig (drawn few times) → they land on different layout iterates → tight crops differ ~5px → `same_size=False` → MSE `nan` → a spurious `-not-reproduced.png`. Every artist was identical; only the crop boundary shifted. **NeuroVista Fig 02 panel c (throughput, MSE ~1274) and the Fig 02 composite (MSE 225)** failed this way. It is **not** a font/tick/rcParams issue — those reproduce faithfully.

| pre-draws | saved size |
|---|---|
| 0 | 1030×834 |
| 1 | 1034×815 |
| 2 | 1035×813 |
| 5+ | 1036×813 (converged) |

## Fix (no band-aid)
New `_api/_save_layout.py::settle_constrained_layout(fig)` draws until the axes positions stop moving (within tol, capped at 10 iters) **before** the tight save, replacing the single pre-flight `canvas.draw()` in `_api/_save.py`. The saved size becomes a pure function of figure content, so the original and every reproduce converge to identical pixels. The first-draw "collapsed to zero" warning (quiver fallback) is preserved. No font workarounds, no validator loosening.

## Verification
- Throughput recipe round-trips **MSE 0.0, same_size**.
- New `tests/integration/test_log_scale_bar_reproduction.py` (bar + `set_yscale('log')` + legend + out-of-axes `text`): **fails pre-fix, passes post-fix**.
- Agent ran 223 tests across save/reproduce/layout suites — zero failures; the full CI SIF matrix is the gate.

## Note
This is the *general* constrained_layout determinism fix and also resolves the size component of the Fig 1 jointplot. The jointplot has a **second, separate** bug (a `rotate_labels`-vs-`reapply_recorded_limits` ylim divergence) handled in a follow-up PR.
