### PR TITLE
fix(reproducer): reapply final rendered axis limits so later legitimate changes survive replay

### DIFF
--- a/src/figrecipe/_api/_save_helpers.py
+++ b/src/figrecipe/_api/_save_helpers.py
@@ -321,6 +321,19 @@ def _capture_axes_bboxes(fig, crop_offset: Optional[dict] = None) -> None:
             if ax_record is None:
                 continue
             ax_record.bbox = _to_cropped(mpl_ax.get_position())
+            # Capture the FINAL rendered view limits (post-render, after every
+            # call/decoration/tick-finalizer has run on the live axes) so the
+            # reproducer can re-apply the TRUE final view rather than the
+            # set_xlim/set_ylim args -- those args miss a legitimate later
+            # widening such as rotate_labels snapping the view to the outermost
+            # tick (NeuroVista Fig 01c). float() strips np.float64 for clean YAML.
+            try:
+                xlo, xhi = mpl_ax.get_xlim()
+                ylo, yhi = mpl_ax.get_ylim()
+                ax_record.final_xlim = (float(xlo), float(xhi))
+                ax_record.final_ylim = (float(ylo), float(yhi))
+            except Exception:
+                pass  # best-effort; reproducer falls back to set_*lim args
             matched_records.add(key)
 
     # Fallback for mm-based composition records (keyed "ax_mm_idx"), which are

--- a/src/figrecipe/_recorder/_core.py
+++ b/src/figrecipe/_recorder/_core.py
@@ -75,6 +75,16 @@ class AxesRecord:
     # Axes bbox [left, bottom, width, height] in the *cropped* image fraction
     # (see _capture_axes_bboxes) -- used for alignment/snap.
     bbox: Optional[List[float]] = None
+    # The FINAL rendered view limits (ax.get_xlim()/get_ylim()) captured from
+    # the live figure at SAVE time (see _capture_axes_bboxes), AFTER every call,
+    # decoration and tick finalizer has run. The reproducer re-applies THESE as
+    # the authoritative last word so the recorded view wins over autoscale
+    # (NeuroVista Ask 2) WITHOUT clobbering a legitimate later change -- e.g.
+    # rotate_labels re-runs the locator and snaps set_ylim(0, 24) out to
+    # (0, 25); the set_ylim *args* alone would wrongly revert that on replay.
+    # ``None`` on legacy recipes -> reproducer falls back to the set_*lim args.
+    final_xlim: Optional[Tuple[float, float]] = None
+    final_ylim: Optional[Tuple[float, float]] = None
     # Same, but in the *uncropped* figure fraction (mpl ax.get_position()).
     # Paired with FigureRecord.content_bbox it lets compose tile crop-aware.
     bbox_uncropped: Optional[List[float]] = None
@@ -111,6 +121,10 @@ class AxesRecord:
         }
         if self.bbox is not None:
             result["bbox"] = self.bbox
+        if self.final_xlim is not None:
+            result["final_xlim"] = list(self.final_xlim)
+        if self.final_ylim is not None:
+            result["final_ylim"] = list(self.final_ylim)
         if self.bbox_uncropped is not None:
             result["bbox_uncropped"] = self.bbox_uncropped
         if self.compose_bbox is not None:
@@ -158,12 +172,16 @@ def _axes_record_from_dict(
     ax_data: Dict[str, Any], position: Tuple[int, int]
 ) -> "AxesRecord":
     """Rebuild an AxesRecord from a serialized dict (recursive for inset sub-panels)."""
+    final_xlim = ax_data.get("final_xlim")
+    final_ylim = ax_data.get("final_ylim")
     ax_record = AxesRecord(
         position=position,
         caption=ax_data.get("caption"),
         stats=ax_data.get("stats"),
         visible=ax_data.get("visible", True),
         bbox=ax_data.get("bbox"),
+        final_xlim=tuple(final_xlim) if final_xlim is not None else None,
+        final_ylim=tuple(final_ylim) if final_ylim is not None else None,
         bbox_uncropped=ax_data.get("bbox_uncropped"),
         compose_bbox=ax_data.get("compose_bbox"),
     )

