### PR TITLE
fix(compose): reproduce per-panel compose captions

### DIFF
--- a/src/figrecipe/_composition/_caption_render.py
+++ b/src/figrecipe/_composition/_caption_render.py
@@ -67,15 +67,30 @@ def render_compose_captions(
             pos = raw.get_position()
             x_center = pos.x0 + pos.width / 2.0
             y_top = pos.y1
+            text = f"({label}) {cap_text}"
+            text_kwargs = {"fontsize": 8, "ha": "center", "va": "bottom"}
             mpl_fig.text(
                 x_center,
                 y_top + 0.02,
-                f"({label}) {cap_text}",
+                text,
                 transform=mpl_fig.transFigure,
-                fontsize=8,
-                ha="center",
-                va="bottom",
+                **text_kwargs,
             )
+            # Record each per-panel caption as a figure-level text so it REPLAYS
+            # on reproduce. figure_texts are re-rendered via fig.text(), whose
+            # default transform is transFigure -- matching the absolute x/y
+            # captured here. Without this the panel captions rendered live but
+            # were dropped on reproduce (only the figure-level caption, which
+            # routes through add_figure_caption, round-tripped).
+            if hasattr(fig, "record"):
+                fig.record.figure_texts.append(
+                    {
+                        "x": x_center,
+                        "y": y_top + 0.02,
+                        "s": text,
+                        "kwargs": dict(text_kwargs),
+                    }
+                )
 
     # --- Figure-level caption ---
     if caption:

--- a/tests/integration/test_caption_api.py
+++ b/tests/integration/test_caption_api.py
@@ -183,3 +183,26 @@ def test_figure_record_deserializes_panel_captions_from_dict():
     record = FigureRecord.from_dict(d)
     # Assert
     assert record.figure_panel_captions == ["capt1", "capt2"]
+
+
+def test_compose_panel_captions_reproduce(tmp_path):
+    # Per-panel compose captions were rendered live via raw mpl_fig.text and
+    # dropped on reproduce (only the figure-level caption round-tripped). They
+    # are now recorded as figure_texts; this guards that a reproduced composed
+    # figure shows its per-panel caption text.
+    # Arrange
+    src_path = _save_minimal_source(str(tmp_path))
+    fig, _axes = fr.compose(
+        layout=(1, 2),
+        sources={(0, 0): src_path, (0, 1): src_path},
+        panel_captions=["Alpha caption", "Beta caption"],
+    )
+    composed = os.path.join(str(tmp_path), "composed.yaml")
+    fr.save(fig, composed, validate=False, verbose=False)
+    _plt.close(fig)
+    # Act
+    rfig, _ = fr.reproduce(composed)
+    mpl_fig = rfig.fig if hasattr(rfig, "fig") else rfig
+    repro_texts = [t.get_text() for t in mpl_fig.texts]
+    # Assert
+    assert any("Alpha caption" in t for t in repro_texts)


### PR DESCRIPTION
## What
Make **per-panel compose captions reproduce**. `fr.compose(panel_captions=[...])` rendered the "(A) …" labels via raw `mpl_fig.text` and stored them only as `record.figure_panel_captions` metadata → they showed live but were **dropped on reproduce**.

## Fix
In `render_compose_captions`, append each per-panel caption to `record.figure_texts` (absolute x/y + fontsize/ha/va) — the same mechanism `add_figure_caption` uses for the figure-level caption — so they replay via the existing `figure_texts` path. Single-figure and figure-level composed captions already round-tripped; this closes the per-panel gap.

## Test
`test_compose_panel_captions_reproduce`: compose with `panel_captions`, save, reproduce, assert the per-panel text is present. Full caption suite **16 passed**.

## Note
Isolated to `_composition/_caption_render.py` — no conflict with #229/#230.
