### PR TITLE
fix(save): deterministic content-bbox crop kills the reproduce-size flake (colorbar/pie/CL/composed)

### DIFF
--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -29,11 +29,10 @@ from ._save_config import (  # noqa: F401
     get_save_transparency,
     resolve_save_paths,
 )
+from ._save_crop import dispatch_crop, wants_content_crop
 from ._save_helpers import (
     _capture_axes_bboxes,
     _capture_content_layout,
-    _crop_diagram_to_content_bbox,
-    _is_standalone_diagram_figure,
 )
 from ._save_helpers import (
     save_hitmap as _save_hitmap,
@@ -208,17 +207,6 @@ def save_figure(
     is_croppable = image_path.suffix.lower() in croppable_formats
     is_svg = image_path.suffix.lower() == ".svg"
 
-    # Standalone RASTER diagrams enable constrained_layout but must NOT be saved
-    # with bbox_inches="tight": that re-measures the ink at SAVE time, and the
-    # recipe-reproduced render carries a hair more vertical ink than the original,
-    # so the tight box differs -> figure-SIZE mismatch at validate (NeuroVista
-    # Fig 02 panel b). They are instead saved full-canvas below and cropped to the
-    # RECORDED, dpi-independent content_bbox (same box for save and every
-    # reproduce). Composed diagrams, and vector diagram exports (PDF/SVG), keep
-    # the normal tight path.
-    is_diagram = _is_standalone_diagram_figure(fig)
-    use_tight = use_constrained and not (is_diagram and is_croppable)
-
     # Get crop margins from mm_layout
     mm_layout = getattr(fig, "_mm_layout", None)
     crop_margin_left_mm = 1
@@ -231,6 +219,17 @@ def save_figure(
         crop_margin_top_mm = mm_layout.get("crop_margin_top_mm", 1)
         crop_margin_bottom_mm = mm_layout.get("crop_margin_bottom_mm", 1)
 
+    # Crop strategy. ``content_bbox`` crop (saved full-canvas, then cropped to the
+    # ONE recorded, dpi-independent box) is deterministic across draw counts, so
+    # the original and every reproduce land at identical pixels -- it replaces
+    # BOTH the size-jittering ``bbox_inches="tight"`` (constrained_layout) and the
+    # content-aware ``crop()`` (composed/mm-layout). ``use_tight`` is therefore
+    # only the LEGACY constrained path used when content_bbox is unavailable; for
+    # the quiver collapse case the settle below clears both flags and we fall back
+    # to the content-aware crop. (#215 generalised from standalone diagrams.)
+    use_content_crop = wants_content_crop(is_croppable, use_constrained, mm_layout)
+    use_tight = use_constrained and not use_content_crop
+
     # Handle facecolor override - make patches opaque if needed
     restore_patches = None
     if _is_opaque_facecolor(facecolor):
@@ -239,27 +238,16 @@ def save_figure(
     pad_inches = 0.0  # updated below if use_tight
 
     try:
-        if use_tight:
-            # For constrained_layout, use bbox_inches='tight' to crop at save time
-            avg_margin_mm = (
-                crop_margin_left_mm
-                + crop_margin_right_mm
-                + crop_margin_top_mm
-                + crop_margin_bottom_mm
-            ) / 4
-            pad_inches = avg_margin_mm / 25.4  # mm to inches
-
-            # Pre-flight: settle constrained_layout to its CONVERGED fixed point
-            # before the bbox_inches="tight" save. constrained_layout solves the
-            # axes rectangle iteratively, so a single draw leaves it part-way and
-            # the tight crop SIZE then depends on how many times the figure was
-            # drawn before saving -- making a recipe unreproducible (the original
-            # fig is drawn far more than a fresh reproduce()-d one, so their tight
-            # crops differ by a few px -> validator SIZE mismatch). Drawing to
-            # convergence makes the saved size a pure function of the content, so
-            # original and reproduced land at identical pixels. The first draw
-            # still surfaces the "collapsed to zero" warning used by the quiver
-            # fallback below (degenerate paths make tight save loop endlessly).
+        if use_constrained:
+            # Settle constrained_layout to its CONVERGED fixed point before saving.
+            # constrained_layout solves the axes rectangle iteratively, so a single
+            # draw leaves it part-way and any save-time ink re-measure then depends
+            # on how many times the figure was drawn -- making a recipe
+            # unreproducible (the original fig is drawn far more than a fresh
+            # reproduce()-d one). Settling makes the geometry a pure function of the
+            # content, so original and reproduced share the SAME content_bbox. The
+            # first draw still surfaces the "collapsed to zero" warning used by the
+            # quiver fallback (degenerate paths make a tight save loop endlessly).
             from ._save_layout import (
                 freeze_layout_positions,
                 settle_constrained_layout,
@@ -267,41 +255,65 @@ def save_figure(
 
             _collapse_detected = settle_constrained_layout(fig.fig)
 
-            # A shared colorbar's space-steal has no single constrained_layout
-            # fixed point (it drifts with draw history), so freeze the converged
-            # geometry before the tight save -- otherwise the original, the
-            # validator's re-render and a fresh reproduce() each crop to slightly
-            # different pixels. Only when a colorbar is present (the no-colorbar
-            # path is already deterministic and must stay byte-identical).
+            # A shared colorbar's space-steal has no single constrained_layout fixed
+            # point (it drifts with draw history), so freeze the converged geometry
+            # -- otherwise the original, the validator's re-render and a fresh
+            # reproduce() each settle to slightly different rectangles. Only when a
+            # colorbar is present (the no-colorbar path is already deterministic).
             if not _collapse_detected and getattr(fig.record, "colorbars", None):
                 freeze_layout_positions(fig.fig)
 
-            try:
-                if _collapse_detected:
-                    raise ValueError("constrained_layout collapsed axes to zero")
-                fig.fig.savefig(
-                    image_path,
-                    dpi=dpi,
-                    transparent=transparent,
-                    bbox_inches="tight",
-                    pad_inches=pad_inches,
-                    facecolor=facecolor,
-                )
-            except (MemoryError, ValueError):
-                # constrained_layout may fail for some plot types (e.g., quiver)
-                # ValueError: image size too large on older matplotlib
-                # Fall back to standard save without bbox_inches
-                import warnings
-
-                warnings.warn(
-                    "constrained_layout save failed, falling back to standard save"
-                )
+            if _collapse_detected:
+                # Degenerate layout: never content-crop a collapsed figure; save
+                # full-canvas and fall back to the content-aware crop downstream.
+                use_content_crop = False
+                use_tight = False
                 fig.fig.savefig(
                     image_path, dpi=dpi, transparent=transparent, facecolor=facecolor
                 )
-                # Mark for cropping since we couldn't use bbox_inches="tight"
-                use_constrained = False
-                use_tight = False
+            elif use_content_crop:
+                # Save FULL-CANVAS; cropped to the recorded content_bbox below so the
+                # saved SIZE is a deterministic function of content (no tight re-
+                # measure). Replaces bbox_inches="tight" for constrained_layout.
+                fig.fig.savefig(
+                    image_path, dpi=dpi, transparent=transparent, facecolor=facecolor
+                )
+            else:
+                # LEGACY constrained path (content_bbox unavailable): crop at save
+                # time via bbox_inches="tight" (size-jittering, kept for back-compat).
+                avg_margin_mm = (
+                    crop_margin_left_mm
+                    + crop_margin_right_mm
+                    + crop_margin_top_mm
+                    + crop_margin_bottom_mm
+                ) / 4
+                pad_inches = avg_margin_mm / 25.4  # mm to inches
+                try:
+                    fig.fig.savefig(
+                        image_path,
+                        dpi=dpi,
+                        transparent=transparent,
+                        bbox_inches="tight",
+                        pad_inches=pad_inches,
+                        facecolor=facecolor,
+                    )
+                except (MemoryError, ValueError):
+                    # constrained_layout may fail for some plot types (e.g. quiver);
+                    # ValueError: image size too large on older matplotlib. Fall
+                    # back to a standard save + downstream content-aware crop.
+                    import warnings
+
+                    warnings.warn(
+                        "constrained_layout save failed, falling back to standard save"
+                    )
+                    fig.fig.savefig(
+                        image_path,
+                        dpi=dpi,
+                        transparent=transparent,
+                        facecolor=facecolor,
+                    )
+                    use_constrained = False
+                    use_tight = False
         else:
             # Standard save without bbox_inches to preserve mm layout
             fig.fig.savefig(
@@ -312,70 +324,30 @@ def save_figure(
         if restore_patches is not None:
             restore_patches()
 
-    # Auto-crop using stored crop margins from mm_layout (or explicit parameter)
-    # Raster formats: pixel-based content-aware crop (post-processing)
-    # SVG: viewBox adjustment via tightbbox query (post-processing, no bbox_inches)
-    # Skip when bbox_inches="tight" already cropped at save time (use_tight).
-    #
-    # Standalone diagrams (saved full-canvas above) crop to the RECORDED,
-    # dpi-independent content_bbox so the save and every reproduce land at
-    # identical pixel dimensions; on failure this returns None and we fall
-    # through to the normal content-aware crop (with a warning).
-    diagram_cropped = False
-    crop_offset = None
-    if is_diagram and is_croppable:
-        crop_offset = _crop_diagram_to_content_bbox(
-            fig,
-            image_path,
-            crop_margin_mm,
-            (
-                crop_margin_left_mm,
-                crop_margin_right_mm,
-                crop_margin_top_mm,
-                crop_margin_bottom_mm,
-            ),
-            dpi,
-        )
-        diagram_cropped = crop_offset is not None
-
-    if is_croppable and not use_tight and not diagram_cropped:
-        if crop_margin_mm is not None:
-            # Explicit uniform crop margin
-            from .._utils._crop import crop
-
-            _, crop_offset = crop(
-                image_path,
-                margin_mm=crop_margin_mm,
-                output_path=image_path,
-                return_offset=True,
-            )
-        elif mm_layout is not None and "crop_margin_left_mm" in mm_layout:
-            # Standard content-based cropping for mm_layout figures
-            from .._utils._crop import crop
-
-            _, crop_offset = crop(
-                image_path,
-                margin_left_mm=crop_margin_left_mm,
-                margin_right_mm=crop_margin_right_mm,
-                margin_top_mm=crop_margin_top_mm,
-                margin_bottom_mm=crop_margin_bottom_mm,
-                output_path=image_path,
-                return_offset=True,
-            )
-
-    elif is_svg and not use_tight:
-        # SVG: adjust viewBox post-save using tightbbox query (not bbox_inches='tight')
-        from .._utils._crop import crop_svg
-
-        avg_margin_mm = (
-            crop_margin_left_mm
-            + crop_margin_right_mm
-            + crop_margin_top_mm
-            + crop_margin_bottom_mm
-        ) / 4
-        if crop_margin_mm is not None:
-            avg_margin_mm = crop_margin_mm
-        crop_svg(image_path, fig.fig, margin_mm=avg_margin_mm)
+    # Post-save crop dispatch (see _save_crop):
+    #   * content_bbox crop -- saved full-canvas above, cropped to the ONE recorded
+    #     dpi-independent box so the original and every reproduce land at identical
+    #     pixels (constrained_layout + composed/mm-layout). Falls back, WITH a
+    #     UserWarning, to the legacy crop when content_bbox is underivable.
+    #   * legacy content-aware crop() for raster, or crop_svg() for SVG.
+    #   * skipped when bbox_inches="tight" already cropped at save time (use_tight).
+    crop_offset = dispatch_crop(
+        fig,
+        image_path,
+        is_croppable=is_croppable,
+        is_svg=is_svg,
+        use_tight=use_tight,
+        use_content_crop=use_content_crop,
+        crop_margin_mm=crop_margin_mm,
+        crop_margins_mm=(
+            crop_margin_left_mm,
+            crop_margin_right_mm,
+            crop_margin_top_mm,
+            crop_margin_bottom_mm,
+        ),
+        mm_layout=mm_layout,
+        dpi=dpi,
+    )
 
     # Capture axes bounding boxes (adjusted for crop if cropping occurred)
     _capture_axes_bboxes(fig, crop_offset)
@@ -390,15 +362,44 @@ def save_figure(
     if hasattr(fig, "_mm_layout") and fig._mm_layout is not None:
         fig.record.mm_layout = fig._mm_layout
 
-    # Save hitmap if requested (for GUI editor element selection)
-    # Pass bbox_inches="tight" only when the image was actually saved that way
-    # (use_tight) so the hitmap crop matches the saved image exactly (critical
-    # for pie/imshow). Standalone diagrams were saved full-canvas, so they must
-    # NOT use "tight" here (their hitmap is rendered separately regardless).
+    # Save hitmap if requested (for GUI editor element selection).
+    # The hitmap must be cropped IDENTICALLY to the saved image so pixel->element
+    # lookups line up:
+    #   * use_tight  -> render the hitmap with the same bbox_inches="tight"+pad.
+    #   * content-crop -> render full-canvas, then crop to the SAME content_bbox.
+    #   * otherwise (content-aware/no crop) -> full-canvas (matches the image).
+    # Standalone diagrams render their hitmap separately regardless.
     if save_hitmap:
         _hitmap_bbox = "tight" if use_tight else None
         _hitmap_pad = pad_inches if use_tight else 0.0
-        _save_hitmap(fig, image_path, dpi, verbose, _hitmap_bbox, _hitmap_pad)
+        _hitmap_path = _save_hitmap(
+            fig, image_path, dpi, verbose, _hitmap_bbox, _hitmap_pad
+        )
+        if (
+            use_content_crop
+            and _hitmap_path is not None
+            and getattr(fig.record, "content_bbox", None) is not None
+        ):
+            from ._save_helpers import crop_to_content_bbox
+
+            _hm_margins = (
+                {
+                    "left": crop_margin_mm,
+                    "right": crop_margin_mm,
+                    "top": crop_margin_mm,
+                    "bottom": crop_margin_mm,
+                }
+                if crop_margin_mm is not None
+                else {
+                    "left": crop_margin_left_mm,
+                    "right": crop_margin_right_mm,
+                    "top": crop_margin_top_mm,
+                    "bottom": crop_margin_bottom_mm,
+                }
+            )
+            crop_to_content_bbox(
+                _hitmap_path, fig.record.content_bbox, _hm_margins, min(dpi, 150)
+            )
     from ._separate_legend import save_separate_legends as _sl
 
     _sl(fig, image_path, dpi=dpi, save_recipe=save_recipe)

--- a/src/figrecipe/_api/_save_crop.py
+++ b/src/figrecipe/_api/_save_crop.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Deterministic post-save crop dispatch for raster figures.
+
+The save path RE-MEASURES ink at save time -- ``bbox_inches="tight"`` for
+constrained_layout figures and the content-aware pixel ``crop()`` for composed
+mm-layout figures. That re-measure jitters sub-pixel between the ORIGINAL figure
+(drawn many times during build/save) and a fresh ``reproduce()``-d one (drawn a
+few times); at a pixel-rounding boundary a 0.2 px shift flips the saved width by
+1 px, and the validator's ``size_tolerance=2`` turns a >=3 px delta into
+``mse=nan`` -> ``image SIZE mismatch`` -> ``<stem>-not-reproduced.png``
+(shared ``fig.colorbar(ax=[...])``, ``ax.pie()``, constrained_layout, composed
+mm-layout).
+
+This module generalises the standalone-diagram crop (#215): whenever a usable,
+dpi-independent ``content_bbox`` exists (recorded for every figure by
+``_capture_content_layout``, byte-identical on reproduce), the figure is saved
+FULL-CANVAS and cropped to that ONE recorded box -- so the original and every
+reproduce land at identical pixels regardless of draw count. The legacy
+``bbox_inches="tight"`` / content-aware ``crop()`` path is used ONLY when
+``content_bbox`` cannot be derived (and then with a ``UserWarning`` -- no silent
+fallback). #227 ``settle_constrained_layout`` + #230 ``cax_bbox`` pinning are
+kept upstream (they keep axes geometry matched so MSE stays low); only the final
+CROP changes here. Vector (SVG/PDF) exports never reach this dispatch.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from ._save_helpers import _crop_to_recorded_content_bbox
+
+__all__ = ["wants_content_crop", "dispatch_crop"]
+
+
+def wants_content_crop(is_croppable: bool, use_constrained: bool, mm_layout) -> bool:
+    """True when the figure should be cropped to its recorded ``content_bbox``.
+
+    Covers exactly the two raster cases whose saved SIZE is otherwise
+    re-measured at save time:
+
+    * ``use_constrained`` -- would crop via ``bbox_inches="tight"``.
+    * a composed / mm-layout figure carrying ``crop_margin_*`` -- would crop
+      content-aware.
+
+    Both are size-deterministic only when cropped to the single recorded box.
+    Figures that already crop deterministically (no constrained_layout and no
+    mm-layout crop margins) keep their existing path untouched.
+    """
+    if not is_croppable:
+        return False
+    if use_constrained:
+        return True
+    return mm_layout is not None and "crop_margin_left_mm" in mm_layout
+
+
+def dispatch_crop(
+    fig,
+    image_path: Path,
+    *,
+    is_croppable: bool,
+    is_svg: bool,
+    use_tight: bool,
+    use_content_crop: bool,
+    crop_margin_mm: Optional[float],
+    crop_margins_mm,
+    mm_layout,
+    dpi: int,
+) -> Optional[dict]:
+    """Crop the saved image and return the ``crop_offset`` (or ``None``).
+
+    Strategy, in order:
+
+    1. ``use_content_crop`` -- crop to the recorded ``content_bbox`` (the
+       deterministic path). On failure (``content_bbox`` underivable) this
+       returns ``None`` WITH a ``UserWarning`` and we fall through to (2)/(3) so
+       a missing box never silently skips cropping.
+    2. raster, not already tight-cropped -- the legacy content-aware ``crop()``
+       (explicit ``crop_margin_mm`` or per-side mm-layout margins).
+    3. SVG, not tight -- ``crop_svg`` viewBox adjustment.
+
+    ``use_tight`` figures were already cropped by ``bbox_inches="tight"`` at save
+    time, so (2) is skipped for them (unless the collapse fallback cleared it).
+    """
+    ml, mr, mt, mb = crop_margins_mm
+
+    if use_content_crop:
+        crop_offset = _crop_to_recorded_content_bbox(
+            fig, image_path, crop_margin_mm, crop_margins_mm, dpi
+        )
+        if crop_offset is not None:
+            return crop_offset
+        # content_bbox underivable: fall through to the legacy crop (warned).
+
+    if is_croppable and not use_tight:
+        from .._utils._crop import crop
+
+        if crop_margin_mm is not None:
+            _, crop_offset = crop(
+                image_path,
+                margin_mm=crop_margin_mm,
+                output_path=image_path,
+                return_offset=True,
+            )
+            return crop_offset
+        if mm_layout is not None and "crop_margin_left_mm" in mm_layout:
+            _, crop_offset = crop(
+                image_path,
+                margin_left_mm=ml,
+                margin_right_mm=mr,
+                margin_top_mm=mt,
+                margin_bottom_mm=mb,
+                output_path=image_path,
+                return_offset=True,
+            )
+            return crop_offset
+        return None
+
+    if is_svg and not use_tight:
+        from .._utils._crop import crop_svg
+
+        avg_margin_mm = (ml + mr + mt + mb) / 4
+        if crop_margin_mm is not None:
+            avg_margin_mm = crop_margin_mm
+        crop_svg(image_path, fig.fig, margin_mm=avg_margin_mm)
+
+    return None
+
+
+# EOF

--- a/src/figrecipe/_api/_save_helpers.py
+++ b/src/figrecipe/_api/_save_helpers.py
@@ -107,19 +107,27 @@ def crop_to_content_bbox(
     return crop_offset
 
 
-def _crop_diagram_to_content_bbox(
+def _crop_to_recorded_content_bbox(
     fig,
     image_path: Path,
     crop_margin_mm: Optional[float],
     crop_margins_mm,
     dpi: int,
 ) -> Optional[dict]:
-    """Crop a standalone-diagram raster to its recorded ``content_bbox``.
+    """Crop a raster to its recorded ``content_bbox`` (deterministic size).
+
+    Generalises the standalone-diagram crop (#215) to ANY croppable raster whose
+    saved SIZE is otherwise re-measured at save time -- constrained_layout figures
+    (which would crop via ``bbox_inches="tight"``) and composed/mm-layout figures
+    (which would crop content-aware). Both re-measures jitter sub-pixel between the
+    original (drawn many times) and a fresh ``reproduce()`` (drawn few), so at a
+    pixel-rounding boundary the saved width can flip by ~1px and the validator's
+    ``size_tolerance`` flips to a SIZE mismatch (colorbar/pie/CL/composed).
 
     Ensures ``fig.record.content_bbox`` exists BEFORE cropping: on the user's
     first real save it is still None, so it is computed here from the (uncropped)
     figure; on the validator's re-save of the original it is already set from the
-    first save, and on a recipe-reproduced figure it is loaded from disk. All
+    first save; and on a recipe-reproduced figure it is loaded from disk. All
     three therefore crop to the SAME dpi-independent fraction, so the saved file
     and every reproduce land at identical pixel dimensions.
 
@@ -128,7 +136,8 @@ def _crop_diagram_to_content_bbox(
 
     Returns a ``crop_offset`` dict, or ``None`` (with a warning) when no
     ``content_bbox`` is available -- the caller then falls back to the normal
-    content-aware crop so a missing bbox never silently skips cropping.
+    ``bbox_inches="tight"`` / content-aware crop so a missing bbox never silently
+    skips cropping (project rule: no silent fallback).
     """
     if getattr(fig.record, "content_bbox", None) is None:
         _capture_content_layout(fig)
@@ -138,8 +147,9 @@ def _crop_diagram_to_content_bbox(
         import warnings
 
         warnings.warn(
-            "Diagram figure has no content_bbox; falling back to content-aware "
-            "crop (the standalone diagram may reproduce at a different size).",
+            "Figure has no content_bbox; falling back to the legacy "
+            "tight/content-aware crop (this figure may reproduce at a "
+            "different pixel size under draw-count jitter).",
             UserWarning,
         )
         return None

--- a/src/figrecipe/_reproducer/_colorbars.py
+++ b/src/figrecipe/_reproducer/_colorbars.py
@@ -69,7 +69,15 @@ def _pin_source_axes(record, axes_2d, ax_keys):
     constrained_layout, with no colorbar stealing space, would otherwise place
     them at their FULL (no-colorbar) positions. Re-applying the recorded bbox
     restores the original tile rectangles so the pinned cax lines up and the
-    tight-cropped image matches the original pixel size.
+    cropped image matches the original pixel size.
+
+    Pins to ``bbox_uncropped`` (the panel's position in the UNCROPPED figure
+    fraction) when available: the figure is saved full-canvas and only then
+    cropped to ``content_bbox``, so the reproduce must place panels at their
+    full-canvas positions (``set_position`` is figure-fraction). The cropped
+    ``bbox`` is in the post-crop frame and would shift every panel. Legacy
+    recipes saved with ``bbox_inches="tight"`` have no crop offset, so their
+    ``bbox`` already equals ``bbox_uncropped`` and the fallback is exact.
     """
     for key in ax_keys:
         parsed = parse_grid_id(key)
@@ -81,7 +89,9 @@ def _pin_source_axes(record, axes_2d, ax_keys):
         except (IndexError, KeyError):
             continue
         ax_record = record.axes.get(key)
-        bbox = getattr(ax_record, "bbox", None) if ax_record else None
+        bbox = getattr(ax_record, "bbox_uncropped", None) if ax_record else None
+        if bbox is None or len(bbox) != 4:
+            bbox = getattr(ax_record, "bbox", None) if ax_record else None
         if bbox is not None and len(bbox) == 4:
             ax.set_position(bbox)
 

--- a/tests/figrecipe/_api/test__save_crop.py
+++ b/tests/figrecipe/_api/test__save_crop.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for the deterministic crop-dispatch (_api/_save_crop).
+
+Covers the gate (`wants_content_crop`) across all branches and the
+`dispatch_crop` legacy fallback paths (content-aware raster crop + SVG
+viewBox crop) that the content_bbox happy-path integration tests don't
+exercise. No mocks — dispatch runs against real saved images.
+"""
+
+import os
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as _plt  # noqa: E402
+
+import figrecipe as fr  # noqa: E402
+from figrecipe._api._save_crop import dispatch_crop, wants_content_crop  # noqa: E402
+
+
+def test_wants_content_crop_false_when_not_croppable():
+    # Arrange
+    is_croppable = False
+    # Act
+    result = wants_content_crop(
+        is_croppable=is_croppable, use_constrained=True, mm_layout=None
+    )
+    # Assert
+    assert result is False
+
+
+def test_wants_content_crop_true_for_constrained_raster():
+    # Arrange
+    is_croppable = True
+    # Act
+    result = wants_content_crop(
+        is_croppable=is_croppable, use_constrained=True, mm_layout=None
+    )
+    # Assert
+    assert result is True
+
+
+def test_wants_content_crop_true_for_mm_layout_with_margins():
+    # Arrange
+    mm_layout = {"crop_margin_left_mm": 1}
+    # Act
+    result = wants_content_crop(
+        is_croppable=True, use_constrained=False, mm_layout=mm_layout
+    )
+    # Assert
+    assert result is True
+
+
+def test_wants_content_crop_false_for_plain_unconstrained_raster():
+    # Arrange
+    mm_layout = None
+    # Act
+    result = wants_content_crop(
+        is_croppable=True, use_constrained=False, mm_layout=mm_layout
+    )
+    # Assert
+    assert result is False
+
+
+def test_dispatch_crop_svg_branch_returns_none(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots()
+    ax.plot([0, 1, 2], [0, 1, 4], id="l")
+    svg_path = Path(os.path.join(str(tmp_path), "fig.svg"))
+    fig.fig.savefig(svg_path)
+    # Act
+    offset = dispatch_crop(
+        fig,
+        svg_path,
+        is_croppable=False,
+        is_svg=True,
+        use_tight=False,
+        use_content_crop=False,
+        crop_margin_mm=None,
+        crop_margins_mm=(1, 1, 1, 1),
+        mm_layout=None,
+        dpi=100,
+    )
+    # Assert
+    assert offset is None
+    _plt.close(fig.fig)
+
+
+def test_dispatch_crop_legacy_content_aware_crop_returns_offset(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots()
+    ax.plot([0, 1, 2], [0, 1, 4], id="l")
+    png_path = Path(os.path.join(str(tmp_path), "fig.png"))
+    fig.fig.savefig(png_path)
+    # Act
+    offset = dispatch_crop(
+        fig,
+        png_path,
+        is_croppable=True,
+        is_svg=False,
+        use_tight=False,
+        use_content_crop=False,
+        crop_margin_mm=2.0,
+        crop_margins_mm=(1, 1, 1, 1),
+        mm_layout=None,
+        dpi=100,
+    )
+    # Assert
+    assert offset is not None
+    _plt.close(fig.fig)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])
+
+# EOF

--- a/tests/figrecipe/_api/test__save_deterministic_crop.py
+++ b/tests/figrecipe/_api/test__save_deterministic_crop.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Draw-count invariance of the reproduced pixel SIZE (deterministic content crop).
+
+The save path RE-MEASURES ink at save time -- ``bbox_inches="tight"`` for
+constrained_layout figures (matplotlib re-fetches ``get_tightbbox`` in
+``print_figure``) and the content-aware pixel ``crop()`` for composed mm-layout
+figures. That re-measure jitters sub-pixel between the ORIGINAL figure (drawn
+many times during build/save) and a fresh ``reproduce()``-d one (drawn a few
+times); at a pixel-rounding boundary a 0.2 px shift flips the saved width by
+1 px, and the validator's ``size_tolerance=2`` turns a >=3 px delta into an
+``image SIZE mismatch`` -> ``<stem>-not-reproduced.png`` (shared
+``fig.colorbar(ax=[...])``, ``ax.pie()``, constrained_layout, composed
+mm-layout).
+
+The fix saves these rasters FULL-CANVAS and crops to the ONE recorded,
+dpi-independent ``content_bbox`` (byte-identical on reproduce), so the saved
+SIZE is a pure function of content -- independent of how many times the figure
+was drawn. These guards inject EXTRA ``fig.canvas.draw()`` calls on the
+reproduced figure (the exact lever that exposed the flake) and assert the
+re-saved pixel size equals the original EXACTLY.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+from PIL import Image
+
+import figrecipe as fr
+
+_EXTRA_DRAWS = 5
+
+
+def _png_size(path):
+    """Return the (width, height) pixel size of a saved PNG."""
+    with Image.open(path) as img:
+        return img.size
+
+
+def _reproduced_size_after_draws(recipe_path, repro_png, n_draws):
+    """Reproduce ``recipe_path``, draw ``n_draws`` extra times, re-save, return size."""
+    import matplotlib.pyplot as plt
+
+    rfig, _ = fr.reproduce(str(recipe_path))
+    mpl_fig = rfig.fig if hasattr(rfig, "fig") else rfig
+    for _ in range(n_draws):
+        mpl_fig.canvas.draw()
+    rfig.savefig(str(repro_png), save_recipe=False, validate=False, verbose=False)
+    size = _png_size(repro_png)
+    plt.close(mpl_fig)
+    return size
+
+
+def test_pie_reproduced_size_invariant_to_draw_count(tmp_path):
+    # Arrange: a pie sets set_aspect("equal") under constrained_layout, whose
+    # tight crop re-measures ink at save time.
+    fig, ax = fr.subplots()
+    ax.pie([3, 1, 4, 1, 5], labels=list("abcde"), autopct="")
+    original_png = tmp_path / "pie.png"
+    fr.save(fig, str(original_png), validate=False, verbose=False)
+    original_size = _png_size(original_png)
+    # Act
+    reproduced_size = _reproduced_size_after_draws(
+        original_png.with_suffix(".yaml"), tmp_path / "pie_repro.png", _EXTRA_DRAWS
+    )
+    # Assert
+    assert reproduced_size == original_size
+
+
+def test_shared_colorbar_reproduced_size_invariant_to_draw_count(tmp_path):
+    # Arrange: two imshow panels sharing one colorbar created on the underlying
+    # matplotlib figure (NOT the recorded fr.colorbar wrapper, so the #230
+    # cax_bbox pinning does not apply). Under constrained_layout the steal width
+    # is draw-history-dependent, so on develop the tight-cropped reproduce drifts
+    # to a different pixel SIZE than the original (1408x636 vs 1377x648); the
+    # full-canvas content_bbox crop removes that drift.
+    data = np.arange(64).reshape(8, 8)
+    fig, axes = fr.subplots(ncols=2, constrained_layout=True)
+    im0 = axes[0].imshow(data)
+    axes[1].imshow(data.T)
+    mappable = im0.get_artist() if hasattr(im0, "get_artist") else im0
+    fig.fig.colorbar(mappable, ax=[axes[0].ax, axes[1].ax])
+    original_png = tmp_path / "shared_colorbar.png"
+    fr.save(fig, str(original_png), validate=False, verbose=False)
+    original_size = _png_size(original_png)
+    # Act
+    reproduced_size = _reproduced_size_after_draws(
+        original_png.with_suffix(".yaml"),
+        tmp_path / "shared_colorbar_repro.png",
+        _EXTRA_DRAWS,
+    )
+    # Assert
+    assert reproduced_size == original_size


### PR DESCRIPTION
## Mechanism (probe-verified root cause)

Figures intermittently fail reproduction validation with an `image SIZE mismatch` / `<stem>-not-reproduced.png` — PASS in isolation, FAIL under full-suite load. The save path RE-MEASURES ink at save time:

- `bbox_inches="tight"` for **constrained_layout** figures (matplotlib re-fetches `get_tightbbox()` in `print_figure`), and
- the content-aware pixel `crop()` for **composed mm-layout** figures.

That re-measure jitters sub-pixel between the ORIGINAL figure (drawn many times during build/save) and a fresh `reproduce()`-d one (drawn a few times). At a pixel-rounding boundary a ~0.2px shift flips the saved width by 1px, and the validator's `size_tolerance=2` turns a ≥3px delta into `mse=nan` → SIZE mismatch. #227 (settle) + #230 (cax_bbox pin) keep the AXES geometry matched (isolation passes), but the final CROP still re-measures → residual flake.

A deterministic probe witness on develop (un-recorded shared `fig.colorbar(ax=[...])` under `constrained_layout`): original `1408x636` vs reproduce `1377x648` — a 31px×12px mismatch, guaranteed `-not-reproduced.png`.

## Fix (generalize the existing diagram path #215)

Standalone diagrams already avoid this: they save FULL-CANVAS and crop to the recorded, dpi-independent `content_bbox`. KEY FACT: `FigureRecord.content_bbox` is ALREADY captured for **every** figure by `_capture_content_layout` (uncropped figure-fraction `[l,b,w,h]`, dpi-independent) and loads byte-identically on reproduce — it was simply never USED to crop non-diagram figures.

This PR generalizes that crop:

- **Whenever a usable/derivable `content_bbox` exists for a croppable raster** (constrained_layout OR composed/mm-layout), the figure is saved FULL-CANVAS and cropped to that ONE recorded box. Original-save derives + records it (settled first); reproduce-save crops to the preloaded recipe box. Both crop to the **same** box ⇒ identical pixel size, invariant to draw count.
- **Legacy fallback** (no `content_bbox`): the current `bbox_inches="tight"` / content-aware `crop()` path, emitting a `UserWarning` so the degradation is visible (project rule: no silent fallback).
- **Kept**: #227 `settle_constrained_layout` + `freeze_layout_positions`, #230 `cax_bbox` pinning, the quiver constrained-layout-collapse → content-aware fallback. **Untouched**: SVG/PDF/vector paths (raster-only crop). Per-side `crop_margin_mm` / `mm_layout` margins honored exactly as the diagram path.
- Crop dispatch extracted to a new thin `src/figrecipe/_api/_save_crop.py` to keep `_save.py` ≤512 lines.

### Shared-colorbar reproduce fix (required by the new full-canvas save)

Under the new full-canvas save, the reproducer's `_pin_source_axes` pinned colorbar tile panels to the **cropped** `bbox` (post-crop frame), shifting every panel on the full-canvas reproduce (MSE ~2200, same size). Fixed by pinning to `bbox_uncropped` (the full-canvas position) when available. Legacy tight-saved recipes have no crop offset, so their `bbox` already equals `bbox_uncropped` and the fallback is exact. Result: shared colorbar reproduces at **MSE 0.0, same size**.

## Saved-size value change

Croppable rasters that previously cropped via tight / content-aware now crop to `content_bbox`, so the saved pixel size shifts ~1px (e.g. plain panel `825x648 → 826x649`, pie `648x648 → 648x649`, the throughput colorbar `1408x636 → 1409x636`). The size is now a pure function of content and **identical between original and every reproduce**.

**No golden-size test updated**: a sweep (`rg` for `.size == (...)`, `.width == NNN`, `.height == NNN`, `shape[0/1] == NNN`) found **zero** hard-coded pixel-dimension literals. All size assertions are tolerant bounds (`img.width < 1000`), original-vs-reproduce equality (`img1.size == img2.size`), or DPI ratios — all stay green.

## Probe results (draws ∈ {0,3,5,7})

| case | develop original vs reproduce | this PR |
|---|---|---|
| shared colorbar (un-recorded) | `1408x636` vs `1377x648` ✗ | `1409x636` == `1409x636` ✓ |
| pie | `648x648` (stable in isolation) | `648x649` invariant ✓ |
| composed mm-layout | `1070x437` (stable in isolation) | `1108x484` invariant ✓ |

## Tests

- New guard `tests/figrecipe/_api/test__save_deterministic_crop.py` (draw-count invariance, pie + shared colorbar). The colorbar guard FAILS on develop and passes here.
- Green: `tests/figrecipe/_api/` + `tests/figrecipe/_reproducer/` (96), `test_all_plotters_composition_roundtrip.py` (48 incl. `[pie]`), `test_log_scale_bar_reproduction.py`, `test_diagram_standalone_reproduction.py`, `test__colorbars.py` (MSE 0), imshow/axis/embed/inset/add_patch/completeness/matrix reproduction (45), serializer (251), hitmap editor+utils (225+2xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)