--- a/src/figrecipe/_reproducer/_reapply_limits.py
+++ b/src/figrecipe/_reproducer/_reapply_limits.py
@@ -8,11 +8,17 @@ later ``set_xscale`` decoration that autoscales, inset sub-panels, colorbars, or
 the tick/locator finalizers -- can re-engage matplotlib autoscaling and widen the
 view away from the explicitly recorded limits.
 
-To make the recorded limits authoritative, this module re-applies the LAST
-recorded ``set_xlim`` / ``set_ylim`` for each axes once everything else is done.
+To make the recorded limits authoritative, this module re-applies, once everything
+else is done, the axes' FINAL rendered view limits captured at save time
+(``AxesRecord.final_xlim`` / ``final_ylim``) when present. Those are the true
+last-rendered state, so they win over autoscale AND faithfully reproduce a
+legitimate later change -- e.g. ``rotate_labels`` re-runs the tick locator and
+snaps ``set_ylim(0, 24)`` out to ``(0, 25)``; replaying only the ``set_ylim``
+*args* would wrongly revert that. Legacy recipes (saved before final limits were
+captured) fall back to the LAST recorded ``set_xlim`` / ``set_ylim`` args, which
 "last wins" mirrors matplotlib's own behaviour when a user calls the setter more
-than once. Only axes that actually recorded an explicit limit are touched, so
-auto-scaled axes keep their auto behaviour.
+than once. Only axes that recorded a final limit (or an explicit setter) are
+touched, so auto-scaled axes keep their auto behaviour.
 """
 
 from typing import Any, List, Optional
@@ -44,25 +50,48 @@ def _last_limit_args(
 
 
 def reapply_recorded_limits(ax, ax_record, calls: Optional[List[str]] = None) -> None:
-    """Re-apply this axes' recorded set_xlim / set_ylim so they override autoscale.
+    """Re-apply this axes' recorded final view limits so they override autoscale.
+
+    Prefers the FINAL rendered limits captured at save time
+    (``final_xlim`` / ``final_ylim``) -- the true last-rendered state, which both
+    beats autoscale and reproduces a legitimate later change (e.g. rotate_labels
+    snapping the view to the outermost tick). Falls back to the LAST recorded
+    ``set_xlim`` / ``set_ylim`` args for legacy recipes that lack final limits.
 
     Parameters
     ----------
     ax :
         Target matplotlib axes (already fully replayed + finalized).
     ax_record : AxesRecord
-        The recorded axes whose limit decorations should win.
+        The recorded axes whose final limits / limit decorations should win.
     calls : list of str, optional
         If given, only re-apply limit decorations whose id is in this list
         (mirrors the same filter ``replay_axes_calls`` applies during replay).
+        Captured final limits reflect the FULL render, so they are used only when
+        no ``calls`` filter is active; a filtered replay uses the decoration args.
     """
-    xlim_args = _last_limit_args(ax_record, "set_xlim", calls)
-    if xlim_args:
-        _safe_set_lim(ax.set_xlim, xlim_args)
+    # The captured final limits describe the whole-figure render, so honor them
+    # only for an unfiltered reproduce; a partial (calls-filtered) replay must
+    # defer to the per-decoration args, which respect the same id filter.
+    use_final = calls is None
+    final_xlim = getattr(ax_record, "final_xlim", None) if use_final else None
+    final_ylim = getattr(ax_record, "final_ylim", None) if use_final else None
 
