### PR TITLE
fix(reproducer): record + replay final spine visibility (NeuroVista Fig03b cliff-delta grid)

### DIFF
--- a/src/figrecipe/_api/_save_helpers.py
+++ b/src/figrecipe/_api/_save_helpers.py
@@ -344,6 +344,20 @@ def _capture_axes_bboxes(fig, crop_offset: Optional[dict] = None) -> None:
                 ax_record.final_ylim = (float(ylo), float(yhi))
             except Exception:
                 pass  # best-effort; reproducer falls back to set_*lim args
+            # Capture the FINAL rendered spine visibility (post-render) so the
+            # reproducer reproduces whatever the user did to the spines -- raw
+            # ax.spines[s].set_visible(...), ax.hide_spines(), or a style. The
+            # style pass on replay only hides top+right, so a script that hides
+            # ALL spines (NeuroVista Fig03b) otherwise keeps a spurious
+            # left+bottom L-spine on replay (MSE 117). bool() strips numpy types.
+            try:
+                ax_record.final_spines = {
+                    side: bool(mpl_ax.spines[side].get_visible())
+                    for side in ("top", "right", "left", "bottom")
+                    if side in mpl_ax.spines
+                }
+            except Exception:
+                pass  # best-effort; reproducer leaves the style default alone
             matched_records.add(key)
 
     # Fallback for mm-based composition records (keyed "ax_mm_idx"), which are

--- a/src/figrecipe/_recorder/_core.py
+++ b/src/figrecipe/_recorder/_core.py
@@ -85,6 +85,16 @@ class AxesRecord:
     # ``None`` on legacy recipes -> reproducer falls back to the set_*lim args.
     final_xlim: Optional[Tuple[float, float]] = None
     final_ylim: Optional[Tuple[float, float]] = None
+    # The FINAL rendered spine visibility per side ({"top","right","left",
+    # "bottom"} -> bool), captured from the live axes at SAVE time (see
+    # _capture_axes_bboxes) AFTER every call/decoration/style pass has run.
+    # The reproducer re-applies it LAST so whatever the user did to the spines
+    # -- raw ``ax.spines[s].set_visible(...)``, ``ax.hide_spines()`` or a style
+    # behaviour -- is reproduced faithfully. Without it, a script that hides ALL
+    # spines (NeuroVista Fig03b grid) loses left+bottom on replay because the
+    # style only hides top+right, leaving a spurious L-shaped spine (MSE 117).
+    # ``None`` on legacy recipes -> reproducer leaves the style default alone.
+    final_spines: Optional[Dict[str, bool]] = None
     # Same, but in the *uncropped* figure fraction (mpl ax.get_position()).
     # Paired with FigureRecord.content_bbox it lets compose tile crop-aware.
     bbox_uncropped: Optional[List[float]] = None
@@ -125,6 +135,8 @@ class AxesRecord:
             result["final_xlim"] = list(self.final_xlim)
         if self.final_ylim is not None:
             result["final_ylim"] = list(self.final_ylim)
+        if self.final_spines is not None:
+            result["final_spines"] = dict(self.final_spines)
         if self.bbox_uncropped is not None:
             result["bbox_uncropped"] = self.bbox_uncropped
         if self.compose_bbox is not None:
@@ -182,6 +194,7 @@ def _axes_record_from_dict(
         bbox=ax_data.get("bbox"),
         final_xlim=tuple(final_xlim) if final_xlim is not None else None,
         final_ylim=tuple(final_ylim) if final_ylim is not None else None,
+        final_spines=ax_data.get("final_spines"),
         bbox_uncropped=ax_data.get("bbox_uncropped"),
         compose_bbox=ax_data.get("compose_bbox"),
     )

