### PR TITLE
fix(compose): finalize imshow ticks/spines on live compose path (NeuroVista fig02 composite)

### DIFF
--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from numpy.typing import NDArray
 
-from .._recorder import FigureRecord
 from .._utils._grid import grid_id, parse_grid_id
 from .._wrappers import RecordingAxes, RecordingFigure
 from ._crop_aware import _apply_source_style, panel_rel_bbox, replay_panel_suptitle
@@ -24,6 +23,7 @@ from ._panel_labels import (
     _add_panel_labels_mm,
     _get_axes_at,
 )
+from ._replay_record import _replay_axes_record, _replay_axes_record_mm
 from ._source_parser import is_image_file as _is_image_file  # noqa: F401
 from ._source_parser import parse_source_spec_with_key as _parse_source_spec_with_key
 from ._source_parser import parse_source_spec_with_path as _parse_source_spec_with_path
@@ -451,61 +451,6 @@ def _compose_mm_based(
     render_compose_captions(fig, axes_list, caption, panel_captions)
 
     return fig, axes_list
-
-
-def _replay_axes_record_mm(
-    mpl_ax,
-    ax_record,
-    fig_record: FigureRecord,
-    idx: int,
-    spec: Dict[str, Any],
-) -> None:
-    """Replay axes record for mm-based composition."""
-    from .._reproducer._core import _replay_call
-
-    result_cache: Dict[str, Any] = {}
-
-    for call in ax_record.calls:
-        result = _replay_call(mpl_ax, call, result_cache)
-        if result is not None:
-            result_cache[call.id] = result
-
-    for call in ax_record.decorations:
-        result = _replay_call(mpl_ax, call, result_cache)
-        if result is not None:
-            result_cache[call.id] = result
-
-    ax_key = f"ax_mm_{idx}"
-    ax_record_copy = ax_record
-    ax_record_copy.mm_position = spec
-    fig_record.axes[ax_key] = ax_record_copy
-
-
-def _replay_axes_record(
-    target_ax: RecordingAxes,
-    ax_record,
-    fig_record: FigureRecord,
-    row: int,
-    col: int,
-) -> None:
-    """Replay all calls from ax_record onto target axes."""
-    from .._reproducer._core import _replay_call
-
-    mpl_ax = target_ax._ax if hasattr(target_ax, "_ax") else target_ax
-    result_cache: Dict[str, Any] = {}
-
-    for call in ax_record.calls:
-        result = _replay_call(mpl_ax, call, result_cache)
-        if result is not None:
-            result_cache[call.id] = result
-
-    for call in ax_record.decorations:
-        result = _replay_call(mpl_ax, call, result_cache)
-        if result is not None:
-            result_cache[call.id] = result
-
-    ax_key = grid_id(row, col)
-    fig_record.axes[ax_key] = ax_record
 
 
 __all__ = ["compose"]

--- a/src/figrecipe/_composition/_replay_record.py
+++ b/src/figrecipe/_composition/_replay_record.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Replay a recorded source panel onto a composed axes (grid + mm paths).
+
+Extracted from ``_compose.py`` to keep that orchestrator under the per-file
+line budget. Both helpers replay a source panel's recorded ``calls`` +
+``decorations`` onto a target matplotlib axes, register the axes record on the
+composed figure's record, then apply the SAME imshow tick/spine finalization the
+reproduce path applies -- so a LIVE composed figure and its reproduction agree
+pixel-for-pixel.
+
+Why the finalize call lives here (not only on reproduce): compose replays the
+recorded calls as raw matplotlib, bypassing the live ``ax.imshow`` wrapper
+(``_wrappers/_axes_plots.imshow_plot``) that hides imshow ticks/spines. Without
+re-applying it, a *labelled* imshow (e.g. a comodulogram with ``set_xyt``) keeps
+its auto ticks in the live composed figure but loses them on reproduce -- a
+tile-gutter pixel divergence (NeuroVista fig02 composite). ``finalize_imshow_axes``
+honours explicit ``set_xticks`` decorations, so deliberately-labelled Hz-band
+ticks survive composition both ways.
+"""
+
+from typing import Any, Dict
+
+from .._recorder import FigureRecord
+from .._utils._grid import grid_id
+from .._wrappers import RecordingAxes
+
+
+def _replay_axes_record_mm(
+    mpl_ax,
+    ax_record,
+    fig_record: FigureRecord,
+    idx: int,
+    spec: Dict[str, Any],
+) -> None:
+    """Replay axes record for mm-based composition."""
+    from .._reproducer._core import _replay_call
+
+    result_cache: Dict[str, Any] = {}
+
+    for call in ax_record.calls:
+        result = _replay_call(mpl_ax, call, result_cache)
+        if result is not None:
+            result_cache[call.id] = result
+
+    for call in ax_record.decorations:
+        result = _replay_call(mpl_ax, call, result_cache)
+        if result is not None:
+            result_cache[call.id] = result
+
+    # Match the reproduce path's imshow finalization (see module docstring).
+    from .._reproducer._replay_axes import finalize_imshow_axes
+
+    finalize_imshow_axes(mpl_ax, ax_record, fig_record.style)
+
+    ax_key = f"ax_mm_{idx}"
+    ax_record_copy = ax_record
+    ax_record_copy.mm_position = spec
+    fig_record.axes[ax_key] = ax_record_copy
+
+
+def _replay_axes_record(
+    target_ax: RecordingAxes,
+    ax_record,
+    fig_record: FigureRecord,
+    row: int,
+    col: int,
+) -> None:
+    """Replay all calls from ax_record onto target axes."""
+    from .._reproducer._core import _replay_call
+
+    mpl_ax = target_ax._ax if hasattr(target_ax, "_ax") else target_ax
+    result_cache: Dict[str, Any] = {}
+
+    for call in ax_record.calls:
+        result = _replay_call(mpl_ax, call, result_cache)
+        if result is not None:
+            result_cache[call.id] = result
+
+    for call in ax_record.decorations:
+        result = _replay_call(mpl_ax, call, result_cache)
+        if result is not None:
+            result_cache[call.id] = result
+
+    # Match the reproduce path's imshow finalization (see module docstring).
+    from .._reproducer._replay_axes import finalize_imshow_axes
+
+    finalize_imshow_axes(mpl_ax, ax_record, fig_record.style)
+
+    ax_key = grid_id(row, col)
+    fig_record.axes[ax_key] = ax_record
+
+
+__all__ = ["_replay_axes_record", "_replay_axes_record_mm"]
+
+# EOF

--- a/tests/figrecipe/_composition/test__compose_replay_fidelity.py
+++ b/tests/figrecipe/_composition/test__compose_replay_fidelity.py
@@ -109,6 +109,79 @@ def test_scatter_hist_kde_marginal_lines_present(joint_composed):
     assert has_marginal_lines
 
 
+@pytest.fixture
+def labeled_imshow_recipe(tmp_path):
+    """Save a labelled imshow source (axis labels, no explicit ticks)."""
+    fig, ax = fr.subplots()
+    ax.imshow(np.random.RandomState(0).rand(20, 20), aspect="auto", id="img")
+    ax.set_xyt("Phase frequency (Hz)", "Amplitude frequency (Hz)", "Comodulogram")
+    recipe = tmp_path / "labeled_imshow.yaml"
+    fr.save(fig, recipe, validate=False, verbose=False)
+    return recipe
+
+
+def _imshow_panel(mpl_fig):
+    """Return the composed axes that carries an image."""
+    return next(a for a in mpl_fig.get_axes() if a.get_images())
+
+
+def test_composed_labeled_imshow_suppresses_auto_ticks(labeled_imshow_recipe):
+    # A labelled imshow with no explicit ticks: the live ax.imshow wrapper hides
+    # imshow ticks at draw, but compose replays raw matplotlib (wrapper bypassed)
+    # so without finalize the composed LIVE panel kept auto ticks that reproduce
+    # then dropped -> tile-gutter pixel divergence (NeuroVista fig02 composite).
+    # After the fix the composed live panel suppresses them, matching reproduce.
+    # Arrange
+    sources = {str(labeled_imshow_recipe): {"xy_mm": (0, 0), "size_mm": (80, 80)}}
+    # Act
+    comp_fig, _ = fr.compose(sources, canvas_size_mm=(90, 90))
+    mpl = comp_fig.fig if hasattr(comp_fig, "fig") else comp_fig
+    panel = _imshow_panel(mpl)
+    # Assert
+    assert list(panel.get_xticks()) == [] and list(panel.get_yticks()) == []
+
+
+def test_composed_labeled_imshow_keeps_explicit_ticks(tmp_path):
+    # A deliberately-labelled comodulogram (explicit Hz-band set_xticks) must
+    # KEEP its ticks through composition -- finalize_imshow_axes suppresses only
+    # the axis dims the recipe did not explicitly tick.
+    # Arrange
+    fig, ax = fr.subplots()
+    ax.imshow(np.random.RandomState(0).rand(20, 20), aspect="auto", id="img")
+    ax.set_xyt("Phase (Hz)", "Amp (Hz)", "Comodulogram")
+    ax.set_xticks([2, 6, 12])
+    recipe = tmp_path / "explicit.yaml"
+    fr.save(fig, recipe, validate=False, verbose=False)
+    sources = {str(recipe): {"xy_mm": (0, 0), "size_mm": (80, 80)}}
+    # Act
+    comp_fig, _ = fr.compose(sources, canvas_size_mm=(90, 90))
+    mpl = comp_fig.fig if hasattr(comp_fig, "fig") else comp_fig
+    panel = _imshow_panel(mpl)
+    # Assert
+    assert list(panel.get_xticks()) == [2, 6, 12]
+
+
+def test_composed_labeled_imshow_live_matches_reproduce(
+    labeled_imshow_recipe, tmp_path
+):
+    # The reported bug directly: a composed labelled imshow diverged from its
+    # reproduction in the tick gutters. Guard the invariant -- the live composed
+    # panel and the reproduced one must agree on imshow tick state.
+    # Arrange
+    sources = {str(labeled_imshow_recipe): {"xy_mm": (0, 0), "size_mm": (80, 80)}}
+    comp_fig, _ = fr.compose(sources, canvas_size_mm=(90, 90))
+    live = comp_fig.fig if hasattr(comp_fig, "fig") else comp_fig
+    live_ticks = list(_imshow_panel(live).get_xticks())
+    composed_recipe = tmp_path / "composed.yaml"
+    fr.save(comp_fig, composed_recipe, validate=False, verbose=False)
+    # Act
+    rfig, _ = fr.reproduce(composed_recipe)
+    rmpl = rfig.fig if hasattr(rfig, "fig") else rfig
+    repro_ticks = list(_imshow_panel(rmpl).get_xticks())
+    # Assert
+    assert live_ticks == repro_ticks
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 


### PR DESCRIPTION
## Problem
NeuroVista's **sole remaining fig02-composite blocker**: a labelled `imshow` (comodulogram with `set_xyt`, no explicit ticks) reproduces **standalone** (MSE 0) but **diverges when composed** — MSE ~224, localized to the imshow tile's tick gutters (the raster itself is pixel-perfect).

## Root cause
A tick/spine suppression **asymmetry**:
- **Standalone live** routes `ax.imshow` through the recording wrapper → `apply_imshow_axes_visibility` suppresses ticks/spines. Standalone reproduce matches → PASS.
- **Compose live** replays recorded calls as **raw matplotlib** (wrapper bypassed); the only finalize is `finalize_special_plots`, whose `is_specgram = bool(xlabel or ylabel)` guard **keeps** ticks for a labelled axes.
- **Compose reproduce** calls `finalize_imshow_axes` (no `is_specgram` guard) → **suppresses**.

Net: live-composed kept ticks, reproduce hid them → guaranteed tile-gutter divergence.

## Fix
The live compose path now applies the **same** `finalize_imshow_axes` the reproduce path uses, so **live-composed == reproduced**. Explicit `set_xticks` decorations are honoured (deliberate Hz-band ticks survive composition).

Refactor (forced by the 512-line budget): extracted `_replay_axes_record{,_mm}` from `_compose.py` (now 456 lines) into `_composition/_replay_record.py`, where the finalize call lives.

## Tests
+3 guards in `test__compose_replay_fidelity.py` (auto-ticks suppressed; explicit ticks survive; live matches reproduce). `_composition`+`_api` (182) + `_reproducer` (74) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)