-    ylim_args = _last_limit_args(ax_record, "set_ylim", calls)
-    if ylim_args:
-        _safe_set_lim(ax.set_ylim, ylim_args)
+    xlim = (
+        list(final_xlim)
+        if final_xlim is not None
+        else _last_limit_args(ax_record, "set_xlim", calls)
+    )
+    if xlim:
+        _safe_set_lim(ax.set_xlim, xlim)
+
+    ylim = (
+        list(final_ylim)
+        if final_ylim is not None
+        else _last_limit_args(ax_record, "set_ylim", calls)
+    )
+    if ylim:
+        _safe_set_lim(ax.set_ylim, ylim)
 
 
 def _safe_set_lim(setter, args: list) -> Any:

--- a/tests/integration/test_axis_scale_and_limits_reproduction.py
+++ b/tests/integration/test_axis_scale_and_limits_reproduction.py
@@ -81,3 +81,24 @@ def test_explicit_ylim_reproduces_exactly(explicit_limits_recipe):
     plt.close("all")
     # Assert
     assert ylim == (3.0, 7.0)
+
+
+def test_later_legitimate_limit_change_survives_reproduction(tmp_path):
+    """A change replayed AFTER set_ylim (rotate_labels snapping the view to the
+    outermost tick) must reproduce -- the recorded FINAL view limit wins, not the
+    earlier set_ylim args (NeuroVista Fig 01c jointplot)."""
+    # Arrange: set_ylim(0, 24) then rotate_labels re-runs the locator and snaps
+    # the y view out to (0, 25); capture that live final ylim as the truth.
+    fig, ax = fr.subplots(style={"constrained_layout": True})
+    ax.plot(np.linspace(0, 24, 50), np.linspace(0, 24, 50))
+    ax.set_ylim(0, 24)
+    ax.rotate_labels(x=30)
+    live_ylim = ax.ax.get_ylim()
+    fr.save(fig, str(tmp_path / "rot.png"), validate=False)
+    plt.close("all")
+    # Act
+    _, rax = fr.reproduce(str(tmp_path / "rot.yaml"))
+    repro_ylim = getattr(rax, "ax", rax).get_ylim()
+    plt.close("all")
+    # Assert
+    assert repro_ylim == pytest.approx(live_ylim, abs=1e-6)


### PR DESCRIPTION
## What
Reproduce the **final rendered axis limits**, so a legitimate limit change made *after* `set_ylim` (e.g. by `rotate_labels`) survives replay.

## Root cause
`reapply_recorded_limits` re-applied the last recorded `set_xlim`/`set_ylim` **decoration args** as the final word (to beat autoscale — NeuroVista Ask 2). But `ax.rotate_labels()` calls `set_yticks(get_yticks())`, which re-runs the locator and snaps the y-view out to the outermost tick — widening `set_ylim(0,24)` → `(0,25)` on the live render. On replay, re-applying the stale `(0,24)` args reverted that widening → reproduced y-range diverged → artists remapped → reproduction failed (NeuroVista Fig 01c jointplot class).

## Fix
Record + reapply the **true final state**:
- `AxesRecord.final_xlim/final_ylim` (Optional tuples, serialized like `bbox`; `None` on legacy recipes).
- Captured in `_capture_axes_bboxes` at save time (after all calls/decorations/tick-finalizers ran on the live fig) via `ax.get_xlim()/get_ylim()`.
- `reapply_recorded_limits` prefers the recorded final limits when present (unfiltered reproduce); falls back to the last-`set_xlim`/`set_ylim` decoration args for legacy recipes and `calls`-filtered partial replays.

Still makes recorded limits beat autoscale (Ask 2) **and** reproduces `rotate_labels` / any later legitimate change.

## Verification
- New `test_later_legitimate_limit_change_survives_reproduction`: **fails pre-fix** (reproduced 24.0 vs live 25.0), **passes post-fix**.
- `_reproducer/` + axis-scale suites: **77 passed**; reproduction/matrix pixel suites: 69 passed. No regressions. CI SIF matrix is the gate.

## Context
Companion to #227 (constrained_layout settle). #227 fixes the jointplot's *size* determinism; this fixes the *limit-divergence* class. No file overlap with #227.
