### PR TITLE
ci(release): run release pipeline in scitex-ci SIF + manual OIDC publish

### DIFF
--- a/.github/ci/build-in-sif.sh
+++ b/.github/ci/build-in-sif.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Runs INSIDE the reused scitex-ci SIF (apptainer exec — invoked via
+# exec-in-sif.sh). Builds figrecipe's wheel + sdist into ./dist/.
+#
+# WHY build in the SIF: the self-hosted Spartan runner has no Python on the
+# bare node (the whole reason the old `actions/setup-python@v5` step failed:
+# "version 3.x not found for this OS"). The SIF bakes python 3.11/3.12/3.13 +
+# pip + uv at /opt/venv-<ver>, exactly like the working pytest-matrix CI.
+#
+# `python -m build` needs the `build` frontend, which is NOT baked in the SIF
+# (only scitex-dev[all,dev] deps are). Mirror run-in-sif.sh: install `build`
+# into a writable --target on node-local /tmp and put it on PYTHONPATH. The
+# SIF's /opt/venv-* are root-owned + RO and the compute-node HOME is RO inside
+# the container, so a normal install fails Permission denied — a --target on
+# writable scratch sidesteps both.
+#
+# Fail-loud (operator directive): a missing interpreter or a failed build is a
+# HARD error, never a silent fallback.
+set -euo pipefail
+
+V="${1:-3.12}"
+VENV="/opt/venv-$V"
+PY="$VENV/bin/python"
+test -x "$PY" || {
+    echo "::error::baked python missing in $VENV — rebuild the SIF: scitex-container apptainer build ci-cpu"
+    exit 1
+}
+
+export LC_ALL=C.UTF-8 LANG=C.UTF-8
+
+# Writable scratch (the runner's TMPDIR=~/.cache/tmp is a host path that does
+# NOT resolve inside the container). Node-local /tmp is writable + ephemeral.
+TMPDIR="/tmp/build-figrecipe-$V"
+export TMPDIR
+rm -rf "$TMPDIR"
+mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
+
+# The compute-node $HOME is RO inside the container — point every cache the
+# installer might touch at the writable scratch (else uv/pip die creating
+# ~/.cache).
+export UV_CACHE_DIR="$TMPDIR/uv-cache"
+export XDG_CACHE_HOME="$TMPDIR"
+export PIP_CACHE_DIR="$TMPDIR/pip-cache"
+
+# A VIRTUAL_ENV leaked from the runner profile (~/.env-3.11) is a broken
+# symlink in here; unset it so no tool follows it.
+unset VIRTUAL_ENV || true
+
+export PATH="$VENV/bin:$PATH"
+echo "build: py=$("$PY" -V) target=$TMPDIR/site"
+
+# Install the PEP 517 build frontend into the writable target (uv fast path,
+# pip safety net), then build with it. Clean dist/ first so only the freshly
+# built artifacts are uploaded.
+uv pip install --python "$PY" --target="$TMPDIR/site" build ||
+    "$PY" -m pip install --target="$TMPDIR/site" build
+
+export PYTHONPATH="$TMPDIR/site${PYTHONPATH:+:$PYTHONPATH}"
+
+rm -rf dist
+"$PY" -m build --outdir dist
+
+echo "=== built artifacts ==="
+ls -l dist
+# fail-loud: refuse to continue the pipeline with an empty dist/.
+test -n "$(ls -A dist 2>/dev/null)" || {
+    echo "::error::python -m build produced no artifacts in dist/"
+    exit 1
+}

--- a/.github/ci/publish-in-sif.sh
+++ b/.github/ci/publish-in-sif.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Runs INSIDE the reused scitex-ci SIF (apptainer exec — invoked via
+# exec-in-sif.sh). Publishes ./dist/* to PyPI via MANUAL OIDC Trusted
+# Publishing, then twine upload.
+#
+# WHY manual OIDC (not pypa/gh-action-pypi-publish): that action is a Docker
+# container action. Self-hosted Spartan compute nodes have NO Docker, so the
+# action cannot run there. PyPI Trusted Publishing is just an OIDC token
+# exchange over plain HTTPS, so we do it by hand:
+#
+#   1. Ask the GitHub Actions OIDC provider for a JWT with audience=pypi,
+#      using the per-job ACTIONS_ID_TOKEN_REQUEST_{TOKEN,URL} env vars (present
+#      because the publish job declares `permissions: id-token: write`).
+#      apptainer exec (no --cleanenv) passes those host env vars into the SIF.
+#   2. Exchange that JWT at PyPI's mint-token endpoint for a short-lived,
+#      scope-limited PyPI API token.
+#   3. twine upload dist/* with TWINE_USERNAME=__token__ and that minted token.
+#
+# This requires a Trusted Publisher to be configured on PyPI for
+# (project=figrecipe, owner=ywatanabe1989, repo=figrecipe,
+#  workflow=pypi-publish-and-github-release-on-tag.yml). It already is — the
+# previous releases published via the Docker action under the same trusted
+# publisher; only the *client* changes here, not PyPI's trust config.
+#
+# curl, python and (after a --target install) twine all live in the SIF.
+#
+# Fail-loud (operator directive): every step asserts non-empty output and
+# `set -euo pipefail`; any failure is a HARD error with the exact cause, never
+# a silent skip.
+set -euo pipefail
+
+V="${1:-3.12}"
+VENV="/opt/venv-$V"
+PY="$VENV/bin/python"
+test -x "$PY" || {
+    echo "::error::baked python missing in $VENV — rebuild the SIF: scitex-container apptainer build ci-cpu"
+    exit 1
+}
+
+export LC_ALL=C.UTF-8 LANG=C.UTF-8
+
+# dist/ must already hold the artifacts (downloaded by the publish job before
+# this script runs). Fail loud if empty.
+if [ ! -d dist ] || [ -z "$(ls -A dist 2>/dev/null)" ]; then
+    echo "::error::dist/ is empty — nothing to publish (download the build artifact first)"
+    exit 1
+fi
+echo "=== dist to publish ==="
+ls -l dist
+
+# --- writable scratch (compute-node HOME is RO inside the container) ---
+TMPDIR="/tmp/publish-figrecipe-$V"
+export TMPDIR
+rm -rf "$TMPDIR"
+mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
+export UV_CACHE_DIR="$TMPDIR/uv-cache"
+export XDG_CACHE_HOME="$TMPDIR"
+export PIP_CACHE_DIR="$TMPDIR/pip-cache"
+unset VIRTUAL_ENV || true
+export PATH="$VENV/bin:$PATH"
+
+# --- step 1: request the OIDC JWT (audience=pypi) from GitHub ---
+: "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:?ACTIONS_ID_TOKEN_REQUEST_TOKEN not set — the publish job needs 'permissions: id-token: write'}"
+: "${ACTIONS_ID_TOKEN_REQUEST_URL:?ACTIONS_ID_TOKEN_REQUEST_URL not set — the publish job needs 'permissions: id-token: write'}"
+
+echo "=== minting OIDC JWT (audience=pypi) ==="
+JWT="$(curl -fsS \
+    -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=pypi" |
+    "$PY" -c 'import sys,json; print(json.load(sys.stdin)["value"])')"
+test -n "$JWT" || {
+    echo "::error::OIDC JWT request returned an empty token"
+    exit 1
+}
+echo "OIDC JWT obtained (length=${#JWT})"
+
+# --- step 2: exchange the JWT for a short-lived PyPI API token ---
+echo "=== exchanging JWT at PyPI mint-token endpoint ==="
+MINT_RESP="$(curl -sS -X POST https://pypi.org/_/oidc/mint-token \
+    -d "{\"token\":\"${JWT}\"}")"
+MINTED="$(printf '%s' "$MINT_RESP" |
+    "$PY" -c 'import sys,json; d=json.load(sys.stdin); print(d.get("token",""))')"
+if [ -z "$MINTED" ]; then
+    # Surface PyPI's error body VERBATIM (the JWT is NOT echoed) so a trust
+    # misconfiguration is diagnosable — this is the decisive failure mode for
+    # the fleet. Print the raw response unconditionally (most reliable on an
+    # error path); pretty-print is best-effort on top.
+    echo "::error::PyPI mint-token returned no token."
+    echo "--- PyPI mint-token response body (raw) ---"
+    printf '%s\n' "$MINT_RESP"
+    echo "--- (pretty, best-effort) ---"
+    printf '%s' "$MINT_RESP" |
+        "$PY" -c 'import sys,json; print(json.dumps(json.load(sys.stdin), indent=2))' \
+            2>/dev/null || true
+    exit 1
+fi
+echo "PyPI token minted (length=${#MINTED})"
+
+# --- step 3: install twine into the writable target, then upload ---
+echo "=== installing twine (--target) ==="
+uv pip install --python "$PY" --target="$TMPDIR/site" twine ||
+    "$PY" -m pip install --target="$TMPDIR/site" twine
+export PYTHONPATH="$TMPDIR/site${PYTHONPATH:+:$PYTHONPATH}"
+
+echo "=== twine upload dist/* ==="
+TWINE_USERNAME="__token__" TWINE_PASSWORD="$MINTED" \
+    "$PY" -m twine upload --non-interactive --disable-progress-bar dist/*
+
+echo "PUBLISH-OK: figrecipe dist/* uploaded to PyPI via manual OIDC trusted publishing"

--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -1,20 +1,41 @@
 name: release
 
-# Tag-driven release pipeline. The intended operator flow is:
+# Tag-driven release pipeline — SELF-HOSTED (Spartan CPU) via the scitex-ci SIF.
+#
+# The intended operator flow is:
 #
 #     git tag vX.Y.Z && git push origin vX.Y.Z
 #
 # Everything else fires automatically:
 #
-#   1. test          — matrix pytest. Must pass or the pipeline halts;
-#                      nothing is published until tests are green on the
+#   1. test          — matrix pytest INSIDE the SIF. Must pass or the pipeline
+#                      halts; nothing is published until tests are green on the
 #                      tagged commit.
-#   2. build         — wheel + sdist, uploaded as workflow artifact.
-#   3. publish       — PyPI via OIDC trusted publisher.
+#   2. build         — wheel + sdist built INSIDE the SIF, uploaded as artifact.
+#   3. publish       — PyPI via MANUAL OIDC trusted publishing INSIDE the SIF.
 #   4. release       — GitHub Release with CHANGELOG notes + artifacts.
 #   5. sync-main     — open a develop→main PR (admin-merge) so main
 #                      always equals the latest released commit. Skipped
 #                      if main already matches.
+#
+# WHY the SIF (operator standardization 2026-06-18, fleet canary 2026-06-21):
+# the Spartan compute runners have NO Python on the bare node, so the old
+# `actions/setup-python@v5` step failed at init ("version 3.x not found for
+# this OS"). The working pytest-matrix CI runs INSIDE the pre-built, reused
+# scitex-ci SIF (`apptainer exec ci-cpu.sif`), which bakes python 3.11/3.12/
+# 3.13 + pip + uv + fd at /opt/venv-<ver>. This release pipeline mirrors that:
+#   - test/build run `bash .github/ci/exec-in-sif.sh <inner>.sh <pyver>`.
+#   - publish CANNOT use pypa/gh-action-pypi-publish (a Docker action; the
+#     compute nodes have no Docker), so it does MANUAL OIDC trusted publishing
+#     inside the SIF (.github/ci/publish-in-sif.sh): GitHub OIDC JWT →
+#     PyPI mint-token → twine upload. Trust config on PyPI is unchanged.
+#   - actions/checkout, upload/download-artifact, codecov are JS actions and
+#     run fine on the self-hosted runner.
+# fail-loud: a missing SIF/shim/interpreter is a HARD error, never a
+# bare-runner fallback.
+#
+# runs-on driven by repo Actions Variable CI_RUNS_ON; SIF + apptainer paths
+# come from SCITEX_CI_SIF / SCITEX_CI_APPTAINER (same as pytest-matrix).
 #
 # Manual re-run: the workflow also accepts a `version` input via
 # workflow_dispatch so you can re-publish without re-tagging.
@@ -28,6 +49,10 @@ on:
         description: 'Tag to publish (e.g. v0.10.19) — must already exist on the repo'
         required: true
         type: string
+
+env:
+  SCITEX_CI_APPTAINER: ${{ vars.SCITEX_CI_APPTAINER }}
+  SCITEX_CI_SIF: ${{ vars.SCITEX_CI_SIF }}
 
 jobs:
   test:
@@ -50,31 +75,14 @@ jobs:
         with:
           ref: ${{ steps.ver.outputs.version }}
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install (best-effort fallback chain)
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
-      - name: Install fd (Rust file finder; preferred fast path for audit discovery)
-        run: |
-          # tests/develop/test_audit.py runs scitex-dev's audit-project, whose
-          # orphan-hinter prefers fd/fdfind for file discovery. This repo sets
-          # audit.require-fd: true (.scitex/dev/config.yaml), so fd-absence
-          # ERRORS rather than falling back — install it here. Debian/Ubuntu
-          # ships the binary as `fdfind`; symlink to `fd` so the `fd` lookup
-          # resolves too. Mirrors the pytest-matrix workflow (#123).
-          sudo apt-get update && sudo apt-get install -y fd-find
-          sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
-          fd --version
-      - name: Run pytest
-        run: |
-          if [ -d tests ]; then
-            pytest tests/ -x
-          else
-            echo "no tests/ directory — skipping pytest"
-          fi
+      # SIF-based self-hosted test run — mirrors pytest-matrix exactly. No
+      # setup-python (the bare Spartan node has no Python tool cache; that step
+      # failed "version not found for this OS"); no apt fd-install (fd is baked
+      # in the SIF). exec-in-sif.sh apptainer-execs the reused ci-cpu.sif and
+      # run-in-sif.sh layers THIS (tagged) checkout + [all,dev] into a writable
+      # target, then runs pytest. fail-loud on a missing SIF/shim.
+      - name: Run tests in the reused CI SIF (apptainer exec — deps layered, not on the bare runner)
+        run: bash .github/ci/exec-in-sif.sh run-in-sif.sh ${{ matrix.python-version }}
 
   build:
     needs: test
@@ -95,13 +103,12 @@ jobs:
         with:
           ref: ${{ steps.ver.outputs.version }}
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install build tools
-        run: pip install build
-      - name: Build distribution
-        run: python -m build
+      # Build INSIDE the SIF (no setup-python on the bare Spartan node).
+      # build-in-sif.sh installs the `build` frontend into a writable --target
+      # inside the SIF, then `python -m build` → dist/. fail-loud on empty dist.
+      - name: Build wheel + sdist in the CI SIF (apptainer exec)
+        run: bash .github/ci/exec-in-sif.sh build-in-sif.sh 3.12
+      # upload-artifact is a JS action — runs fine on the self-hosted runner.
       - uses: actions/upload-artifact@v4
         with:
           name: dist
@@ -113,14 +120,25 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/figrecipe
+    # id-token: write is what populates ACTIONS_ID_TOKEN_REQUEST_{TOKEN,URL},
+    # which publish-in-sif.sh uses to mint the OIDC JWT. Keep it.
     permissions:
       id-token: write
     steps:
+      # Need the repo checked out so .github/ci/exec-in-sif.sh +
+      # publish-in-sif.sh are on disk (the build job uploaded only dist/).
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      # Manual OIDC trusted publishing INSIDE the SIF — pypa/gh-action-pypi-
+      # publish is a Docker action and the Spartan compute nodes have no Docker.
+      # publish-in-sif.sh: GitHub OIDC JWT (audience=pypi) → PyPI mint-token →
+      # twine upload dist/*. apptainer exec (no --cleanenv) passes the
+      # ACTIONS_ID_TOKEN_REQUEST_* env vars into the SIF. fail-loud at each step.
+      - name: Publish to PyPI via manual OIDC trusted publishing in the SIF
+        run: bash .github/ci/exec-in-sif.sh publish-in-sif.sh 3.12
 
   release:
     needs: [build, publish]


### PR DESCRIPTION
## What

Rewrites the tag-driven **release** workflow to run on self-hosted Spartan via the **scitex-ci SIF**, mirroring the working `pytest-matrix` CI.

## Why

PR #244 flipped the release pipeline to self-hosted runners, but it fails at `actions/setup-python@v5` ("version 3.x not found for this OS") — setup-python cannot provide Python on a bare Spartan compute node. (v0.29.0 release run `27898366882` failed in all 3 test legs at exactly this step, skipping build/publish/release.) The working `pytest-matrix` CI succeeds because it runs **inside** the reused `ci-cpu.sif` (`apptainer exec`), which bakes python 3.11/3.12/3.13 + pip + uv + fd at `/opt/venv-<ver>`.

## Changes

- **test**: drop `setup-python` + apt `fd`-install; run `bash .github/ci/exec-in-sif.sh run-in-sif.sh <pyver>` (fd is baked in the SIF). Identical step to `pytest-matrix`.
- **build**: drop `setup-python`; new **`.github/ci/build-in-sif.sh`** apptainer-execs the SIF, installs the `build` frontend into a writable `--target`, then `python -m build` → `dist/`. fail-loud on empty dist.
- **publish**: `pypa/gh-action-pypi-publish` is a **Docker** action and the compute nodes have **no Docker**. Replaced with **manual OIDC trusted publishing** in new **`.github/ci/publish-in-sif.sh`**: GitHub OIDC JWT (`audience=pypi`) → PyPI `mint-token` → `twine upload dist/*`. Keeps `id-token: write`; `apptainer exec` (no `--cleanenv`) passes `ACTIONS_ID_TOKEN_REQUEST_*` into the SIF. fail-loud + non-empty asserts at each step.
- **release / sync-main**: logic unchanged (gh + git + awk are on the runner; no setup-python to drop).

## Pre-flight (on the live `ci-cpu.sif`, runner node bm207)

- `build-in-sif.sh` → builds `figrecipe-0.29.0-py3-none-any.whl` + `.tar.gz` ✓
- twine installs to `--target`; `twine check` **PASSES** both artifacts ✓
- OIDC JSON-parse one-liners verified with mock payloads ✓
- curl present in SIF; `ACTIONS_ID_TOKEN_REQUEST_*` confirmed to pass through `apptainer exec` ✓

## Note

The `release` workflow triggers only on `tags: ['v*']` / `workflow_dispatch`, so it does **not** run on this PR. Its real validation is the v0.29.0 re-tag after this merges to develop→main (canary for the fleet-wide migration). The live GitHub-OIDC→PyPI-mint exchange is the one piece only testable on a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)