### PR TITLE
fix(recorder): record ax.vlines/ax.hlines so reproduce replays them

### DIFF
--- a/src/figrecipe/_dev/demo_plotters/line_curve/plot_hlines.py
+++ b/src/figrecipe/_dev/demo_plotters/line_curve/plot_hlines.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""hlines: horizontal lines at y positions demo."""
+
+import numpy as np
+
+from figrecipe.styles import load_style
+
+
+def plot_hlines(plt, rng, ax=None):
+    """Horizontal-lines demo with multiple colored groups.
+
+    Demonstrates: ax.hlines() with SCITEX color palette (each group of
+    y-positions drawn from x=0 to x=1 in its own color).
+    """
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = ax.get_figure() if hasattr(ax, "get_figure") else ax.fig
+
+    # Get SCITEX color palette
+    style = load_style()
+    palette = style.get("colors", {}).get("palette", [])
+    colors = [tuple(v / 255.0 for v in c) for c in palette[:3]]
+
+    groups = [("A", 0.0), ("B", 10.0), ("C", 20.0)]
+    for (label, offset), color in zip(groups, colors):
+        ys = np.sort(rng.uniform(0, 10, 8)) + offset
+        ax.hlines(ys, 0.0, 1.0, colors=color, linewidth=1.2, id=f"hlines_{label}")
+
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_title("hlines")
+    ax.set_xlim(-0.1, 1.2)
+    ax.set_ylim(0, 30)
+    return fig, ax
+
+
+# EOF

--- a/src/figrecipe/_dev/demo_plotters/line_curve/plot_vlines.py
+++ b/src/figrecipe/_dev/demo_plotters/line_curve/plot_vlines.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""vlines: vertical lines at x positions demo."""
+
+import numpy as np
+
+from figrecipe.styles import load_style
+
+
+def plot_vlines(plt, rng, ax=None):
+    """Vertical-lines demo with multiple colored groups.
+
+    Demonstrates: ax.vlines() with SCITEX color palette (each group of
+    event x-positions drawn from y=0 to y=1 in its own color).
+    """
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = ax.get_figure() if hasattr(ax, "get_figure") else ax.fig
+
+    # Get SCITEX color palette
+    style = load_style()
+    palette = style.get("colors", {}).get("palette", [])
+    colors = [tuple(v / 255.0 for v in c) for c in palette[:3]]
+
+    groups = [("A", 0.0), ("B", 10.0), ("C", 20.0)]
+    for (label, offset), color in zip(groups, colors):
+        xs = np.sort(rng.uniform(0, 10, 8)) + offset
+        ax.vlines(xs, 0.0, 1.0, colors=color, linewidth=1.2, id=f"vlines_{label}")
+
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_title("vlines")
+    ax.set_xlim(0, 30)
+    ax.set_ylim(-0.1, 1.2)
+    return fig, ax
+
+
+# EOF

