### PR TITLE
feat(diagram): read font sizes from the active style (consistent with figures)

### DIFF
--- a/src/figrecipe/_diagram/_diagram/_render.py
+++ b/src/figrecipe/_diagram/_diagram/_render.py
@@ -12,7 +12,11 @@ from matplotlib.patches import (
 
 from ..._utils._units import mm_to_pt
 from .._shared._styles_native import COLORS as _COLORS
-from .._shared._styles_native import get_edge_style, get_emphasis_style
+from .._shared._styles_native import (
+    get_edge_style,
+    get_emphasis_style,
+    resolve_font_config,
+)
 
 if TYPE_CHECKING:
     from ._core import ArrowSpec, BoxSpec, Diagram
@@ -248,7 +252,7 @@ def render_container(diagram: "Diagram", ax: Axes, cid: str, container: Dict) ->
             container["title"],
             ha=ha,
             va=va,
-            fontsize=11,
+            fontsize=resolve_font_config()["title_size"],
             fontweight="bold",
             color=colors["text"],
             zorder=7,
@@ -409,7 +413,7 @@ def render_arrow(diagram: "Diagram", ax: Axes, arrow: "ArrowSpec") -> None:
             arrow.label,
             ha="center",
             va="center",
-            fontsize=8,
+            fontsize=resolve_font_config()["edge_label_size"],
             color=color,
             fontstyle="italic",
             zorder=6,
@@ -456,6 +460,6 @@ def draw_all_elements(diagram, ax):
             diagram.title,
             ha="center",
             va="top",
-            fontsize=12,
+            fontsize=resolve_font_config()["title_size"],
             fontweight="bold",
         )

