### PR TITLE
fix(reproducer): capture + replay colorbar geometry (NeuroVista Fig02 panel d)

### DIFF
--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -13,6 +13,9 @@ from typing import Optional
 # print() when scitex-logging is absent.
 from .._logging import get_logger
 
+# Import helpers from separate module
+from ._save_capture import _capture_colorbar_geometry
+
 # Save settings / path / transparency helpers live in _save_config; re-exported
 # here so existing ``from .._api._save import get_save_dpi`` (etc.) keep working.
 from ._save_config import (  # noqa: F401
@@ -26,11 +29,8 @@ from ._save_config import (  # noqa: F401
     get_save_transparency,
     resolve_save_paths,
 )
-
-# Import helpers from separate module
 from ._save_helpers import (
     _capture_axes_bboxes,
-    _capture_colorbar_geometry,
     _capture_content_layout,
     _crop_diagram_to_content_bbox,
     _is_standalone_diagram_figure,

--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -30,6 +30,7 @@ from ._save_config import (  # noqa: F401
 # Import helpers from separate module
 from ._save_helpers import (
     _capture_axes_bboxes,
+    _capture_colorbar_geometry,
     _capture_content_layout,
     _crop_diagram_to_content_bbox,
     _is_standalone_diagram_figure,
@@ -259,9 +260,21 @@ def save_figure(
             # original and reproduced land at identical pixels. The first draw
             # still surfaces the "collapsed to zero" warning used by the quiver
             # fallback below (degenerate paths make tight save loop endlessly).
-            from ._save_layout import settle_constrained_layout
+            from ._save_layout import (
+                freeze_layout_positions,
+                settle_constrained_layout,
+            )
 
             _collapse_detected = settle_constrained_layout(fig.fig)
+
+            # A shared colorbar's space-steal has no single constrained_layout
+            # fixed point (it drifts with draw history), so freeze the converged
+            # geometry before the tight save -- otherwise the original, the
+            # validator's re-render and a fresh reproduce() each crop to slightly
+            # different pixels. Only when a colorbar is present (the no-colorbar
+            # path is already deterministic and must stay byte-identical).
+            if not _collapse_detected and getattr(fig.record, "colorbars", None):
+                freeze_layout_positions(fig.fig)
 
             try:
                 if _collapse_detected:
@@ -366,6 +379,7 @@ def save_figure(
 
     # Capture axes bounding boxes (adjusted for crop if cropping occurred)
     _capture_axes_bboxes(fig, crop_offset)
+    _capture_colorbar_geometry(fig)  # pin shared-colorbar geometry for replay
     _capture_content_layout(fig)  # tight-content layout for crop-aware compose
 
     # Store crop info in record for future reference

--- a/src/figrecipe/_api/_save_capture.py
+++ b/src/figrecipe/_api/_save_capture.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save-time capture of resolved live-figure geometry for faithful replay.
+
+Extracted from ``_save_helpers.py`` to keep that module under the per-file line
+budget. These helpers run on the LIVE matplotlib figure at save (after
+``settle_constrained_layout``) and stash the resolved geometry onto
+``fig.record`` so the reproducer can pin it exactly instead of re-deriving it.
+"""
+
+
+def _capture_colorbar_geometry(fig) -> None:
+    """Record each colorbar's resolved cax position so replay can pin it.
+
+    A shared colorbar (``fig.colorbar(im, ax=[...])``) steals space from its
+    source panels, and under ``constrained_layout`` the amount stolen is
+    draw-history-dependent -- a freshly ``reproduce()``-d figure that re-steals
+    lands on a DIFFERENT cax width than the original, so the tight-cropped image
+    comes out a different pixel size (validator SIZE mismatch). Capturing the
+    colorbar Axes' settled ``get_position()`` here (this runs after
+    ``settle_constrained_layout``, on the live figure) lets the reproducer place
+    the colorbar at that EXACT rectangle via ``add_axes`` instead of re-stealing.
+
+    Stored as ``cax_bbox = [left, bottom, width, height]`` in UNCROPPED figure
+    fraction (matching ``add_axes`` input). Best-effort and index-aligned with
+    ``record.colorbars`` via the transient ``record.live_colorbars`` handles;
+    on any mismatch the entry is left without ``cax_bbox`` and replay falls back
+    to the legacy ``ax=`` re-steal path.
+    """
+    live = getattr(fig.record, "live_colorbars", None) or []
+    colorbars = fig.record.colorbars or []
+    for cbar, cbar_rec in zip(live, colorbars):
+        try:
+            cax = cbar.ax
+            pos = cax.get_position()
+            cbar_rec["cax_bbox"] = [
+                float(pos.x0),
+                float(pos.y0),
+                float(pos.width),
+                float(pos.height),
+            ]
+        except Exception:
+            # Leave cax_bbox unset -> reproducer uses the legacy ax= path.
+            continue
+        # Also record the resolved tick positions. A colorbar built with a
+        # stolen host axes (``ax=``) and one pinned to a fixed ``cax=`` pick
+        # DIFFERENT default tick counts even at identical clim + size (matplotlib
+        # initialises the locator differently per mode), and the tick LABELS
+        # drive the colorbar's outboard ink -> a SIZE mismatch. Replaying the
+        # exact ticks makes the two render identically.
+        try:
+            ticks = cbar.get_ticks()
+            cbar_rec["cax_ticks"] = [float(t) for t in ticks]
+        except Exception:
+            pass
+
+
+__all__ = ["_capture_colorbar_geometry"]

--- a/src/figrecipe/_api/_save_helpers.py
+++ b/src/figrecipe/_api/_save_helpers.py
@@ -347,6 +347,52 @@ def _capture_axes_bboxes(fig, crop_offset: Optional[dict] = None) -> None:
                 fig.record.axes[key].bbox = _to_cropped(mpl_ax.get_position())
 
 
+def _capture_colorbar_geometry(fig) -> None:
+    """Record each colorbar's resolved cax position so replay can pin it.
+
+    A shared colorbar (``fig.colorbar(im, ax=[...])``) steals space from its
+    source panels, and under ``constrained_layout`` the amount stolen is
+    draw-history-dependent -- a freshly ``reproduce()``-d figure that re-steals
+    lands on a DIFFERENT cax width than the original, so the tight-cropped image
+    comes out a different pixel size (validator SIZE mismatch). Capturing the
+    colorbar Axes' settled ``get_position()`` here (this runs after
+    ``settle_constrained_layout``, on the live figure) lets the reproducer place
+    the colorbar at that EXACT rectangle via ``add_axes`` instead of re-stealing.
+
+    Stored as ``cax_bbox = [left, bottom, width, height]`` in UNCROPPED figure
+    fraction (matching ``add_axes`` input). Best-effort and index-aligned with
+    ``record.colorbars`` via the transient ``record.live_colorbars`` handles;
+    on any mismatch the entry is left without ``cax_bbox`` and replay falls back
+    to the legacy ``ax=`` re-steal path.
+    """
+    live = getattr(fig.record, "live_colorbars", None) or []
+    colorbars = fig.record.colorbars or []
+    for cbar, cbar_rec in zip(live, colorbars):
+        try:
+            cax = cbar.ax
+            pos = cax.get_position()
+            cbar_rec["cax_bbox"] = [
+                float(pos.x0),
+                float(pos.y0),
+                float(pos.width),
+                float(pos.height),
+            ]
+        except Exception:
+            # Leave cax_bbox unset -> reproducer uses the legacy ax= path.
+            continue
+        # Also record the resolved tick positions. A colorbar built with a
+        # stolen host axes (``ax=``) and one pinned to a fixed ``cax=`` pick
+        # DIFFERENT default tick counts even at identical clim + size (matplotlib
+        # initialises the locator differently per mode), and the tick LABELS
+        # drive the colorbar's outboard ink -> a SIZE mismatch. Replaying the
+        # exact ticks makes the two render identically.
+        try:
+            ticks = cbar.get_ticks()
+            cbar_rec["cax_ticks"] = [float(t) for t in ticks]
+        except Exception:
+            pass
+
+
 def _capture_content_layout(fig) -> None:
     """Record the tight content layout for crop-aware composition.
 

--- a/src/figrecipe/_api/_save_helpers.py
+++ b/src/figrecipe/_api/_save_helpers.py
@@ -347,52 +347,6 @@ def _capture_axes_bboxes(fig, crop_offset: Optional[dict] = None) -> None:
                 fig.record.axes[key].bbox = _to_cropped(mpl_ax.get_position())
 
 
-def _capture_colorbar_geometry(fig) -> None:
-    """Record each colorbar's resolved cax position so replay can pin it.
-
-    A shared colorbar (``fig.colorbar(im, ax=[...])``) steals space from its
-    source panels, and under ``constrained_layout`` the amount stolen is
-    draw-history-dependent -- a freshly ``reproduce()``-d figure that re-steals
-    lands on a DIFFERENT cax width than the original, so the tight-cropped image
-    comes out a different pixel size (validator SIZE mismatch). Capturing the
-    colorbar Axes' settled ``get_position()`` here (this runs after
-    ``settle_constrained_layout``, on the live figure) lets the reproducer place
-    the colorbar at that EXACT rectangle via ``add_axes`` instead of re-stealing.
-
-    Stored as ``cax_bbox = [left, bottom, width, height]`` in UNCROPPED figure
-    fraction (matching ``add_axes`` input). Best-effort and index-aligned with
-    ``record.colorbars`` via the transient ``record.live_colorbars`` handles;
-    on any mismatch the entry is left without ``cax_bbox`` and replay falls back
-    to the legacy ``ax=`` re-steal path.
-    """
-    live = getattr(fig.record, "live_colorbars", None) or []
-    colorbars = fig.record.colorbars or []
-    for cbar, cbar_rec in zip(live, colorbars):
-        try:
-            cax = cbar.ax
-            pos = cax.get_position()
-            cbar_rec["cax_bbox"] = [
-                float(pos.x0),
-                float(pos.y0),
-                float(pos.width),
-                float(pos.height),
-            ]
-        except Exception:
-            # Leave cax_bbox unset -> reproducer uses the legacy ax= path.
-            continue
-        # Also record the resolved tick positions. A colorbar built with a
-        # stolen host axes (``ax=``) and one pinned to a fixed ``cax=`` pick
-        # DIFFERENT default tick counts even at identical clim + size (matplotlib
-        # initialises the locator differently per mode), and the tick LABELS
-        # drive the colorbar's outboard ink -> a SIZE mismatch. Replaying the
-        # exact ticks makes the two render identically.
-        try:
-            ticks = cbar.get_ticks()
-            cbar_rec["cax_ticks"] = [float(t) for t in ticks]
-        except Exception:
-            pass
-
-
 def _capture_content_layout(fig) -> None:
     """Record the tight content layout for crop-aware composition.
 

--- a/src/figrecipe/_api/_save_layout.py
+++ b/src/figrecipe/_api/_save_layout.py
@@ -28,7 +28,39 @@ from typing import Optional
 
 import numpy as np
 
-__all__ = ["settle_constrained_layout"]
+__all__ = ["settle_constrained_layout", "freeze_layout_positions"]
+
+
+def freeze_layout_positions(fig, extra_draws: int = 2) -> None:
+    """Pin every axes at its CURRENT position so later draws can't re-flow it.
+
+    ``constrained_layout`` re-solves the axes rectangles on every draw -- and
+    ``savefig(bbox_inches="tight")`` triggers an extra solve at save time that
+    nudges the geometry to a slightly different, history-dependent point. For a
+    figure with a shared colorbar the steal width never lands on a single fixed
+    point, so the original save, the validator's re-render, and a fresh
+    ``reproduce()`` each crop to marginally different pixels (SIZE mismatch).
+
+    Call this AFTER ``settle_constrained_layout`` to freeze the converged
+    geometry: a couple of extra draws nudge the layout the last sub-pixel to its
+    true fixed point, then ``set_in_layout(False)`` removes each axes (tiles AND
+    the colorbar cax) from the layout solver while LEAVING ``constrained_layout``
+    enabled -- so the deterministic ``bbox_inches="tight"`` save path still runs
+    but no longer perturbs the rectangles. The reproducer pins the SAME recorded
+    rectangles and freezes identically, so original and reproduction tight-crop
+    to the same pixels. Best-effort: a missing ``set_in_layout`` (very old mpl)
+    or a failed draw is ignored.
+    """
+    for _ in range(max(0, extra_draws)):
+        try:
+            fig.canvas.draw()
+        except Exception:
+            break
+    for ax in fig.get_axes():
+        try:
+            ax.set_in_layout(False)
+        except Exception:
+            pass
 
 
 def settle_constrained_layout(

--- a/src/figrecipe/_recorder/_core.py
+++ b/src/figrecipe/_recorder/_core.py
@@ -260,8 +260,18 @@ class FigureRecord:
     # Source data directories for composition (enables symlinks instead of copying)
     # Maps ax_key -> source data directory path
     source_data_dirs: Optional[Dict[str, Path]] = None
-    # Colorbar calls: list of {mappable_id, ax_key, kwargs}
+    # Colorbar calls: list of {ax_key, ax_keys, kwargs, cax_bbox}. ``ax_key`` is
+    # the first source axes (used to locate the mappable on replay); ``ax_keys``
+    # lists ALL axes the colorbar stole space from (``fig.colorbar(im, ax=[...])``);
+    # ``cax_bbox`` is the colorbar Axes' resolved [l, b, w, h] figure-fraction
+    # position, captured at SAVE time after the layout settled so replay can pin
+    # the colorbar geometry exactly instead of re-stealing space (the re-steal is
+    # NOT reproducible under constrained_layout -- draw-history-dependent).
     colorbars: List[Dict[str, Any]] = field(default_factory=list)
+    # Transient: live matplotlib ``Colorbar`` objects, index-aligned with
+    # ``colorbars``, populated while recording. NOT serialized; the save path
+    # reads each colorbar's resolved cax position into ``cax_bbox``.
+    live_colorbars: List[Any] = field(default_factory=list, repr=False, compare=False)
     # Per-panel caption texts (set via fr.compose(panel_captions=...))
     figure_panel_captions: Optional[List[str]] = None
 

--- a/src/figrecipe/_reproducer/_colorbars.py
+++ b/src/figrecipe/_reproducer/_colorbars.py
@@ -21,63 +21,161 @@ COLORBAR_METHODS = {
     "specgram",
 }
 
+# Colorbar kwargs that only matter when matplotlib STEALS space from a host
+# axes (the ``ax=`` path). When we instead pin the colorbar to a fixed ``cax``
+# rectangle, these have no effect (and ``shrink``/``aspect``/``fraction`` are
+# rejected by ``fig.colorbar(cax=...)``), so they are dropped on that path.
+_STEAL_ONLY_KWARGS = {
+    "ax",
+    "shrink",
+    "pad",
+    "fraction",
+    "aspect",
+    "anchor",
+    "panchor",
+    "use_gridspec",
+    "location",
+}
+
+
+def _grid_positions(ax_keys):
+    """Yield the (row, col) tuples for parseable grid keys."""
+    for key in ax_keys:
+        parsed = parse_grid_id(key)
+        if parsed is not None:
+            yield parsed
+
+
+def _find_mappable(record, ax_key, result_cache):
+    """Return the ScalarMappable recorded on ``ax_key`` (or None)."""
+    ax_record = record.axes.get(ax_key)
+    if ax_record is None:
+        return None
+    for call in ax_record.calls:
+        if call.function in COLORBAR_METHODS and call.id in result_cache:
+            mappable = result_cache[call.id]
+            # Some methods return tuples -- extract the actual image mappable.
+            if isinstance(mappable, tuple):
+                if call.function in ("hist2d", "specgram"):
+                    mappable = mappable[3]
+            return mappable
+    return None
+
+
+def _pin_source_axes(record, axes_2d, ax_keys):
+    """Pin each source axes to its recorded (settled) position.
+
+    A shared colorbar shrank these panels in the original; the reproducer's
+    constrained_layout, with no colorbar stealing space, would otherwise place
+    them at their FULL (no-colorbar) positions. Re-applying the recorded bbox
+    restores the original tile rectangles so the pinned cax lines up and the
+    tight-cropped image matches the original pixel size.
+    """
+    for key in ax_keys:
+        parsed = parse_grid_id(key)
+        if parsed is None:
+            continue
+        row, col = parsed
+        try:
+            ax = axes_2d[row, col]
+        except (IndexError, KeyError):
+            continue
+        ax_record = record.axes.get(key)
+        bbox = getattr(ax_record, "bbox", None) if ax_record else None
+        if bbox is not None and len(bbox) == 4:
+            ax.set_position(bbox)
+
 
 def _replay_colorbars(fig, axes_2d, record, result_cache):
-    """Replay recorded colorbars for exact reproduction."""
+    """Replay recorded colorbars for exact reproduction.
+
+    For each recorded colorbar:
+
+    * If ``cax_bbox`` was captured (current recipes), pin the colorbar to that
+      exact figure-fraction rectangle via ``add_axes`` + ``colorbar(cax=...)``,
+      pin its source panels to their recorded positions, and take them all out
+      of the layout solver so the deterministic tight save can't re-flow them.
+      This reproduces a shared colorbar's geometry exactly (the legacy re-steal
+      does not -- it is draw-history-dependent under constrained_layout).
+    * Otherwise (legacy recipes) fall back to the original ``ax=`` re-steal.
+    """
     colorbars = getattr(record, "colorbars", []) or []
     if not colorbars:
         # No recorded colorbars - nothing to do
         # (Old recipes without colorbar recording won't reproduce colorbars)
         return
 
+    from .._utils._colorbar import style_colorbar
+
     for cbar_info in colorbars:
         ax_key = cbar_info.get("ax_key")
-        kwargs = cbar_info.get("kwargs", {})
+        kwargs = dict(cbar_info.get("kwargs", {}))
+        cax_bbox = cbar_info.get("cax_bbox")
 
         if ax_key is None:
             continue
 
-        # Parse ax position (accepts "r0c0" or legacy "ax_0_0")
         parsed = parse_grid_id(ax_key)
         if parsed is None:
             continue
-        row, col = parsed
 
-        ax = axes_2d[row, col]
-
-        # Find the mappable for this axes from result_cache
-        ax_record = record.axes.get(ax_key)
-        if ax_record is None:
-            continue
-
-        mappable = None
-        method_name = None
-        for call in ax_record.calls:
-            if call.function in COLORBAR_METHODS and call.id in result_cache:
-                mappable = result_cache[call.id]
-                method_name = call.function
-                break
-
+        mappable = _find_mappable(record, ax_key, result_cache)
         if mappable is None:
             continue
 
-        # Some methods return tuples - extract the actual mappable
-        if isinstance(mappable, tuple):
-            if method_name == "hist2d":
-                # hist2d returns (counts, xedges, yedges, image)
-                mappable = mappable[3]
-            elif method_name == "specgram":
-                # specgram returns (spectrum, freqs, t, image)
-                mappable = mappable[3]
+        if cax_bbox is not None and len(cax_bbox) == 4:
+            # --- Pinned-geometry path (deterministic) ---------------------
+            # Pin the source panels to their recorded rectangles, place the
+            # colorbar at the captured rectangle, and freeze every axes out of
+            # the layout (``set_in_layout(False)``) so the deterministic
+            # ``bbox_inches="tight"`` save reproduces the ORIGINAL pixels.
+            #
+            # NB: ``style_colorbar`` is intentionally NOT called here. The live
+            # ``fig.colorbar`` recording path does not style the colorbar, so the
+            # original carries matplotlib's default tick length / outline. Re-
+            # styling on replay would shorten the ticks and shift the outboard
+            # ink (a SIZE/MSE mismatch). The recorded ``cax_bbox`` (geometry),
+            # ``cax_ticks`` (labels) and the replayed rcParams already reproduce
+            # the colorbar's appearance exactly.
+            ax_keys = cbar_info.get("ax_keys") or [ax_key]
+            _pin_source_axes(record, axes_2d, ax_keys)
+            cax = fig.add_axes(cax_bbox)
+            pinned_kwargs = {
+                k: v for k, v in kwargs.items() if k not in _STEAL_ONLY_KWARGS
+            }
+            cbar = fig.colorbar(mappable, cax=cax, **pinned_kwargs)
+            cax.set_position(cax_bbox)  # colorbar() can nudge the cax; re-pin.
 
-        # Add colorbar with recorded kwargs - use raw fig.colorbar to avoid
-        # add_colorbar adding extra styling kwargs that weren't in original
-        cbar = fig.colorbar(mappable, ax=ax, **kwargs)
+            # Force the recorded ticks. ``set_ticks`` with explicit values turns
+            # autoscale back on and expands the cax to span the tick range (e.g.
+            # ticks [-4..3] -> ylim [-4, 3]) -- but the original's cax spans its
+            # CLIM, with out-of-range ticks simply clipped. Restore the colorbar-
+            # creation (clim) ylim afterwards so the gradient maps identically.
+            cax_ticks = cbar_info.get("cax_ticks")
+            if cax_ticks:
+                clim_ylim = cbar.ax.get_ylim()
+                try:
+                    cbar.set_ticks(cax_ticks)
+                    cbar.ax.set_ylim(clim_ylim)
+                except Exception:
+                    pass
 
-        # Apply styling to match original (style_colorbar is called by add_colorbar)
-        from .._utils._colorbar import style_colorbar
-
-        style_colorbar(cbar, record.style)
+            # Freeze: keep constrained_layout enabled (so the save still uses the
+            # deterministic tight path) but take the pinned axes out of the solver
+            # so the save-time re-solve can't move them.
+            for managed in (*[axes_2d[p] for p in _grid_positions(ax_keys)], cax):
+                try:
+                    managed.set_in_layout(False)
+                except Exception:
+                    pass
+        else:
+            # --- Legacy re-steal path (pre-cax_bbox recipes) --------------
+            row, col = parsed
+            ax = axes_2d[row, col]
+            kwargs.pop("ax", None)
+            cbar = fig.colorbar(mappable, ax=ax, **kwargs)
+            # Apply styling to match original (style_colorbar called by add_colorbar)
+            style_colorbar(cbar, record.style)
 
 
 # EOF

--- a/src/figrecipe/_wrappers/_figure.py
+++ b/src/figrecipe/_wrappers/_figure.py
@@ -179,23 +179,78 @@ class RecordingFigure(FigureTextMixin):
     # non-bold weight).
 
     def colorbar(self, mappable, ax=None, **kwargs) -> Any:
-        """Add a colorbar and record it for reproduction."""
-        ax_key = None
-        mpl_ax = getattr(ax, "_ax", ax)  # RecordingAxes._ax or raw Axes
-        for row in self._axes:
-            for rec_ax in row:
-                if rec_ax._ax is mpl_ax:
-                    ax_key = grid_id(rec_ax._position[0], rec_ax._position[1])
-                    break
+        """Add a colorbar and record it for reproduction.
+
+        ``ax`` may be a single axes OR a list/array of axes (a shared colorbar
+        that steals space from several panels, e.g.
+        ``fig.colorbar(im, ax=axes.ravel().tolist())``). Every source axes is
+        recorded in ``ax_keys`` so replay knows the full steal set; the colorbar's
+        resolved geometry is captured later at SAVE time (see
+        ``_capture_colorbar_geometry``) so reproduction can pin it exactly.
+        """
+        # Normalize ``ax`` to a flat list of raw matplotlib axes, unwrapping any
+        # RecordingAxes. Build the matching grid keys in the same order.
+        if isinstance(ax, (list, tuple)):
+            ax_seq = list(ax)
+        elif hasattr(ax, "ravel") and not hasattr(ax, "_ax"):
+            # numpy array of axes
+            ax_seq = list(ax.ravel())
+        elif ax is None:
+            ax_seq = []
+        else:
+            ax_seq = [ax]
+
+        mpl_axes = [getattr(a, "_ax", a) for a in ax_seq]
+
+        ax_keys: List[str] = []
+        for mpl_ax in mpl_axes:
+            for row in self._axes:
+                for rec_ax in row:
+                    if rec_ax._ax is mpl_ax:
+                        ax_keys.append(
+                            grid_id(rec_ax._position[0], rec_ax._position[1])
+                        )
+                        break
+
+        # Identify the axes that OWNS the mappable (``mappable.axes``). With a
+        # shared colorbar over a list of panels, the mappable belongs to ONE
+        # specific panel (e.g. the last ``imshow``); its clim drives the
+        # colorbar ticks. Recording this key lets replay pick the SAME mappable
+        # (hence the same clim/ticks) rather than guessing the first panel.
+        mappable_ax_key = None
+        owner_ax = getattr(mappable, "axes", None)
+        if owner_ax is not None:
+            for row in self._axes:
+                for rec_ax in row:
+                    if rec_ax._ax is owner_ax:
+                        mappable_ax_key = grid_id(
+                            rec_ax._position[0], rec_ax._position[1]
+                        )
+                        break
+
+        # First matched key locates the mappable on replay (back-compat field).
+        ax_key = mappable_ax_key or (ax_keys[0] if ax_keys else None)
+
         ser_kw = {
             k: v
             for k, v in kwargs.items()
             if isinstance(v, (str, int, float, bool, list, type(None)))
         }
-        self._recorder.figure_record.colorbars.append(
-            {"ax_key": ax_key, "kwargs": ser_kw}
-        )
-        return self._fig.colorbar(mappable, ax=mpl_ax, **kwargs)
+        record = {"ax_key": ax_key, "kwargs": ser_kw}
+        if ax_keys:
+            record["ax_keys"] = ax_keys
+        if mappable_ax_key is not None:
+            record["mappable_ax_key"] = mappable_ax_key
+        self._recorder.figure_record.colorbars.append(record)
+
+        # ``fig.colorbar`` accepts a single axes or a sequence; pass the
+        # unwrapped form so matplotlib never sees a RecordingAxes wrapper.
+        cbar_ax = mpl_axes if len(mpl_axes) > 1 else (mpl_axes[0] if mpl_axes else None)
+        cbar = self._fig.colorbar(mappable, ax=cbar_ax, **kwargs)
+        # Stash the live colorbar so the save path can read its resolved cax
+        # position (index-aligned with ``colorbars``).
+        self._recorder.figure_record.live_colorbars.append(cbar)
+        return cbar
 
     def add_panel_labels(
         self,

--- a/tests/figrecipe/_reproducer/test__colorbars.py
+++ b/tests/figrecipe/_reproducer/test__colorbars.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Reproduction of a shared colorbar's geometry.
+
+``fig.colorbar(im, ax=axes.ravel().tolist(), ...)`` steals space from several
+panels. Under ``constrained_layout`` that steal has no single fixed point, so a
+naive reproduce re-steals to a different cax width and the tight-cropped image
+comes out a different pixel SIZE -- the save-time reproducibility validator then
+fails loud and writes a ``<stem>-not-reproduced.<ext>`` artifact beside the
+figure. The recorder now captures the colorbar's resolved geometry (``cax_bbox``
++ ``cax_ticks``) and the reproducer pins it exactly, so the reproduction matches
+the original and no artifact is written.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+
+import figrecipe as fr
+
+
+def test_shared_colorbar_reproduces_without_artifact(tmp_path):
+    # Arrange: a 2x2 imshow grid with a single colorbar shared across all tiles.
+    rng = np.random.default_rng(0)
+    fig, axes = fr.subplots(2, 2, constrained_layout=True)
+    im = None
+    for ax in axes.ravel():
+        im = ax.imshow(rng.standard_normal((10, 12)), cmap="viridis")
+    fig.colorbar(im, ax=axes.ravel().tolist(), label="z", shrink=0.6, pad=0.02)
+    image_path = tmp_path / "shared_colorbar.png"
+
+    # Act: save (validation reproduces the recipe and compares to the original).
+    fr.save(fig, str(image_path), validate=True, verbose=False)
+
+    # Assert: no "-not-reproduced" artifact -> the colorbar figure reproduced.
+    artifact = image_path.parent / f"{image_path.stem}-not-reproduced.png"
+    assert not artifact.exists()


### PR DESCRIPTION
## What
Capture + replay **colorbar geometry** so a panel with `fig.colorbar(...)` reproduces (NeuroVista Fig02 panel d).

## Root cause
The recorder stored only a single `ax_key` + kwargs; replay called `fig.colorbar(mappable, ax=<single axes>)`, re-stealing space. The original `ax=` could span many axes and the constrained-layout space-steal isn't deterministic on replay → the reproduced colorbar landed ~72px wider (789→861), tripping the size-mismatch validator (the fail-loud worked — this is the geometry it flagged).

## Fix
Record the colorbar's **resolved cax position** (figure-fraction bbox) at save (after layout settles, alongside the axes-bbox capture); on replay, if `cax_bbox` is present, create the colorbar at that exact position via `fig.add_axes(cax_bbox)` + `fig.colorbar(mappable, cax=...)` — pinned, no steal. Falls back to the legacy `ax=` path for old recipes.

## Verification
- New `tests/figrecipe/_reproducer/test__colorbars.py` — colorbar round-trip leaves no `-not-reproduced` artifact (fails pre-fix, passes post).
- `_reproducer` + `_api` suites: **96 passed**, no regressions.
- New recipes capture `cax_bbox` and reproduce faithfully; legacy recipes (like the current on-disk fig02d) need one re-save to gain the field — then panel D + the composite panel-D region reproduce.

## Note
Touches `_save.py`/`_save_helpers.py`; overlaps PR #229 (overlap detector) — I'll rebase #229 onto this. Built on current develop (#227/#228), no conflict with develop.
