### PR TITLE
fix(reproducer): pin reproduced constrained_layout axes to recorded geometry (NeuroVista fig05a residual)

### DIFF
--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -264,19 +264,32 @@ def save_figure(
 
             _collapse_detected = settle_constrained_layout(fig.fig)
 
-            # A shared colorbar's space-steal has no single constrained_layout fixed
-            # point (it drifts with draw history), so freeze the converged geometry
-            # -- otherwise the original, the validator's re-render and a fresh
-            # reproduce() each settle to slightly different rectangles. Only when a
-            # colorbar is present (the no-colorbar path is already deterministic).
-            if not _collapse_detected and getattr(fig.record, "colorbars", None):
+            # Freeze the converged geometry before saving. ``savefig`` runs its OWN
+            # draw, which advances constrained_layout ONE more iteration past the
+            # settled point -- so the SAVED pixels use a slightly different axes
+            # rectangle than the geometry ``_capture_*`` records afterwards (the
+            # post-capture draw nudges it back). On NeuroVista fig05a that ~0.001-
+            # fraction (~1 px) gap is exactly what the reproducer's recorded-bbox
+            # pin then mis-targets: it pins to the RECORDED position, which the
+            # un-frozen original never actually rendered at. ``set_in_layout(False)``
+            # (after a couple of settling draws) takes every axes out of the solver
+            # so ``savefig`` can no longer move them -- making the saved pixels, the
+            # recorded ``bbox_uncropped`` and the reproducer's pinned position all
+            # the SAME settled rectangle. (Originally colorbar-only; generalised
+            # because the no-colorbar path is NOT draw-count-stable either.) Skipped
+            # on a collapsed layout (the quiver fallback needs the live re-solve).
+            if not _collapse_detected:
                 freeze_layout_positions(fig.fig)
 
             if _collapse_detected:
                 # Degenerate layout: never content-crop a collapsed figure; save
                 # full-canvas and fall back to the content-aware crop downstream.
+                # Record the collapse so the reproducer skips its constrained_layout
+                # panel pin (pinning the degenerate recorded rect would desync the
+                # re-measured ink between original and reproduction).
                 use_content_crop = False
                 use_tight = False
+                fig.record.layout_collapsed = True
                 fig.fig.savefig(
                     image_path, dpi=dpi, transparent=transparent, facecolor=facecolor
                 )

--- a/src/figrecipe/_recorder/_core.py
+++ b/src/figrecipe/_recorder/_core.py
@@ -247,6 +247,14 @@ class FigureRecord:
     rcparams: Optional[Dict[str, Any]] = None
     # Constrained layout flag
     constrained_layout: bool = False
+    # True when constrained_layout COLLAPSED at save time (axes shrank to zero,
+    # e.g. a tiny mm figure with large decorations). The save then abandons the
+    # deterministic content-bbox crop for the content-aware re-measure fallback
+    # (``_collapse_detected`` in ``save_figure``), so the reproducer must NOT pin
+    # the panels to their degenerate recorded geometry -- it must re-measure the
+    # same un-pinned ink. Captured at SAVE; ``False`` on legacy recipes (which
+    # then take the pin path, matching their pre-flag behaviour).
+    layout_collapsed: bool = False
     # Figure-level decorations (suptitle, supxlabel, supylabel)
     suptitle: Optional[Dict[str, Any]] = None
     supxlabel: Optional[Dict[str, Any]] = None
@@ -329,6 +337,10 @@ class FigureRecord:
         # Add constrained_layout if True
         if self.constrained_layout:
             result["figure"]["constrained_layout"] = True
+        # Persist the collapse flag only when True (keeps recipes lean); the
+        # reproducer skips the constrained_layout panel pin for a collapsed save.
+        if self.layout_collapsed:
+            result["figure"]["layout_collapsed"] = True
         # Add suptitle if set
         if self.suptitle is not None:
             result["figure"]["suptitle"] = self.suptitle
@@ -390,6 +402,7 @@ class FigureRecord:
             style=fig_data.get("style"),
             rcparams=fig_data.get("rcparams"),
             constrained_layout=fig_data.get("constrained_layout", False),
+            layout_collapsed=fig_data.get("layout_collapsed", False),
             suptitle=fig_data.get("suptitle"),
             supxlabel=fig_data.get("supxlabel"),
             supylabel=fig_data.get("supylabel"),

--- a/src/figrecipe/_reproducer/_finalize_axes.py
+++ b/src/figrecipe/_reproducer/_finalize_axes.py
@@ -93,5 +93,99 @@ def finalize_reproduced_axes(
             if side in ax.spines:
                 ax.spines[side].set_visible(visible)
 
+    # Pin constrained_layout panels to their recorded geometry (LAST). See the
+    # function docstring -- this freezes the axes rectangles so the save-time
+    # constrained_layout re-solve cannot land them at a different fixed point
+    # than the original recorded (NeuroVista fig05a, same-size MSE ~907).
+    pin_constrained_layout_axes(axes_2d, record)
 
-__all__ = ["finalize_reproduced_axes"]
+
+def pin_constrained_layout_axes(axes_2d: np.ndarray, record: FigureRecord) -> None:
+    """Pin reproduced constrained_layout panels to their recorded geometry.
+
+    ``constrained_layout`` solves the panel rectangles ITERATIVELY to a fixed
+    point that depends on the construction path, not just the content. The
+    original figure is built via the mm ``plt.subplots`` helper (which seeds a
+    ``subplots_adjust`` before constrained_layout takes over) and drawn many
+    times; a fresh ``reproduce()`` builds a plain ``plt.subplots(
+    constrained_layout=True)`` with no such seed. The two therefore converge to
+    slightly different fixed points -- on NeuroVista fig05a the reproduced panels
+    land ~0.007-0.015 figure-fraction lower with a ~0.007 taller height than the
+    recorded position, shifting every spine/tick/vline ~1 px and failing the
+    same-size reproducibility check (MSE ~907).
+
+    The original records each panel's SETTLED ``get_position()`` at save time
+    (``AxesRecord.bbox_uncropped``, captured AFTER ``settle_constrained_layout``).
+    Re-applying it here and removing the axes from the layout solver
+    (``set_in_layout(False)``) freezes the geometry so the save-time re-solve
+    (``settle_constrained_layout`` in ``_api/_save.py``) cannot move it. This
+    generalises the per-colorbar source-panel pin (#230 ``_pin_source_axes``) to
+    EVERY panel of a constrained_layout figure. Crucially it is compatible with
+    the #233 deterministic content-bbox crop: that crop is keyed on the recorded
+    ``content_bbox`` and is decoupled from axes geometry, so pinning no longer
+    fights the save SIZE (the reason a naive pin was rejected pre-#233).
+
+    Scope (minimal regression): runs ONLY when ``record.constrained_layout`` is
+    True AND the original layout did NOT collapse (``record.layout_collapsed``).
+    A COLLAPSED layout (tiny axes, e.g. bar+log+minor-ticks in 60x40 mm) is saved
+    by ``save_figure`` via the content-AWARE re-measure fallback (NOT the content-
+    bbox crop), so both the original and the reproduction must re-measure the SAME
+    un-pinned ink -- pinning the reproduction to the degenerate recorded rect would
+    change its ink extent and break the size match. The collapse is read from the
+    recipe flag captured at SAVE time (no probe draw here: a draw in the reproduce
+    path perturbs already-pinned colorbar geometry). Non-constrained figures keep
+    their deterministic ``subplots_adjust`` / mm-layout path untouched. Pins to
+    ``bbox_uncropped`` (the panel's position in the UNCROPPED figure fraction --
+    ``set_position`` is figure-fraction and the save is full-canvas), falling back
+    to the cropped ``bbox`` for legacy recipes saved with ``bbox_inches="tight"``
+    (whose ``bbox`` already equals the uncropped position). A constrained_layout
+    panel with NEITHER recorded box is a legacy recipe predating geometry capture:
+    it is left on the re-solve path with a one-time ``UserWarning`` (no silent
+    fallback) -- such a recipe must be re-saved to capture the geometry.
+    """
+    if not getattr(record, "constrained_layout", False):
+        return
+
+    # A collapsed layout is saved via the content-aware re-measure fallback on
+    # BOTH sides; pinning the reproduction would desync the ink extent. Skip it
+    # (leave the axes in the solver) so the save reproduces the original fallback.
+    # Read the recorded flag rather than re-probing with a draw -- a draw here
+    # perturbs colorbar geometry the colorbar replay just pinned (#230).
+    if getattr(record, "layout_collapsed", False):
+        return
+
+    missing_geometry = False
+    for ax_key, ax_record in record.axes.items():
+        parsed = parse_grid_id(ax_key)
+        if parsed is None:
+            continue  # mm-composed panels reproduce via their own path
+        row, col = parsed
+        try:
+            ax = axes_2d[row, col]
+        except (IndexError, KeyError):
+            continue
+        bbox = getattr(ax_record, "bbox_uncropped", None)
+        if bbox is None or len(bbox) != 4:
+            bbox = getattr(ax_record, "bbox", None)
+        if bbox is None or len(bbox) != 4:
+            missing_geometry = True
+            continue
+        ax.set_position(bbox)
+        try:
+            ax.set_in_layout(False)
+        except Exception:
+            pass  # very old matplotlib: position is still pinned above
+
+    if missing_geometry:
+        import warnings
+
+        warnings.warn(
+            "constrained_layout figure has panel(s) without recorded geometry "
+            "(bbox_uncropped/bbox); leaving them on the layout re-solve path. "
+            "Re-save the figure to capture panel geometry for exact "
+            "constrained_layout reproduction.",
+            UserWarning,
+        )
+
+
+__all__ = ["finalize_reproduced_axes", "pin_constrained_layout_axes"]

--- a/tests/figrecipe/_reproducer/test__cl_axes_pin.py
+++ b/tests/figrecipe/_reproducer/test__cl_axes_pin.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save -> reproduce round-trip for constrained_layout panel geometry (figrecipe).
+
+``constrained_layout`` solves the panel rectangles ITERATIVELY to a fixed point
+that depends on the construction path, not just the content. The original figure
+is built via the mm ``plt.subplots`` helper (which seeds a ``subplots_adjust``
+before constrained_layout takes over); a fresh ``reproduce()`` builds a plain
+``plt.subplots(constrained_layout=True)``. The two converged to DIFFERENT fixed
+points, so the reproduced panels landed ~1 px off the recorded position and the
+same-size reproducibility check failed (NeuroVista fig05a, MSE ~907).
+
+The fix freezes the original's settled geometry before its ``savefig`` re-solve
+(``_api/_save.py`` -> ``freeze_layout_positions`` for every constrained_layout
+figure) so the saved pixels equal the recorded ``bbox_uncropped``, and the
+reproducer pins each constrained_layout panel to that recorded rectangle and
+takes it out of the layout solver (``_reproducer/_finalize_axes.py`` ->
+``pin_constrained_layout_axes``). These tests guard that a constrained_layout
+figure reproduces its panel geometry exactly AND reproduces clean in pixels.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import figrecipe as fr
+
+
+def _build_constrained_layout_figure():
+    """A 2-panel constrained_layout timeline (the NeuroVista fig05a class).
+
+    Built via the mm subplots helper with out-of-axes annotations + vlines +
+    left-aligned titles + hidden spines, so its constrained_layout solve is
+    sensitive to the construction path (the condition that made the reproduced
+    rectangle diverge from the recorded one).
+    """
+    fig, axes = fr.subplots(
+        nrows=2,
+        ncols=1,
+        axes_width_mm=80,
+        axes_height_mm=12.5,
+        margin_left_mm=18,
+        margin_right_mm=10,
+        margin_bottom_mm=14,
+        margin_top_mm=10,
+        space_h_mm=8,
+        panel_labels=False,
+        constrained_layout=True,
+    )
+    days = np.sort(np.random.default_rng(0).uniform(10, 290, size=40))
+    for idx, ax in enumerate(axes):
+        ax.set_title(
+            f"Design {'AB'[idx]} -- timeline schematic", fontsize=9, loc="left"
+        )
+        ax.vlines(days, 0.0, 1.0, color="#4477aa", linewidth=1.0)
+        ax.set_xlim(0, 300)
+        ax.set_ylim(-0.1, 1.2)
+        ax.set_yticks([])
+        ax.text(
+            0.02,
+            -0.35,
+            "pre-day-100 events excluded\n(inclusion floor)",
+            transform=ax.ax.transAxes,
+            fontsize=6,
+            clip_on=False,
+        )
+        for spine in ("top", "right", "left"):
+            ax.ax.spines[spine].set_visible(False)
+    axes[1].set_xlabel("post-implant day", fontsize=8)
+    return fig
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def constrained_layout_saved(tmp_path):
+    fig = _build_constrained_layout_figure()
+    recipe_path = tmp_path / "cl_timeline.png"
+    _, _, result = fr.save(
+        fig, str(recipe_path), validate=True, validate_error_level="warning"
+    )
+    yaml_path = str(recipe_path).replace(".png", ".yaml")
+    return {"dir": tmp_path, "yaml": yaml_path, "result": result}
+
+
+def _recorded_uncropped_bboxes(yaml_path):
+    import yaml
+
+    with open(yaml_path) as fh:
+        data = yaml.safe_load(fh)
+    return {
+        key: ax_entry.get("bbox_uncropped")
+        for key, ax_entry in data.get("axes", {}).items()
+    }
+
+
+def test_reproduced_panels_match_recorded_position(constrained_layout_saved):
+    # Arrange
+    recorded = _recorded_uncropped_bboxes(constrained_layout_saved["yaml"])
+    rfig, raxes = fr.reproduce(constrained_layout_saved["yaml"])
+    rfig.fig.canvas.draw()
+    # Act
+    reproduced = [
+        list(getattr(ax, "ax", ax).get_position().bounds) for ax in np.ravel(raxes)
+    ]
+    expected = [recorded["r0c0"], recorded["r1c0"]]
+    # Assert
+    assert np.allclose(reproduced, expected, atol=1e-6)
+
+
+def test_constrained_layout_figure_reproduces_clean(constrained_layout_saved):
+    # Arrange
+    artifacts = list(constrained_layout_saved["dir"].glob("*-not-reproduced.*"))
+    # Act
+    leftover = len(artifacts)
+    # Assert
+    assert leftover == 0
+
+
+def test_constrained_layout_figure_validates_under_threshold(constrained_layout_saved):
+    # Arrange
+    result = constrained_layout_saved["result"]
+    # Act
+    is_valid = result.valid
+    # Assert
+    assert is_valid
+
+
+def test_reproduced_panels_pinned_out_of_layout(constrained_layout_saved):
+    # Arrange
+    _, raxes = fr.reproduce(constrained_layout_saved["yaml"])
+    # Act
+    in_layout = [getattr(ax, "ax", ax).get_in_layout() for ax in np.ravel(raxes)]
+    # Assert
+    assert not any(in_layout)


### PR DESCRIPTION
## Root cause

`constrained_layout` solves panel rectangles **iteratively** to a fixed point that depends on the *construction path*, not just the content. The original figure is built via the mm `plt.subplots` helper (which seeds a `subplots_adjust` before CL takes over) and drawn many times; a fresh `reproduce()` builds a plain `plt.subplots(constrained_layout=True)`. The two converge to **different** fixed points, so the reproduced panels land ~1 px off the recorded position, shifting every spine/tick/vline and failing the same-size reproducibility check.

NeuroVista **fig05a**: recorded `y0=0.6057/0.1131, h=0.3331` vs reproduce `y0=0.5982/0.0982, h=0.3405` → same-size **MSE ~907**, 5.4 % of pixels changed.

There are **two coupled** root causes (a reproduce-only pin is insufficient — see below):

1. **Save side.** `savefig` runs its *own* draw, which advances CL one more iteration past the settled point — so the SAVED pixels use a different axes rectangle than the geometry `_capture_*` records afterwards (the post-capture draw nudges it back). The recorded `bbox_uncropped` therefore did *not* equal the position the original PNG actually rendered at. Probe (un-frozen original):
   ```
   after settle : y0=0.6057   before savefig: y0=0.6057   after savefig: y0=0.6047  <- saved pixels
   captured bbox_uncropped = 0.6057                                          <- pin target
   ```
2. **Reproduce side.** CL is re-solved on reproduce and lands at a *different* fixed point than the original.

## Post-#233 feasibility: YES

Pre-#233 a naive pin fought `bbox_inches="tight"` (which re-measured ink and depended on axes geometry). **#233 changed the save to full-canvas + crop-to-recorded-`content_bbox`**, which is decoupled from axes geometry. Verified: with the pin in place the saved SIZE is unchanged and stays deterministic — the pin no longer breaks the crop. The deterministic-crop test (`test__save_deterministic_crop`) and the full crop/composition suites stay green.

## Fix

- **`_api/_save.py`** — generalise the colorbar-only `freeze_layout_positions` to **every non-collapsed** constrained_layout figure, so the saved pixels == recorded `bbox_uncropped` == reproducer's pinned position (one settled rectangle). Records `FigureRecord.layout_collapsed = True` on the collapse fallback.
- **`_reproducer/_finalize_axes.py::pin_constrained_layout_axes`** — pin each CL panel to its recorded `bbox_uncropped` (fallback cropped `bbox`) and `set_in_layout(False)` so the save-time re-solve cannot move it. Integrated as the last pass in `finalize_reproduced_axes` (after #234 spines). Generalises #230's `_pin_source_axes`.
- **`_recorder/_core.py`** — new `FigureRecord.layout_collapsed` field (serialized only when True).

**Scope gate (minimal regression):** the pin runs ONLY when `record.constrained_layout` is True **and NOT** `record.layout_collapsed`. A collapsed layout (tiny axes, e.g. bar+log+minor-ticks in 60×40 mm) is saved via the content-aware re-measure fallback on *both* sides — pinning the degenerate recorded rect would desync the ink (it regressed `test_bar_logscale_under_global_rcparam_reproduces_pixel_identical`). The collapse is read from the recorded flag, **not** re-probed with a draw, because a probe draw in the reproduce path perturbs colorbar geometry the #230 colorbar replay just pinned (a draw-based probe regressed 11 colorbar pixel-perfect tests). Legacy recipes (no flag / no recorded geometry) fall back with a `UserWarning` — no silent fallback. Non-constrained figures are untouched.

## Before / after

| figure | before | after |
| --- | --- | --- |
| **fig05a** (real recipe, validator) | same-size, **MSE 907** → `-not-reproduced.png` | **PASSED** (re-run NeuroVista script) |
| reproduce-pin only (no save-freeze) | MSE **385** (still FAIL) | — (proves the save-side freeze is required) |
| minimal 2-panel CL repro | n/a | **MSE 0.0**, invariant across 0/1/5 extra `canvas.draw()` |
| real fig05a reproduce vs reproduce | n/a | **MSE 0.0**, invariant across 0/2/6 extra draws |

## Regression results (PYTHONPATH=worktree/src, full paths)

- `tests/figrecipe/_reproducer/` — **85 passed** (incl. #234 spines, #230 colorbars, new `test__cl_axes_pin`)
- `tests/figrecipe/_api/` + crop (`test__save_crop`, `test__save_deterministic_crop` #233) + `_recorder/` + #227 `test_log_scale_bar_reproduction` — **94 + 30 passed**
- `tests/figrecipe/_composition/` + `_quality/` — **202 passed**
- `tests/integration/` reproduction tests (add_patch, axis_scale, diagram_standalone, embed, imshow_tick, inset, log_scale_bar, vlines_schematic) — **27 passed**
- `tests/integration/` reproducibility matrix/completeness/linewidth — **24 passed** (the bar-log collapse case fixed by the `layout_collapsed` gate)
- `tests/integration/` light (caption, imports, entry_points, env, grid_key, numpy_scalar, stale_recipe) — **50 passed, 2 skipped**
- `tests/integration/test_all_plotters_composition_roundtrip.py` — **50 passed**; `test_all_plotters_nested_roundtrip.py` — **63 passed**
- `tests/figrecipe/_recorder/` + `_serializer/` + `_api/` (incl. new `layout_collapsed` field roundtrip) — **374 passed, 49 skipped**

**Zero regressions across the full reproduce + save surface.**

## Notes

- **#236 (vlines/hlines recording) is already in develop** (merged as #236), so fig05a panels render. This branch is **rebased directly onto current develop** — it contains ONLY the 4-file CL-pin change (no #236 files leaking in).
- New recipe field captured at SAVE (`layout_collapsed`) — NeuroVista must re-run scripts to regenerate recipes; legacy recipes fall back loudly (no silent fallback).