--- a/src/figrecipe/_params/_PLOTTING_METHODS.py
+++ b/src/figrecipe/_params/_PLOTTING_METHODS.py
@@ -38,6 +38,14 @@ PLOTTING_METHODS = {
     "tricontourf",
     "eventplot",
     "stairs",
+    # vlines/hlines draw data-coordinate line collections from arrays (a
+    # plotting primitive, unlike the single full-span axvline/axhline
+    # reference lines, which are decorations). Recorded so reproduce()
+    # replays them -- omitting them dropped every ax.vlines tick on replay
+    # (NeuroVista Fig05a schematic: panels rendered empty, large same-size
+    # MSE because the whole tick field vanished).
+    "vlines",
+    "hlines",
     "ecdf",
     "matshow",
     "spy",

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_hlines.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_hlines.py
@@ -1,0 +1,16 @@
+"""Smoke import mirror for figrecipe._dev.demo_plotters.line_curve.plot_hlines.
+
+Auto-generated subpackage mirror placeholder; replace with real tests
+as the module matures. Satisfies the src<->tests mirror audit rule.
+"""
+
+import pytest
+
+
+def test_import__dev_demo_plotters_line_curve_plot_hlines_module():
+    # Arrange
+    # Act
+    module_path = "figrecipe._dev.demo_plotters.line_curve.plot_hlines"
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_vlines.py
+++ b/tests/figrecipe/_dev/demo_plotters/line_curve/test_plot_vlines.py
@@ -1,0 +1,16 @@
+"""Smoke import mirror for figrecipe._dev.demo_plotters.line_curve.plot_vlines.
+
+Auto-generated subpackage mirror placeholder; replace with real tests
+as the module matures. Satisfies the src<->tests mirror audit rule.
+"""
+
+import pytest
+
+
+def test_import__dev_demo_plotters_line_curve_plot_vlines_module():
+    # Arrange
+    # Act
+    module_path = "figrecipe._dev.demo_plotters.line_curve.plot_vlines"
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path

--- a/tests/figrecipe/_reproducer/test__core.py
+++ b/tests/figrecipe/_reproducer/test__core.py
@@ -237,6 +237,13 @@ class TestPixelPerfect:
         success, msg = run_pixel_perfect_test("hist2d")
         assert success, f"hist2d: {msg}"
 
+    def test_hlines_pixel_perfect(self):
+        # Arrange
+        # Act
+        # Assert
+        success, msg = run_pixel_perfect_test("hlines")
+        assert success, f"hlines: {msg}"
+
     def test_imshow_pixel_perfect(self):
         # Arrange
         # Act
@@ -418,6 +425,13 @@ class TestPixelPerfect:
         # Assert
         success, msg = run_pixel_perfect_test("violinplot")
         assert success, f"violinplot: {msg}"
+
+    def test_vlines_pixel_perfect(self):
+        # Arrange
+        # Act
+        # Assert
+        success, msg = run_pixel_perfect_test("vlines")
+        assert success, f"vlines: {msg}"
 
     def test_xcorr_pixel_perfect(self):
         # Arrange

--- a/tests/integration/test_vlines_schematic_reproduction.py
+++ b/tests/integration/test_vlines_schematic_reproduction.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save -> reproduce round-trip for an ax.vlines() schematic (figrecipe).
+
+``ax.vlines`` / ``ax.hlines`` draw data-coordinate line collections from arrays
+(a plotting primitive), but they were absent from ``PLOTTING_METHODS``, so the
+recording wrapper never intercepted them: the lines drew on the live figure yet
+were NEVER written to the recipe (``calls: []``). On reproduce the whole tick
+field vanished, leaving the panel empty and a large *same-size* pixel MSE
+(NeuroVista Fig 05a Design-A-vs-B schematic: panels rendered blank).
+
+These guards build a minimal 2-panel schematic with the exact primitives the
+real figure uses -- ``vlines`` event ticks, ``axvspan`` train/test blocks,
+``axvline`` cutoffs, and colored ``text`` labels -- and assert the recipe both
+records the ``vlines`` and reproduces clean (no ``*-not-reproduced`` artefact).
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import numpy as np
+
+import figrecipe as fr
+
+
+def _build_schematic():
+    """Two-panel schematic: vlines ticks + spans + cutoffs + colored text."""
+    fig, axes = fr.subplots(nrows=2, ncols=1, axes_width_mm=80, axes_height_mm=20)
+
+    event_days = np.sort(np.random.default_rng(0).uniform(10.0, 290.0, size=40))
+    train_color = "#1F77B4"
+    test_color = "#FF4632"
+
+    ax_a = axes[0]
+    ax_a.set_title("Design A -- time-mixed 5-fold CV", loc="left")
+    for i, day in enumerate(event_days):
+        ax_a.vlines(day, 0.0, 1.0, colors=train_color if i % 2 else test_color)
+    ax_a.set_xlim(0, 300)
+    ax_a.set_ylim(-0.1, 1.2)
+    ax_a.set_yticks([])
+
+    ax_b = axes[1]
+    ax_b.set_title("Design B -- Karoly prospective", loc="left")
+    ax_b.axvspan(100, 200, facecolor=train_color, alpha=0.18)
+    ax_b.axvspan(200, 300, facecolor=test_color, alpha=0.18)
+    ax_b.axvline(100, color="black", linestyle="--", linewidth=0.7)
+    ax_b.axvline(200, color="black", linestyle="--", linewidth=0.7)
+    for day in event_days:
+        color = train_color if day < 200 else test_color
+        ax_b.vlines(day, 0.0, 1.0, colors=color)
+    ax_b.text(150, 1.06, "train", ha="center", va="bottom", color=train_color)
+    ax_b.text(250, 1.06, "test", ha="center", va="bottom", color=test_color)
+    ax_b.set_xlim(0, 300)
+    ax_b.set_ylim(-0.1, 1.2)
+    ax_b.set_yticks([])
+    return fig
+
+
+def test_vlines_are_recorded_in_recipe(tmp_path):
+    # Arrange
+    fig = _build_schematic()
+    # Act
+    _img, yaml_path, _result = fr.save(fig, str(tmp_path / "schematic.png"))
+    recorded = [c["function"] for c in fr.info(yaml_path)["calls"]]
+    # Assert
+    assert recorded.count("vlines") == 80
+
+
+def test_vlines_schematic_reproduces_without_divergence(tmp_path):
+    # Arrange
+    fig = _build_schematic()
+    # Act
+    fr.save(fig, str(tmp_path / "schematic.png"))
+    # Assert
+    assert not list(tmp_path.glob("*-not-reproduced.*"))


### PR DESCRIPTION
## Problem

A NeuroVista 2-panel **schematic** figure (Fig05a "Design A vs B") failed reproduction validation with a same-size pixel divergence (`MSE 1614, ~10% of canvas changed`). Same size → a **content replay gap**, not a crop-size issue. Panel A rendered **empty of body content**.

## Root cause — RECORD-side gap (definitive)

`ax.vlines` / `ax.hlines` draw data-coordinate line collections from arrays (a plotting primitive), but they were **missing from `PLOTTING_METHODS`** (`src/figrecipe/_params/_PLOTTING_METHODS.py`). The recording wrapper gates interception on set membership:

```
# _wrappers/_axes.py:105
if callable(attr) and name in (PLOTTING_METHODS | DECORATION_METHODS):
    return self._create_recording_wrapper(name, attr)
return attr   # <- vlines/hlines fell through to RAW matplotlib
```

So `ax.vlines(...)` drew on the live figure but was **never written to the recipe** (`calls: []` for both panels). On reproduce the entire 40-tick field vanished → empty panel → large same-size MSE.

Confirmed by inspecting the recipe (`calls: []` despite 40 `vlines` calls in the source) and by a from-scratch repro (same MSE/pixel-fraction signature). The `axvspan`/`axvline`/`text` in the figure WERE present in the recipe — they are in `DECORATION_METHODS` — which is why only the `vlines` content was lost.

## Fix

Add `vlines`/`hlines` to `PLOTTING_METHODS`. They are standard mpl axes methods with simple signatures, so the **generic** record path (`record_call_with_color_capture`) and **generic** replay path (`_reproducer/_core._replay_call` → `getattr(ax, name)`) handle them with no special-casing — no band-aid. Colors/linewidth/clip_on round-trip faithfully.

## Verification

- New **pixel-perfect** round-trip tests for both: `test_vlines_pixel_perfect`, `test_hlines_pixel_perfect` — both reproduce **byte-identical (diff == 0)**.
- New integration guard `test_vlines_schematic_reproduction.py`: a 2-panel `vlines` + `axvspan` + `axvline` + colored-`text` schematic **records the vlines** and **reproduces with no `-not-reproduced` artifact**. Verified it **fails pre-fix** (MSE ~2950, same whole-area signature) and **passes post-fix**.
- `PLOTTING_METHODS` carries a completeness guardrail (`test_every_recorded_plot_type_has_a_builder`) requiring every recorded plot type to ship a demo builder — added `plot_vlines.py` / `plot_hlines.py` (+ src↔tests mirror tests) to satisfy it.
- Targeted suites green: `tests/figrecipe/_reproducer/` (76 passed), `tests/figrecipe/_wrappers/`, `tests/integration/*reproduction*` (27 passed), `tests/figrecipe/_params/`, `tests/figrecipe/_dev/` (75 passed).

## Known residual (separate, pre-existing — NOT addressed here)

After this fix the **real** Fig05a recipe drops from **MSE 1614 (10.2%) → MSE 806 (4.7%)** and the panels are correctly populated, but it does **not yet pass < 100**. The remaining divergence is an **independent constrained-layout settling issue**: reproduce re-solves `constrained_layout` and lands the grid axes rect a few thousandths off the recorded `bbox` (recorded `y0=0.6047/0.1152` vs reproduce-settled `y0=0.5982/0.0982`), shifting all chrome (spines/ticks/labels/text edges + vline endpoints) by ~1px. This is **not** a record/replay gap in the targeted primitives:

- A minimal `vlines + axvspan + axvline + text` 2-panel figure reproduces clean (MSE 0.0–0.2).
- A scitex mm-layout 2-panel figure *without* the overflowing out-of-axes annotations reproduces clean (MSE 0.0).
- It is draw-count-independent (not the #227 iteration class) and a naive recorded-`bbox` pin breaks the tight-crop size — it is entangled with the constrained_layout + `bbox_inches="tight"` machinery and needs its own focused, regression-tested PR.

This PR closes the assigned **content** bug (the dropped `vlines`/`hlines`). The layout residual is filed here for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)