--- a/src/figrecipe/_diagram/_diagram/_render_box_text.py
+++ b/src/figrecipe/_diagram/_diagram/_render_box_text.py
@@ -34,11 +34,24 @@ def _build_text_items(
 
     Title first, optional subtitle, then each content line (dict or str) with
     the bullet prefix applied.
+
+    Font sizes come from the active figrecipe style (the same source regular
+    figures read). A box title IS the node's label, so it uses ``node_size``
+    (axis_label_pt); the subtitle and content lines are secondary detail and
+    use the smaller ``edge_label_size`` (legend_pt), preserving the original
+    intra-box hierarchy (title > subtitle ~= content). Codeblock content keeps
+    its dedicated 7pt monospace size (verbatim code, not a label) and explicit
+    per-line ``fontsize`` dict overrides are honoured.
     """
+    from .._shared._styles_native import resolve_font_config
+
+    font = resolve_font_config()
     is_code = box.shape == "codeblock"
-    items: List[Tuple[str, float, str, object]] = [(box.title, 11, "bold", title_color)]
+    items: List[Tuple[str, float, str, object]] = [
+        (box.title, font["node_size"], "bold", title_color)
+    ]
     if box.subtitle:
-        items.append((box.subtitle, 9, "normal", colors["text"]))
+        items.append((box.subtitle, font["edge_label_size"], "normal", colors["text"]))
     bullet_prefixes = {"circle": "· ", "dash": "– ", "arrow": "→ "}
     for line in box.content:
         pfx = bullet_prefixes.get(box.bullet, "")
@@ -46,14 +59,19 @@ def _build_text_items(
             items.append(
                 (
                     pfx + line.get("text", ""),
-                    line.get("fontsize", 8),
+                    line.get("fontsize", font["edge_label_size"]),
                     line.get("fontweight", "normal"),
                     line.get("color", colors["text"]),
                 )
             )
         else:
             items.append(
-                (pfx + str(line), 8 if not is_code else 7, "normal", colors["text"])
+                (
+                    pfx + str(line),
+                    font["edge_label_size"] if not is_code else 7,
+                    "normal",
+                    colors["text"],
+                )
             )
     return items
 

--- a/src/figrecipe/_diagram/_shared/_arrows.py
+++ b/src/figrecipe/_diagram/_shared/_arrows.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Tuple
 
 from matplotlib.patches import FancyArrowPatch
 
-from ._styles_native import FONT_CONFIG, get_edge_style
+from ._styles_native import get_edge_style, resolve_font_config
 
 
 def create_edge_arrow(
@@ -80,14 +80,15 @@ def create_edge_arrow(
         # Offset label slightly above the line
         offset_y = 0.015
 
+        font = resolve_font_config()
         label_kwargs = {
             "x": mid_x,
             "y": mid_y + offset_y,
             "s": label,
             "ha": "center",
             "va": "bottom",
-            "fontsize": FONT_CONFIG["edge_label_size"],
-            "fontfamily": FONT_CONFIG["family"],
+            "fontsize": font["edge_label_size"],
+            "fontfamily": font["family"],
             "color": edge_style["color"],
             "zorder": 4,
         }

--- a/src/figrecipe/_diagram/_shared/_native_render.py
+++ b/src/figrecipe/_diagram/_shared/_native_render.py
@@ -12,7 +12,7 @@ from matplotlib.figure import Figure
 from ._arrows import compute_connection_points, create_edge_arrow
 from ._layout import compute_layout
 from ._shapes import create_node_patch, estimate_node_bounds
-from ._styles_native import FONT_CONFIG
+from ._styles_native import resolve_font_config
 
 if TYPE_CHECKING:
     from ._schema import DiagramSpec
@@ -132,7 +132,7 @@ class DiagramRenderer:
         if self.spec.title:
             ax.set_title(
                 self.spec.title,
-                fontsize=FONT_CONFIG["title_size"],
+                fontsize=resolve_font_config()["title_size"],
                 fontweight="bold",
             )
 

--- a/src/figrecipe/_diagram/_shared/_shapes.py
+++ b/src/figrecipe/_diagram/_shared/_shapes.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Tuple
 
 from matplotlib.patches import FancyBboxPatch
 
-from ._styles_native import FONT_CONFIG, get_emphasis_style
+from ._styles_native import get_emphasis_style, resolve_font_config
 
 # Shape configurations - boxstyle strings for FancyBboxPatch
 # Note: pad and rounding_size are in axes fraction, keep them small
@@ -65,6 +65,7 @@ def create_node_patch(
     """
     colors = get_emphasis_style(emphasis)
     boxstyle = get_shape_style(shape)
+    font = resolve_font_config()
 
     # Use provided dimensions or compute adaptive size
     if width is not None:
@@ -96,9 +97,9 @@ def create_node_patch(
         "s": label,
         "ha": "center",
         "va": "center",
-        "fontsize": FONT_CONFIG["node_size"],
-        "fontfamily": FONT_CONFIG["family"],
-        "fontweight": FONT_CONFIG["weight"],
+        "fontsize": font["node_size"],
+        "fontfamily": font["family"],
+        "fontweight": font["weight"],
         "color": colors["text"],
         "zorder": 3,
     }

--- a/src/figrecipe/_diagram/_shared/_styles_native.py
+++ b/src/figrecipe/_diagram/_shared/_styles_native.py
@@ -87,7 +87,14 @@ EDGE_STYLES = {
     "dotted": {"linestyle": ":", "color": _lighten(_SCITEX_RGB["gray"], 0.25)},
 }
 
-# Font configuration
+# Font configuration.
+#
+# These values are the FALLBACK used only when no figrecipe style is active
+# (e.g. ``fr.load_style(None)``) or when the style cannot be read. When a style
+# IS active, ``resolve_font_config()`` overrides the *_size keys from the active
+# style's font points so diagrams match regular figures (single source of
+# truth: ``styles/presets/*.yaml`` via ``to_subplots_kwargs``). See that
+# function for the role -> point-size mapping.
 FONT_CONFIG = {
     "family": "sans-serif",
     "node_size": 9,
@@ -95,6 +102,74 @@ FONT_CONFIG = {
     "title_size": 11,
     "weight": "normal",
 }
+
+# Emit the "no active style, using fallback fonts" warning at most once so a
+# render loop does not spam the log (no-silent-fallback: still surfaced once).
+_FALLBACK_WARNED = False
+
+
+def resolve_font_config() -> Dict[str, object]:
+    """Resolve diagram font sizes from the *active* figrecipe style.
+
+    Diagrams share ONE source of truth with regular figures: the active style's
+    font points, read via ``styles.to_subplots_kwargs()`` (the same converter
+    ``ps.subplots`` consumes). Resolving here -- at render time -- means a
+    diagram built under SCITEX inherits SCITEX font sizes, and changing
+    ``SCITEX.yaml`` (or loading another preset) moves both diagrams and figures.
+
+    Role -> style point-size mapping (SCITEX defaults in parentheses):
+
+    - ``title_size``      <- ``fonts_title_pt``       (8) diagram + box titles
+    - ``node_size``       <- ``fonts_axis_label_pt``  (7) box/node label text
+    - ``edge_label_size`` <- ``fonts_legend_pt``      (6) arrow/edge labels
+
+    ``edge_label_size`` uses ``legend_pt`` (not ``tick_label_pt``) so edge
+    labels stay one step smaller than node text, preserving the original visual
+    hierarchy (edge < node) now that node text shrank from 9 to 7.
+
+    ``family`` and ``weight`` are not style-driven and keep their FONT_CONFIG
+    values (the style's ``fonts.family`` governs rcParams already; diagram text
+    inherits it through matplotlib unless explicitly set).
+
+    Returns
+    -------
+    dict
+        A copy of FONT_CONFIG with the ``*_size`` keys overridden from the
+        active style. When no style is active (or it cannot be read) the
+        FONT_CONFIG fallback values are returned unchanged (warned once).
+    """
+    global _FALLBACK_WARNED
+
+    config = dict(FONT_CONFIG)
+
+    try:
+        from ...styles._kwargs_converter import to_subplots_kwargs
+        from ...styles._style_loader import _STYLE_CACHE
+    except Exception:  # pragma: no cover - styles package always importable
+        return config
+
+    # No style loaded -> intentional fallback to FONT_CONFIG constants. Surface
+    # it once instead of silently shrinking/keeping the wrong size.
+    if _STYLE_CACHE is None:
+        if not _FALLBACK_WARNED:
+            import warnings
+
+            warnings.warn(
+                "No figrecipe style active; diagram fonts use FONT_CONFIG "
+                "fallback sizes. Call fr.load_style('SCITEX') so diagram fonts "
+                "match figures.",
+                UserWarning,
+                stacklevel=2,
+            )
+            _FALLBACK_WARNED = True
+        return config
+
+    kwargs = to_subplots_kwargs(_STYLE_CACHE)
+    config["title_size"] = kwargs["fonts_title_pt"]
+    config["node_size"] = kwargs["fonts_axis_label_pt"]
+    config["edge_label_size"] = kwargs["fonts_legend_pt"]
+    return config
+
 
 # Named colors (hex) for direct access
 COLORS = {name: _rgb_to_hex(rgb) for name, rgb in _SCITEX_RGB.items()}
@@ -186,6 +261,7 @@ __all__ = [
     "EMPHASIS_COLORS",
     "EDGE_STYLES",
     "FONT_CONFIG",
+    "resolve_font_config",
     "get_emphasis_style",
     "get_edge_style",
     "hex_to_rgb",

--- a/src/figrecipe/_reproducer/_replay_diagram.py
+++ b/src/figrecipe/_reproducer/_replay_diagram.py
@@ -52,13 +52,14 @@ def replay_diagram_call(ax: Axes, call: CallRecord) -> Any:
     ax.set_aspect("equal")
     ax.axis("off")
 
-    # Add title if specified
+    # Add title if specified. Resolve the size from the active style (same as
+    # the save-time renderer in _native_render.render) so save == reproduce.
     if renderer.spec.title:
-        from .._diagram._shared._styles_native import FONT_CONFIG
+        from .._diagram._shared._styles_native import resolve_font_config
 
         ax.set_title(
             renderer.spec.title,
-            fontsize=FONT_CONFIG["title_size"],
+            fontsize=resolve_font_config()["title_size"],
             fontweight="bold",
         )
 

--- a/tests/figrecipe/_diagram/_shared/test_font_from_style.py
+++ b/tests/figrecipe/_diagram/_shared/test_font_from_style.py
@@ -1,0 +1,111 @@
+"""Diagram fonts are read from the active figrecipe style (not hardcoded).
+
+Diagrams used to hardcode ``FONT_CONFIG`` (title 11 / node 9 / edge 7) and
+ignore the active style, so a diagram title (11pt) clashed with SCITEX figure
+titles (8pt). These guards pin the new behaviour: diagram text sizes come from
+the SAME source regular figures read (``to_subplots_kwargs`` over the active
+style), with the role -> point-size mapping
+
+    title_size      <- fonts_title_pt       (SCITEX 8)
+    node_size       <- fonts_axis_label_pt  (SCITEX 7)
+    edge_label_size <- fonts_legend_pt      (SCITEX 6)
+
+and the FONT_CONFIG constants kept only as the no-style fallback.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+import figrecipe as fr
+from figrecipe.diagram import Diagram
+
+
+def _title_fontsize(ax) -> float:
+    """Return the fontsize of the rendered diagram-title text artist."""
+    return next(t.get_fontsize() for t in ax.texts if t.get_text() == "My Title")
+
+
+def _label_fontsize(ax, label: str) -> float:
+    """Return the fontsize of the rendered box-label text artist ``label``."""
+    return next(t.get_fontsize() for t in ax.texts if t.get_text() == label)
+
+
+def _render_titled_diagram():
+    """Render a small titled diagram with two labelled boxes; return its axes."""
+    diag = Diagram(title="My Title", width_mm=120, height_mm=60)
+    diag.add_box("a", title="Alpha", x_mm=30, y_mm=30, width_mm=30, height_mm=18)
+    diag.add_box("b", title="Beta", x_mm=90, y_mm=30, width_mm=30, height_mm=18)
+    _fig, ax = diag.render()
+    return ax
+
+
+def test_diagram_title_size_equals_active_style_title_pt():
+    # Arrange
+    fr.load_style("SCITEX")
+    expected = fr.STYLE.fonts.title_pt
+    # Act
+    ax = _render_titled_diagram()
+    # Assert
+    assert _title_fontsize(ax) == expected
+
+
+def test_box_label_size_equals_active_style_axis_label_pt():
+    # Arrange
+    fr.load_style("SCITEX")
+    expected = fr.STYLE.fonts.axis_label_pt
+    # Act
+    ax = _render_titled_diagram()
+    # Assert
+    assert _label_fontsize(ax, "Alpha") == expected
+
+
+def test_style_title_pt_override_propagates_to_diagram_title():
+    # Arrange
+    fr.load_style("SCITEX")
+    fr.STYLE.fonts.title_pt = 20
+    try:
+        # Act
+        size = _title_fontsize(_render_titled_diagram())
+    finally:
+        fr.load_style("SCITEX")
+    # Assert
+    assert size == 20
+
+
+def test_no_active_style_returns_font_config_fallback_values():
+    # Arrange
+    from figrecipe._diagram._shared import _styles_native as sn
+
+    fr.load_style(None)
+    sn._FALLBACK_WARNED = True  # silence the one-shot warning for this check
+    try:
+        # Act
+        resolved = sn.resolve_font_config()
+    finally:
+        fr.load_style("SCITEX")
+    # Assert
+    assert resolved["title_size"] == sn.FONT_CONFIG["title_size"]
+
+
+def test_no_active_style_warns_about_font_config_fallback():
+    # Arrange
+    import warnings
+
+    from figrecipe._diagram._shared import _styles_native as sn
+
+    fr.load_style(None)
+    sn._FALLBACK_WARNED = False
+    # Act
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            sn.resolve_font_config()
+    finally:
+        fr.load_style("SCITEX")
+    # Assert
+    assert any("FONT_CONFIG fallback" in str(w.message) for w in caught)


### PR DESCRIPTION
## What

Diagrams previously hardcoded `FONT_CONFIG` (title 11 / node 9 / edge 7) and **ignored the active style**, so a diagram title rendered at 11pt while SCITEX figure titles are 8pt — inconsistent and oversized. This makes diagram font sizes come from the **same source regular figures read** (`to_subplots_kwargs()` over the active style), via a new `resolve_font_config()` resolver in `_diagram/_shared/_styles_native.py`.

## Role -> point-size mapping (SCITEX defaults in parentheses)

| diagram role | style key | SCITEX |
|---|---|---|
| `title_size` (diagram + container titles) | `fonts.title_pt` | 8 |
| `node_size` (box/node label text) | `fonts.axis_label_pt` | 7 |
| `edge_label_size` (arrow/edge labels + box subtitle/content) | `fonts.legend_pt` | 6 |

`edge_label_size` uses **`legend_pt` (6)**, not `tick_label_pt` (7), so edge/secondary text stays one step below node text — preserving the original visual hierarchy (edge < node) now that node text shrank 9 -> 7.

## Single source of truth + no silent fallback

- `resolve_font_config()` reads the active style at **render time** (not an import-time constant), so changing `SCITEX.yaml` fonts — or loading another preset — moves diagrams **and** figures together.
- `FONT_CONFIG` stays as the **fallback** only when no style is active (`fr.load_style(None)`), and that fallback emits a one-shot `UserWarning` (no silent degrade).

## What was routed vs left

**Routed** (user-facing): diagram title, container title, box title (= node label), box subtitle/content, arrow/edge labels — in both the `fr.Diagram` path (`_render.py`, `_render_box_text.py`) and the graph `DiagramRenderer` path (`_native_render.py`, `_shapes.py`, `_arrows.py`), plus the graph **reproduce**-title in `_reproducer/_replay_diagram.py` so **save == reproduce**.

**Left alone** (internal): icon glyph sizing (`_icons.py` `h*0.6`), codeblock monospace code body + title-bar (`_codeblock.py`, the 7pt verbatim-code size), debug overlay (`_debug.py`), interactive editor UI text (`_editor.py`), and the PIL watermark stamp (`_io.py`). Explicit per-content-line `fontsize=` dict overrides are still honoured.

## Caveat (downstream must re-run)

Diagram fonts **shrink to match figures** (title 11->8, node 9->7), so diagram output looks different (smaller, consistent) and **diagram recipes record the new sizes — downstream must re-run their scripts** to regenerate. This is expected and desired (it also reduces the gPAC diagram's width toward the 180mm goal).

## Tests

- New guards: `tests/figrecipe/_diagram/_shared/test_font_from_style.py` (5) — title==title_pt, box-label==axis_label_pt, `title_pt` override propagates, no-style fallback value + warning.
- `tests/figrecipe/_diagram/` -> **50 passed**.
- `tests/figrecipe/_reproducer/` -> **81 passed**.
- Round-trip smoke: a diagram saved via `ax.diagram(...)` + `fr.save(validate=True)` reports **Reproducibility Validation: PASSED** (save == reproduce holds with the new sizes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)