--- a/src/figrecipe/_reproducer/_finalize_axes.py
+++ b/src/figrecipe/_reproducer/_finalize_axes.py
@@ -75,5 +75,23 @@ def finalize_reproduced_axes(
             row, col = parsed if parsed else (0, 0)
             reapply_recorded_limits(axes_2d[row, col], ax_record, calls)
 
+    # Re-apply the recorded FINAL spine visibility LAST. apply_style_mm (run
+    # pre-replay) only hides top+right per the style behaviour, so a script that
+    # hid ALL spines would otherwise keep a spurious left+bottom L-spine on
+    # replay (NeuroVista Fig03b, MSE 117). final_spines is captured post-render
+    # from the live axes, so this faithfully reproduces whatever the user did --
+    # raw set_visible, ax.hide_spines(), or the style. ``None`` (legacy recipes)
+    # -> leave the style default untouched.
+    for ax_key, ax_record in record.axes.items():
+        spines = getattr(ax_record, "final_spines", None)
+        if not spines:
+            continue
+        parsed = parse_grid_id(ax_key)
+        row, col = parsed if parsed else (0, 0)
+        ax = axes_2d[row, col]
+        for side, visible in spines.items():
+            if side in ax.spines:
+                ax.spines[side].set_visible(visible)
+
 
 __all__ = ["finalize_reproduced_axes"]

--- a/tests/figrecipe/_reproducer/test__spine_visibility.py
+++ b/tests/figrecipe/_reproducer/test__spine_visibility.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save -> reproduce round-trip for hidden axes spines (figrecipe).
+
+A script that hides ALL four spines (e.g. the NeuroVista Fig03b 4x4 Cliff's
+delta grid: colored Rectangle cells + cell text + a thick-edged "pool" outline,
+all spines off) used to fail save-time reproducibility with MSE ~117: the recipe
+never recorded spine visibility, so the style pass on replay only hid top+right
+and a spurious left+bottom L-shaped spine survived.
+
+The fix captures the FINAL rendered spine visibility per axes at save time
+(``AxesRecord.final_spines``) and the reproducer re-applies it last. These tests
+guard that the visibility round-trips and that the grid reproduces clean.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import pytest
+import yaml
+
+import figrecipe as fr
+
+
+def _grid_with_hidden_spines(ax):
+    """A 2x2 colored-Rectangle grid + cell text + a thick "pool" outline, with
+    every spine hidden -- a minimal stand-in for the Fig03b construct."""
+    ax.set_xlim(-0.6, 1.6)
+    ax.set_ylim(-0.6, 1.6)
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xticks([])
+    ax.set_yticks([])
+    fills = ["#a69695", "#bb847e", "#8f9aa1", "#7f95a3"]
+    for idx, (row, col) in enumerate([(0, 0), (0, 1), (1, 0), (1, 1)]):
+        ax.add_patch(
+            mpatches.Rectangle(
+                (col - 0.5, (1 - row) - 0.5),
+                1.0,
+                1.0,
+                facecolor=fills[idx],
+                edgecolor="#9e9e9e",
+                linewidth=0.6,
+            )
+        )
+        ax.text(col, 1 - row, f"{idx + 1}\n+0.10", ha="center", va="center", fontsize=6)
+    # Thick-edged "pool" outline on one cell (facecolor none).
+    ax.add_patch(
+        mpatches.Rectangle(
+            (-0.5, 0.5), 1.0, 1.0, facecolor="none", edgecolor="#ff4632", linewidth=2.0
+        )
+    )
+    for spine in ("top", "right", "left", "bottom"):
+        ax.ax.spines[spine].set_visible(False)
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def hidden_spine_grid(tmp_path):
+    fig, ax = fr.subplots(axes_width_mm=40, axes_height_mm=40)
+    _grid_with_hidden_spines(ax)
+    recipe_path = tmp_path / "grid.png"
+    fr.save(fig, str(recipe_path), validate=True, validate_error_level="warning")
+    yaml_path = str(recipe_path).replace(".png", ".yaml")
+    return {"dir": tmp_path, "yaml": yaml_path}
+
+
+def _final_spines(yaml_path):
+    with open(yaml_path) as fh:
+        data = yaml.safe_load(fh)
+    for ax_entry in data.get("axes", {}).values():
+        if "final_spines" in ax_entry:
+            return ax_entry["final_spines"]
+    return None
+
+
+def test_final_spines_recorded(hidden_spine_grid):
+    # Arrange
+    spines = _final_spines(hidden_spine_grid["yaml"])
+    # Act
+    all_hidden = spines is not None and not any(spines.values())
+    # Assert
+    assert all_hidden
+
+
+def test_left_spine_hidden_on_replay(hidden_spine_grid):
+    # Arrange
+    _, rax = fr.reproduce(hidden_spine_grid["yaml"])
+    # Act
+    left_visible = getattr(rax, "ax", rax).spines["left"].get_visible()
+    # Assert
+    assert left_visible is False
+
+
+def test_bottom_spine_hidden_on_replay(hidden_spine_grid):
+    # Arrange
+    _, rax = fr.reproduce(hidden_spine_grid["yaml"])
+    # Act
+    bottom_visible = getattr(rax, "ax", rax).spines["bottom"].get_visible()
+    # Assert
+    assert bottom_visible is False
+
+
+def test_hidden_spine_grid_reproduces_clean(hidden_spine_grid):
+    # Arrange
+    artifacts = list(hidden_spine_grid["dir"].glob("*-not-reproduced.*"))
+    # Act
+    leftover = len(artifacts)
+    # Assert
+    assert leftover == 0
+
+
+def test_hidden_spine_grid_validates_under_threshold(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots(axes_width_mm=40, axes_height_mm=40)
+    _grid_with_hidden_spines(ax)
+    # Act
+    _, _, result = fr.save(
+        fig, str(tmp_path / "grid2.png"), validate=True, validate_error_level="warning"
+    )
+    # Assert
+    assert result.valid


### PR DESCRIPTION
## Problem

The NeuroVista 4x4 Cliff's δ grid (`fig03b_pat10_4x4_cliff_delta`) failed save-time reproducibility:

```
same image size but pixels differ: MSE 116.98 (threshold 100);
0.5% of pixels changed, rows 17%-87% x cols 22%-78%
```

SAME image size, a small **localized** divergence — a content replay gap.

## Root cause (RECORD/REPLAY gap — NOT the imshow-tick class)

Reproduced exactly (MSE 116.98) by diffing a faithful live build of the figure against `reproduce()`. The diff heatmap isolates the divergence to an **L-shaped left+bottom spine** — grid fills, cell text and the thick "pool" outline reproduce byte-identically.

The source script hides **all four** spines (`ax.spines[s].set_visible(False)`). But:
- The recorder never captures spine visibility (no spine call in the recipe).
- On replay, `apply_style_mm` only hides **top+right** per the style behaviour, leaving **left+bottom visible** → a spurious L-spine the original had hidden.

Verified: forcing the reproduced figure's spines to match the original drops MSE **116.98 → 0.0** (byte-identical).

## Fix (path-independent; mirrors the `final_xlim`/`final_ylim` precedent)

- `AxesRecord.final_spines`: per-side rendered visibility; serialized in `to_dict` / restored in `_axes_record_from_dict`.
- `_capture_axes_bboxes` captures `ax.spines[side].get_visible()` at **save time, post-render** — so it reflects whatever the user did (raw `set_visible`, `ax.hide_spines()`, or the style).
- `finalize_reproduced_axes` re-applies `final_spines` **last**, after the style pass.

Legacy recipes (no `final_spines`) are untouched — the reproducer leaves the style default alone (no silent change). On a fig03b recipe with the field recorded, **MSE 116.98 → 0.0**.

## Test

`tests/figrecipe/_reproducer/test__spine_visibility.py` — minimal grid (colored Rectangles + cell text + thick pool patch, all spines hidden), saved with `validate=True`. Asserts: all-hidden recorded, left+bottom hidden on replay, no `-not-reproduced.png`, `result.valid`. **Fails on unpatched develop, passes with the fix.**

## Verification

- New guard: 5 passed.
- `tests/figrecipe/_reproducer/` (79), `tests/figrecipe/_recorder/` + spine tests (91), integration `add_patch`/`imshow_tick`/`log_scale_bar` (11), `reproducibility_completeness` + `axis_scale_and_limits` + `_wrappers/test__axes.py` (53) — all green.
- Normal default-style plots still record `final_spines` matching the default and reproduce MSE 0.0 (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)