### PR TITLE
promote: figrecipe self-hosted SIF release + manual OIDC (#246) → main

### DIFF
--- a/.github/ci/build-in-sif.sh
+++ b/.github/ci/build-in-sif.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Runs INSIDE the reused scitex-ci SIF (apptainer exec — invoked via
+# exec-in-sif.sh). Builds figrecipe's wheel + sdist into ./dist/.
+#
+# WHY build in the SIF: the self-hosted Spartan runner has no Python on the
+# bare node (the whole reason the old `actions/setup-python@v5` step failed:
+# "version 3.x not found for this OS"). The SIF bakes python 3.11/3.12/3.13 +
+# pip + uv at /opt/venv-<ver>, exactly like the working pytest-matrix CI.
+#
+# `python -m build` needs the `build` frontend, which is NOT baked in the SIF
+# (only scitex-dev[all,dev] deps are). Mirror run-in-sif.sh: install `build`
+# into a writable --target on node-local /tmp and put it on PYTHONPATH. The
+# SIF's /opt/venv-* are root-owned + RO and the compute-node HOME is RO inside
+# the container, so a normal install fails Permission denied — a --target on
+# writable scratch sidesteps both.
+#
+# Fail-loud (operator directive): a missing interpreter or a failed build is a
+# HARD error, never a silent fallback.
+set -euo pipefail
+
+V="${1:-3.12}"
+VENV="/opt/venv-$V"
+PY="$VENV/bin/python"
+test -x "$PY" || {
+    echo "::error::baked python missing in $VENV — rebuild the SIF: scitex-container apptainer build ci-cpu"
+    exit 1
+}
+
+export LC_ALL=C.UTF-8 LANG=C.UTF-8
+
+# Writable scratch (the runner's TMPDIR=~/.cache/tmp is a host path that does
+# NOT resolve inside the container). Node-local /tmp is writable + ephemeral.
+TMPDIR="/tmp/build-figrecipe-$V"
+export TMPDIR
+rm -rf "$TMPDIR"
+mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
+
+# The compute-node $HOME is RO inside the container — point every cache the
+# installer might touch at the writable scratch (else uv/pip die creating
+# ~/.cache).
+export UV_CACHE_DIR="$TMPDIR/uv-cache"
+export XDG_CACHE_HOME="$TMPDIR"
+export PIP_CACHE_DIR="$TMPDIR/pip-cache"
+
+# A VIRTUAL_ENV leaked from the runner profile (~/.env-3.11) is a broken
+# symlink in here; unset it so no tool follows it.
+unset VIRTUAL_ENV || true
+
+export PATH="$VENV/bin:$PATH"
+echo "build: py=$("$PY" -V) target=$TMPDIR/site"
+
+# Install the PEP 517 build frontend into the writable target (uv fast path,
+# pip safety net), then build with it. Clean dist/ first so only the freshly
+# built artifacts are uploaded.
+uv pip install --python "$PY" --target="$TMPDIR/site" build ||
+    "$PY" -m pip install --target="$TMPDIR/site" build
+
+export PYTHONPATH="$TMPDIR/site${PYTHONPATH:+:$PYTHONPATH}"
+
+rm -rf dist
+"$PY" -m build --outdir dist
+
+echo "=== built artifacts ==="
+ls -l dist
+# fail-loud: refuse to continue the pipeline with an empty dist/.
+test -n "$(ls -A dist 2>/dev/null)" || {
+    echo "::error::python -m build produced no artifacts in dist/"
+    exit 1
+}

--- a/.github/ci/publish-in-sif.sh
+++ b/.github/ci/publish-in-sif.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Runs INSIDE the reused scitex-ci SIF (apptainer exec — invoked via
+# exec-in-sif.sh). Publishes ./dist/* to PyPI via MANUAL OIDC Trusted
+# Publishing, then twine upload.
+#
+# WHY manual OIDC (not pypa/gh-action-pypi-publish): that action is a Docker
+# container action. Self-hosted Spartan compute nodes have NO Docker, so the
+# action cannot run there. PyPI Trusted Publishing is just an OIDC token
+# exchange over plain HTTPS, so we do it by hand:
+#
+#   1. Ask the GitHub Actions OIDC provider for a JWT with audience=pypi,
+#      using the per-job ACTIONS_ID_TOKEN_REQUEST_{TOKEN,URL} env vars (present
+#      because the publish job declares `permissions: id-token: write`).
+#      apptainer exec (no --cleanenv) passes those host env vars into the SIF.
+#   2. Exchange that JWT at PyPI's mint-token endpoint for a short-lived,
+#      scope-limited PyPI API token.
+#   3. twine upload dist/* with TWINE_USERNAME=__token__ and that minted token.
+#
+# This requires a Trusted Publisher to be configured on PyPI for
+# (project=figrecipe, owner=ywatanabe1989, repo=figrecipe,
+#  workflow=pypi-publish-and-github-release-on-tag.yml). It already is — the
+# previous releases published via the Docker action under the same trusted
+# publisher; only the *client* changes here, not PyPI's trust config.
+#
+# curl, python and (after a --target install) twine all live in the SIF.
+#
+# Fail-loud (operator directive): every step asserts non-empty output and
+# `set -euo pipefail`; any failure is a HARD error with the exact cause, never
+# a silent skip.
+set -euo pipefail
+
+V="${1:-3.12}"
+VENV="/opt/venv-$V"
+PY="$VENV/bin/python"
+test -x "$PY" || {
+    echo "::error::baked python missing in $VENV — rebuild the SIF: scitex-container apptainer build ci-cpu"
+    exit 1
+}
+
+export LC_ALL=C.UTF-8 LANG=C.UTF-8
+
+# dist/ must already hold the artifacts (downloaded by the publish job before
+# this script runs). Fail loud if empty.
+if [ ! -d dist ] || [ -z "$(ls -A dist 2>/dev/null)" ]; then
+    echo "::error::dist/ is empty — nothing to publish (download the build artifact first)"
+    exit 1
+fi
+echo "=== dist to publish ==="
+ls -l dist
+
+# --- writable scratch (compute-node HOME is RO inside the container) ---
+TMPDIR="/tmp/publish-figrecipe-$V"
+export TMPDIR
+rm -rf "$TMPDIR"
+mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
+export UV_CACHE_DIR="$TMPDIR/uv-cache"
+export XDG_CACHE_HOME="$TMPDIR"
+export PIP_CACHE_DIR="$TMPDIR/pip-cache"
+unset VIRTUAL_ENV || true
+export PATH="$VENV/bin:$PATH"
+
+# --- step 1: request the OIDC JWT (audience=pypi) from GitHub ---
+: "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:?ACTIONS_ID_TOKEN_REQUEST_TOKEN not set — the publish job needs 'permissions: id-token: write'}"
+: "${ACTIONS_ID_TOKEN_REQUEST_URL:?ACTIONS_ID_TOKEN_REQUEST_URL not set — the publish job needs 'permissions: id-token: write'}"
+
+echo "=== minting OIDC JWT (audience=pypi) ==="
+JWT="$(curl -fsS \
+    -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=pypi" |
+    "$PY" -c 'import sys,json; print(json.load(sys.stdin)["value"])')"
+test -n "$JWT" || {
+    echo "::error::OIDC JWT request returned an empty token"
+    exit 1
+}
+echo "OIDC JWT obtained (length=${#JWT})"
+
+# --- step 2: exchange the JWT for a short-lived PyPI API token ---
+echo "=== exchanging JWT at PyPI mint-token endpoint ==="
+MINT_RESP="$(curl -sS -X POST https://pypi.org/_/oidc/mint-token \
+    -d "{\"token\":\"${JWT}\"}")"
+MINTED="$(printf '%s' "$MINT_RESP" |
+    "$PY" -c 'import sys,json; d=json.load(sys.stdin); print(d.get("token",""))')"
+if [ -z "$MINTED" ]; then
+    # Surface PyPI's error body VERBATIM (the JWT is NOT echoed) so a trust
+    # misconfiguration is diagnosable — this is the decisive failure mode for
+    # the fleet. Print the raw response unconditionally (most reliable on an
+    # error path); pretty-print is best-effort on top.
+    echo "::error::PyPI mint-token returned no token."
+    echo "--- PyPI mint-token response body (raw) ---"
+    printf '%s\n' "$MINT_RESP"
+    echo "--- (pretty, best-effort) ---"
+    printf '%s' "$MINT_RESP" |
+        "$PY" -c 'import sys,json; print(json.dumps(json.load(sys.stdin), indent=2))' \
+            2>/dev/null || true
+    exit 1
+fi
+echo "PyPI token minted (length=${#MINTED})"
+
+# --- step 3: install twine into the writable target, then upload ---
+echo "=== installing twine (--target) ==="
+uv pip install --python "$PY" --target="$TMPDIR/site" twine ||
+    "$PY" -m pip install --target="$TMPDIR/site" twine
+export PYTHONPATH="$TMPDIR/site${PYTHONPATH:+:$PYTHONPATH}"
+
+echo "=== twine upload dist/* ==="
+TWINE_USERNAME="__token__" TWINE_PASSWORD="$MINTED" \
+    "$PY" -m twine upload --non-interactive --disable-progress-bar dist/*
+
+echo "PUBLISH-OK: figrecipe dist/* uploaded to PyPI via manual OIDC trusted publishing"

--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -1,20 +1,41 @@
 name: release
 
-# Tag-driven release pipeline. The intended operator flow is:
+# Tag-driven release pipeline — SELF-HOSTED (Spartan CPU) via the scitex-ci SIF.
+#
+# The intended operator flow is:
 #
 #     git tag vX.Y.Z && git push origin vX.Y.Z
 #
 # Everything else fires automatically:
 #
-#   1. test          — matrix pytest. Must pass or the pipeline halts;
-#                      nothing is published until tests are green on the
+#   1. test          — matrix pytest INSIDE the SIF. Must pass or the pipeline
+#                      halts; nothing is published until tests are green on the
 #                      tagged commit.
-#   2. build         — wheel + sdist, uploaded as workflow artifact.
-#   3. publish       — PyPI via OIDC trusted publisher.
+#   2. build         — wheel + sdist built INSIDE the SIF, uploaded as artifact.
+#   3. publish       — PyPI via MANUAL OIDC trusted publishing INSIDE the SIF.
 #   4. release       — GitHub Release with CHANGELOG notes + artifacts.
 #   5. sync-main     — open a develop→main PR (admin-merge) so main
 #                      always equals the latest released commit. Skipped
 #                      if main already matches.
+#
+# WHY the SIF (operator standardization 2026-06-18, fleet canary 2026-06-21):
+# the Spartan compute runners have NO Python on the bare node, so the old
+# `actions/setup-python@v5` step failed at init ("version 3.x not found for
+# this OS"). The working pytest-matrix CI runs INSIDE the pre-built, reused
+# scitex-ci SIF (`apptainer exec ci-cpu.sif`), which bakes python 3.11/3.12/
+# 3.13 + pip + uv + fd at /opt/venv-<ver>. This release pipeline mirrors that:
+#   - test/build run `bash .github/ci/exec-in-sif.sh <inner>.sh <pyver>`.
+#   - publish CANNOT use pypa/gh-action-pypi-publish (a Docker action; the
+#     compute nodes have no Docker), so it does MANUAL OIDC trusted publishing
+#     inside the SIF (.github/ci/publish-in-sif.sh): GitHub OIDC JWT →
+#     PyPI mint-token → twine upload. Trust config on PyPI is unchanged.
+#   - actions/checkout, upload/download-artifact, codecov are JS actions and
+#     run fine on the self-hosted runner.
+# fail-loud: a missing SIF/shim/interpreter is a HARD error, never a
+# bare-runner fallback.
+#
+# runs-on driven by repo Actions Variable CI_RUNS_ON; SIF + apptainer paths
+# come from SCITEX_CI_SIF / SCITEX_CI_APPTAINER (same as pytest-matrix).
 #
 # Manual re-run: the workflow also accepts a `version` input via
 # workflow_dispatch so you can re-publish without re-tagging.
@@ -28,6 +49,10 @@ on:
         description: 'Tag to publish (e.g. v0.10.19) — must already exist on the repo'
         required: true
         type: string
+
+env:
+  SCITEX_CI_APPTAINER: ${{ vars.SCITEX_CI_APPTAINER }}
+  SCITEX_CI_SIF: ${{ vars.SCITEX_CI_SIF }}
 
 jobs:
   test:
@@ -50,31 +75,14 @@ jobs:
         with:
           ref: ${{ steps.ver.outputs.version }}
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install (best-effort fallback chain)
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
-      - name: Install fd (Rust file finder; preferred fast path for audit discovery)
-        run: |
-          # tests/develop/test_audit.py runs scitex-dev's audit-project, whose
-          # orphan-hinter prefers fd/fdfind for file discovery. This repo sets
-          # audit.require-fd: true (.scitex/dev/config.yaml), so fd-absence
-          # ERRORS rather than falling back — install it here. Debian/Ubuntu
-          # ships the binary as `fdfind`; symlink to `fd` so the `fd` lookup
-          # resolves too. Mirrors the pytest-matrix workflow (#123).
-          sudo apt-get update && sudo apt-get install -y fd-find
-          sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
-          fd --version
-      - name: Run pytest
-        run: |
-          if [ -d tests ]; then
-            pytest tests/ -x
-          else
-            echo "no tests/ directory — skipping pytest"
-          fi
+      # SIF-based self-hosted test run — mirrors pytest-matrix exactly. No
+      # setup-python (the bare Spartan node has no Python tool cache; that step
+      # failed "version not found for this OS"); no apt fd-install (fd is baked
+      # in the SIF). exec-in-sif.sh apptainer-execs the reused ci-cpu.sif and
+      # run-in-sif.sh layers THIS (tagged) checkout + [all,dev] into a writable
+      # target, then runs pytest. fail-loud on a missing SIF/shim.
+      - name: Run tests in the reused CI SIF (apptainer exec — deps layered, not on the bare runner)
+        run: bash .github/ci/exec-in-sif.sh run-in-sif.sh ${{ matrix.python-version }}
 
   build:
     needs: test
@@ -95,13 +103,12 @@ jobs:
         with:
           ref: ${{ steps.ver.outputs.version }}
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install build tools
-        run: pip install build
-      - name: Build distribution
-        run: python -m build
+      # Build INSIDE the SIF (no setup-python on the bare Spartan node).
+      # build-in-sif.sh installs the `build` frontend into a writable --target
+      # inside the SIF, then `python -m build` → dist/. fail-loud on empty dist.
+      - name: Build wheel + sdist in the CI SIF (apptainer exec)
+        run: bash .github/ci/exec-in-sif.sh build-in-sif.sh 3.12
+      # upload-artifact is a JS action — runs fine on the self-hosted runner.
       - uses: actions/upload-artifact@v4
         with:
           name: dist
@@ -113,14 +120,25 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/figrecipe
+    # id-token: write is what populates ACTIONS_ID_TOKEN_REQUEST_{TOKEN,URL},
+    # which publish-in-sif.sh uses to mint the OIDC JWT. Keep it.
     permissions:
       id-token: write
     steps:
+      # Need the repo checked out so .github/ci/exec-in-sif.sh +
+      # publish-in-sif.sh are on disk (the build job uploaded only dist/).
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      # Manual OIDC trusted publishing INSIDE the SIF — pypa/gh-action-pypi-
+      # publish is a Docker action and the Spartan compute nodes have no Docker.
+      # publish-in-sif.sh: GitHub OIDC JWT (audience=pypi) → PyPI mint-token →
+      # twine upload dist/*. apptainer exec (no --cleanenv) passes the
+      # ACTIONS_ID_TOKEN_REQUEST_* env vars into the SIF. fail-loud at each step.
+      - name: Publish to PyPI via manual OIDC trusted publishing in the SIF
+        run: bash .github/ci/exec-in-sif.sh publish-in-sif.sh 3.12
 
   release:
     needs: [build, publish]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.2] - 2026-06-25
+
+### Performance
+- **`import figrecipe` no longer pays the `.env` walk-up cost up front
+  (audit-cli §10).** The eager `scitex_config` import + `load_dotenv(walk_up=True)`
+  is deferred to first public-API use: importing `scitex_config` pulls in
+  `importlib.metadata`, and the parent-dir `.env` walk does many filesystem stat
+  calls that, on a network filesystem (Spartan gpfs), dominate import startup and
+  tripped the §10 import-speed audit. A bare `import figrecipe` that never touches
+  the public API now performs no `.env` walk; any real use loads it once before
+  the first API call. **Behavior note:** `.env` is loaded on first figrecipe API
+  use rather than at `import figrecipe` time.
+
+### Note
+- Also carries the 0.29.1 colorbar round-trip fix below, which never reached PyPI
+  (its release run was blocked by this same §10 audit gate).
+
 ## [0.29.1] - 2026-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.4] - 2026-06-27
+
+### Added
+- **Caption validation FR-CAP-001: `\footnote` in a caption now errors loud.**
+  figrecipe owns captions canonically, so it rejects caption text containing the
+  `\footnote` command (and the `\footnotemark`/`\footnotetext` family) — which
+  breaks LaTeX in spanning floats (`figure*`): `\caption@ydblarg` "extra }" + a
+  runaway `\@xfootnote`. Checked at input (`add_figure_caption`, `compose`
+  `caption=`/`panel_captions=`) and at the save/`.tex`-emit output (naming the
+  file + which caption/panel). Raises `figrecipe._captions.FootnoteInCaptionError`
+  (a `ValueError`). Inline the footnote text into the caption instead. This is
+  figrecipe's own independent rule (scitex-writer enforces its own on the
+  manuscript-LaTeX side).
+
 ## [0.29.3] - 2026-06-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.1] - 2026-06-25
+
+### Fixed
+- **Manual `plt.colorbar`/`fig.colorbar` calls now survive the recipe
+  round-trip.** Colorbars added via the manual matplotlib API (rather than
+  figrecipe's wrappers) were not recorded, so `reproduce` dropped them.
+  The recorder now captures these calls and the reproducer replays them,
+  keeping the colorbar (and its mappable spec, clim, and axes geometry)
+  faithful through record → save → reproduce.
+
 ## [0.28.20] - 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.5] - 2026-06-27
+
+### Fixed
+- **Tick record/replay faithfulness safeguards.** A pre-0.29.3 bug could
+  serialize `set_xticks` POSITIONS with a different count than the labels (e.g.
+  `[8,16,24]` written as `[0,1]`), so reproducing such a recipe raised
+  "FixedLocator locations (N) does not match the number of labels (M)" and the
+  axis rendered garbled. Current figrecipe already records ticks faithfully;
+  these are guards so it can never silently regress:
+  - **Reproduce-side heal**: loading a recipe whose tick positions/labels counts
+    diverge now truncates/pins to the common length and WARNS loudly instead of
+    hard-failing — legacy recipes render rather than crash.
+  - **Record-time fail-loud guard** (`FR-FAITHFUL-TICKS`): a `set_xticks`/
+    `set_yticks` op whose serialized positions count != labels count raises at
+    save, so a mismatched (unreproducible) recipe is never shipped.
+  - Regression tests lock faithful `set_xticks([8,16,24], labels=...)` round-trip.
+
 ## [0.29.4] - 2026-06-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.3] - 2026-06-26
+
+### Added
+- **Composed figures now carry their source panels' captions forward.**
+  `compose()` pulls each source panel's own `record.caption`, prefixes its
+  `(A)/(B)/...` label, and assembles them into the composed figure's
+  `figure.panel_captions` when the caller passes no explicit `panel_captions`
+  (grid mode always; mm/tiled when each source contributes one axes). Closes
+  the gap where composed figures silently dropped panel captions — the same
+  defect class as the composed-colorbar drop. Caller-supplied `panel_captions`
+  still take precedence.
+- **Writer-compatible caption-only `.tex` sidecar.** Saving a recipe that
+  carries caption text now emits `<stem>.tex` next to the `.png`/`.yaml`,
+  derived from the canonical `record.caption` (+ folded per-panel captions).
+  It is a bare `\caption{...}\label{fig:<stem>}` fragment with NO
+  `\begin{figure}` wrapper, so it `\input`s directly inside a manuscript's own
+  float without nesting figure environments. New `format_caption_only_tex()`.
+- **Manuscript mode** (`fr.set_manuscript_mode()`, `fr.manuscript_mode()`
+  context manager, or `FIGRECIPE_MANUSCRIPT_MODE=1`). When active, captions are
+  recorded canonically (`metadata.caption`) and the `.tex` sidecar is still
+  emitted, but the caption is NOT drawn onto the canvas — so a manuscript build
+  doesn't double-render the caption (baked pixels + LaTeX `\caption`).
+
 ## [0.29.2] - 2026-06-25
 
 ### Performance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.0"
+version = "0.29.1"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.2"
+version = "0.29.3"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.4"
+version = "0.29.5"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.3"
+version = "0.29.4"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.1"
+version = "0.29.2"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -8,24 +8,39 @@ from __future__ import annotations
 from pathlib import Path as _Path
 
 # Best-effort .env loading: walk parent dirs from cwd up to $HOME, loading
-# every .env found (closest wins). Imported lazily and tolerantly so that a
-# missing/broken scitex-config never breaks `import figrecipe`.
-try:
-    from scitex_config import load_dotenv as _load_dotenv
+# every .env found (closest wins). DEFERRED to first public-attribute access
+# (see _ensure_env_loaded / __getattr__) rather than run at import: importing
+# scitex_config pulls in importlib.metadata and the walk_up does many filesystem
+# stat calls, which on a network filesystem (e.g. Spartan gpfs) dominate
+# `import figrecipe` startup and trip audit-cli §10. A bare `import figrecipe`
+# that never touches the public API pays none of this; any real use loads it
+# once before the first API call.
+_env_loaded = False
 
-    _load_dotenv(walk_up=True, stop_at=str(_Path.home()))
-except Exception:
-    pass
+
+def _ensure_env_loaded() -> None:
+    """Load .env files once, on first public-API use (best-effort, tolerant)."""
+    global _env_loaded
+    if _env_loaded:
+        return
+    _env_loaded = True
+    try:
+        from scitex_config import load_dotenv as _load_dotenv
+
+        _load_dotenv(walk_up=True, stop_at=str(_Path.home()))
+    except Exception:
+        pass
+
 
 from ._branding import BRAND_NAME as _BRAND_NAME
 from ._branding import rebrand_text as _rebrand_text
-from ._qr import add_qr_to_figure
 
 # Register sys.modules aliases for modules moved by #141 (figrecipe._quality
 # topical refactor) so legacy `from figrecipe._validator import X` style
 # imports keep working with a single-fire DeprecationWarning pointing at the
 # new path. See figrecipe._compat for details.
 from ._compat import install_module_aliases as _install_module_aliases
+from ._qr import add_qr_to_figure
 
 _install_module_aliases()
 del _install_module_aliases
@@ -209,6 +224,8 @@ def __getattr__(name: str):
     if name in _LAZY_ATTRS:
         import importlib
 
+        # Best-effort .env load on first real use (deferred from import).
+        _ensure_env_loaded()
         # Patch on first matplotlib-touching access — see _patch_pyplot_close.
         _patch_pyplot_close()
         module_path, attr = _LAZY_ATTRS[name]
@@ -219,6 +236,7 @@ def __getattr__(name: str):
     if name in _MODULE_ALIASES:
         import importlib
 
+        _ensure_env_loaded()
         value = importlib.import_module(_MODULE_ALIASES[name], __name__)
         globals()[name] = value
         return value
@@ -237,6 +255,7 @@ def __dir__() -> list[str]:
 # Lazy seaborn access (avoids import error if seaborn not installed)
 class _SnsModule:
     def __getattr__(self, name):
+        _ensure_env_loaded()
         from ._seaborn import get_seaborn_recorder
 
         return getattr(get_seaborn_recorder(), name)

--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -156,6 +156,9 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     # ._captions (public caption API)
     "add_figure_caption": ("._captions._public", "add_figure_caption"),
     "add_panel_captions": ("._captions._public", "add_panel_captions"),
+    "set_manuscript_mode": ("._captions._manuscript_mode", "set_manuscript_mode"),
+    "manuscript_mode": ("._captions._manuscript_mode", "manuscript_mode"),
+    "is_manuscript_mode": ("._captions._manuscript_mode", "is_manuscript_mode"),
     # ._composition
     "align_panels": ("._composition", "align_panels"),
     "align_smart": ("._composition", "align_smart"),
@@ -286,6 +289,9 @@ __all__ = [
     # Caption API
     "add_figure_caption",
     "add_panel_captions",
+    "set_manuscript_mode",
+    "manuscript_mode",
+    "is_manuscript_mode",
     "panel_label",
     # Bundle format
     "Figz",

--- a/src/figrecipe/_captions/__init__.py
+++ b/src/figrecipe/_captions/__init__.py
@@ -42,8 +42,12 @@ from ._formats import (
     format_caption_for_tex,
     format_caption_for_txt,
 )
+from ._validate import FootnoteInCaptionError, check_caption_latex_safe
 
 __all__ = [
+    # Validation (FR-CAP-001)
+    "FootnoteInCaptionError",
+    "check_caption_latex_safe",
     # Core class
     "ScientificCaption",
     "caption_manager",

--- a/src/figrecipe/_captions/_formats.py
+++ b/src/figrecipe/_captions/_formats.py
@@ -5,6 +5,7 @@
 __all__ = [
     "format_caption_for_txt",
     "format_caption_for_tex",
+    "format_caption_only_tex",
     "format_caption_for_md",
     "escape_latex",
     "create_text_figure_list",
@@ -14,7 +15,7 @@ __all__ = [
 
 import textwrap
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 def escape_latex(text: str) -> str:
@@ -136,6 +137,48 @@ def format_caption_for_tex(
     \\label{{fig:{label_slug}}}
 \\end{{figure}}
 """
+
+
+def format_caption_only_tex(
+    caption: str,
+    label_slug: Optional[str] = None,
+) -> str:
+    r"""Format a caption as a bare ``\caption{...}`` (+ optional ``\label``).
+
+    Unlike :func:`format_caption_for_tex`, this emits NO ``\begin{figure}``
+    wrapper, so the fragment can be ``\input`` directly inside a manuscript's
+    own float (e.g. scitex-writer's ``\begin{figure*}``) without nesting two
+    figure environments.
+
+    The figure NUMBER is intentionally never injected: LaTeX numbers the float
+    where the fragment is included, so a hardcoded ``Figure N.`` here would
+    fight the manuscript's own numbering. The caption text is emitted verbatim
+    (LaTeX-escaped); any bold lead-in is the caption author's responsibility.
+
+    Parameters
+    ----------
+    caption : str
+        Caption text (already assembled; for composed figures this is the
+        figure-level caption with per-panel ``(A) ...`` lines folded in).
+    label_slug : str, optional
+        When given, append ``\label{fig:<slug>}`` (typically the recipe stem),
+        so a standalone fragment can ``\ref{fig:<stem>}``. When ``None`` (the
+        manuscript-symlink path), the ``\label`` is OMITTED so the consumer
+        (scitex-writer) can deterministically auto-label by the SYMLINK
+        filename stem — a hardcoded label would otherwise win and break
+        ``\ref{fig:<filename-stem>}``.
+
+    Returns
+    -------
+    str
+        ``"\\caption{...}\n"`` and, when ``label_slug`` is set, a following
+        ``"\\label{fig:<slug>}\n"``.
+    """
+    tex_caption = escape_latex(caption)
+    out = f"\\caption{{{tex_caption}}}\n"
+    if label_slug:
+        out += f"\\label{{fig:{label_slug}}}\n"
+    return out
 
 
 def format_caption_for_md(

--- a/src/figrecipe/_captions/_manuscript_mode.py
+++ b/src/figrecipe/_captions/_manuscript_mode.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Manuscript mode: keep captions canonical, suppress the on-canvas copy.
+
+In a manuscript build the figure caption is typeset by LaTeX (from the emitted
+``<stem>.tex`` sidecar), so baking the caption onto the PNG would double-render
+it (pixels + ``\\caption``). Manuscript mode makes ``add_figure_caption`` /
+compose record the caption in the recipe (``metadata.caption`` /
+``figure.panel_captions``) and emit the ``.tex`` sidecar, but NOT draw the
+caption onto the canvas (and not record it as a replayed ``figure_texts``
+entry). The drawn copy and the ``.tex`` are derived views; the YAML stays the
+single source of truth.
+
+Toggle via :func:`set_manuscript_mode`, the :func:`manuscript_mode` context
+manager, or the ``FIGRECIPE_MANUSCRIPT_MODE`` environment variable.
+"""
+
+import os
+from contextlib import contextmanager
+
+__all__ = ["set_manuscript_mode", "is_manuscript_mode", "manuscript_mode"]
+
+_MANUSCRIPT_MODE = False
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def set_manuscript_mode(on: bool = True) -> None:
+    """Enable/disable manuscript mode process-wide."""
+    global _MANUSCRIPT_MODE
+    _MANUSCRIPT_MODE = bool(on)
+
+
+def is_manuscript_mode() -> bool:
+    """True when manuscript mode is active (explicit flag OR env var)."""
+    if _MANUSCRIPT_MODE:
+        return True
+    return os.environ.get("FIGRECIPE_MANUSCRIPT_MODE", "").strip().lower() in _TRUTHY
+
+
+@contextmanager
+def manuscript_mode(on: bool = True):
+    """Context manager that sets manuscript mode for the enclosed block."""
+    global _MANUSCRIPT_MODE
+    prev = _MANUSCRIPT_MODE
+    _MANUSCRIPT_MODE = bool(on)
+    try:
+        yield
+    finally:
+        _MANUSCRIPT_MODE = prev

--- a/src/figrecipe/_captions/_public.py
+++ b/src/figrecipe/_captions/_public.py
@@ -68,6 +68,11 @@ def add_figure_caption(
     str
         The rendered caption text (Markdown-stripped).
     """
+    # Fail loud on caption content that breaks downstream LaTeX (FR-CAP-001).
+    from ._validate import check_caption_latex_safe
+
+    check_caption_latex_safe(caption, "the figure caption")
+
     # Resolve the underlying matplotlib Figure (RecordingFigure wraps it).
     mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
 

--- a/src/figrecipe/_captions/_public.py
+++ b/src/figrecipe/_captions/_public.py
@@ -71,6 +71,30 @@ def add_figure_caption(
     # Resolve the underlying matplotlib Figure (RecordingFigure wraps it).
     mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
 
+    # Manuscript mode: record the caption (canonical YAML + numbering/sidecar)
+    # but do NOT reserve canvas space or draw it — LaTeX typesets the caption
+    # from the emitted .tex sidecar, so baking it onto the PNG would double-
+    # render. The image stays clean; the drawn copy is a derived view.
+    from ._manuscript_mode import is_manuscript_mode
+
+    if is_manuscript_mode():
+        if hasattr(fig, "record"):
+            fig.record.caption = caption
+        caption_manager.add_figure_caption(
+            fig,
+            caption,
+            figure_label=figure_label,
+            style=style,
+            position=position,
+            width_ratio=width_ratio,
+            font_size=font_size,
+            wrap_width=wrap_width,
+            save_to_file=save_to_file,
+            file_path=file_path,
+            render=False,
+        )
+        return _strip_markdown(caption)
+
     # Reserve room for the caption BEFORE rendering, by adjusting axes
     # positions when they encroach on the caption strip.  The previous
     # implementation called ``mpl_fig.subplots_adjust(bottom=0.15)`` and

--- a/src/figrecipe/_captions/_validate.py
+++ b/src/figrecipe/_captions/_validate.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+r"""Caption content validation — figrecipe's own (independent) rules.
+
+figrecipe owns figure captions canonically (``metadata.caption`` /
+``figure.panel_captions`` in the recipe YAML, plus the caption-only ``<stem>.tex``
+it emits). These checks fail LOUD on caption text that is known to break
+downstream LaTeX, so the problem is caught at figure-build/save time rather than
+at manuscript-compile time.
+
+This rule is INTENTIONALLY independent of scitex-writer's equivalent
+manuscript-side rule — each tool owns and enforces its own copy.
+
+Rule FR-CAP-001 — no ``\footnote`` in captions:
+    ``\footnote`` (and the ``\footnotemark``/``\footnotetext`` family) inside a
+    figure caption breaks LaTeX in spanning floats (``figure*``): the ``\caption``
+    argument is read in a context where ``\footnote`` triggers
+    ``\caption@ydblarg`` "Argument ... has an extra }" and a runaway
+    ``\@xfootnote``. Inline the footnote text into the caption instead.
+"""
+
+from typing import Optional
+
+__all__ = ["FootnoteInCaptionError", "check_caption_latex_safe"]
+
+# The LaTeX command (with backslash). Matching this substring also catches
+# \footnotemark / \footnotetext, which are equally unwelcome in a caption.
+_FOOTNOTE_TOKEN = "\\footnote"
+
+
+class FootnoteInCaptionError(ValueError):
+    """Raised when a figure caption contains a ``\\footnote`` command."""
+
+
+def check_caption_latex_safe(text: Optional[str], where: str) -> None:
+    r"""Raise :class:`FootnoteInCaptionError` if *text* contains ``\footnote``.
+
+    Parameters
+    ----------
+    text : str or None
+        Caption text to check. ``None``/empty is allowed (no-op).
+    where : str
+        Human description of the caption's origin, surfaced in the error so the
+        caller knows exactly which caption/panel (and file) is offending —
+        e.g. ``"the figure caption"`` or ``"the panel B caption of fig01.yaml"``.
+    """
+    if not text:
+        return
+    if _FOOTNOTE_TOKEN in str(text):
+        raise FootnoteInCaptionError(
+            f"figrecipe [FR-CAP-001]: \\footnote is not allowed in {where}. "
+            r"\footnote inside a figure caption breaks LaTeX in spanning floats "
+            r"(figure*): it triggers \caption@ydblarg 'extra }' and a runaway "
+            r"\@xfootnote. Inline the footnote text into the caption instead."
+        )

--- a/src/figrecipe/_composition/_caption_carry.py
+++ b/src/figrecipe/_composition/_caption_carry.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Carry per-source panel captions forward into a composed figure.
+
+When ``compose()`` is called without explicit ``panel_captions``, each source
+panel's own ``record.caption`` should become its ``(A)/(B)/...`` entry on the
+composed figure — otherwise composed figures silently drop panel captions (the
+same gap class as composed colorbars). These helpers assemble that list from
+the per-source captions collected during composition.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+__all__ = ["auto_panel_captions_grid", "auto_panel_captions_seq"]
+
+
+def _nonempty(cap: Optional[str]) -> bool:
+    return bool(cap and str(cap).strip())
+
+
+def auto_panel_captions_grid(
+    source_captions: Dict[Tuple[int, int], Optional[str]],
+    nrows: int,
+    ncols: int,
+) -> Optional[List[str]]:
+    """Build a row-major panel-caption list from per-source captions.
+
+    Index ``row * ncols + col`` matches the flattened (row-major) axes order
+    that ``render_compose_captions`` iterates, so each cell's caption lands on
+    the right panel. Missing/empty cells become ``""`` (rendered as a no-op).
+    Returns ``None`` when no source carried a caption, leaving compose's
+    caption rendering a no-op exactly as before.
+    """
+    if not any(_nonempty(c) for c in source_captions.values()):
+        return None
+    out: List[str] = []
+    for row in range(nrows):
+        for col in range(ncols):
+            cap = source_captions.get((row, col))
+            out.append(str(cap).strip() if _nonempty(cap) else "")
+    return out
+
+
+def auto_panel_captions_seq(
+    captions: List[Optional[str]],
+    axis_counts: List[int],
+) -> Optional[List[str]]:
+    """Build a panel-caption list for sequential (mm/tiled) composition.
+
+    Only safe when every source contributed exactly one axes — otherwise the
+    one-caption-per-source mapping can't align with the per-axes label order,
+    so we decline (return ``None``) and leave it to the caller. Returns
+    ``None`` when no source carried a caption.
+    """
+    if any(n != 1 for n in axis_counts):
+        return None
+    if not any(_nonempty(c) for c in captions):
+        return None
+    return [str(c).strip() if _nonempty(c) else "" for c in captions]

--- a/src/figrecipe/_composition/_caption_render.py
+++ b/src/figrecipe/_composition/_caption_render.py
@@ -49,20 +49,31 @@ def render_compose_captions(
     flat = _flatten_axes(axes)
     mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
 
-    # Persist in record for round-trip
+    # Persist in record for round-trip (canonical — kept even in manuscript
+    # mode; only the on-canvas DRAW is suppressed below).
     if caption is not None:
         fig.record.caption = caption
     if panel_captions:
         fig.record.figure_panel_captions = panel_captions
 
+    from .._captions._manuscript_mode import is_manuscript_mode
+
+    _manuscript = is_manuscript_mode()
+
     # --- Per-panel captions: render label + text above each panel ---
-    if panel_captions:
+    # Suppressed in manuscript mode (LaTeX typesets them from the .tex sidecar).
+    if panel_captions and not _manuscript:
         import string
 
         n = len(flat)
         labels = list(string.ascii_uppercase[:n])
 
         for i, (ax, label, cap_text) in enumerate(zip(flat, labels, panel_captions)):
+            # Skip panels with no caption text so auto-assembled lists with
+            # gaps (some sources carry a caption, some don't) don't draw a
+            # bare "(C)" label with nothing after it.
+            if not (cap_text and str(cap_text).strip()):
+                continue
             raw = ax._ax if hasattr(ax, "_ax") else ax
             pos = raw.get_position()
             x_center = pos.x0 + pos.width / 2.0

--- a/src/figrecipe/_composition/_caption_render.py
+++ b/src/figrecipe/_composition/_caption_render.py
@@ -49,6 +49,13 @@ def render_compose_captions(
     flat = _flatten_axes(axes)
     mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
 
+    # Fail loud on caption content that breaks downstream LaTeX (FR-CAP-001).
+    from .._captions._validate import check_caption_latex_safe
+
+    check_caption_latex_safe(caption, "the composed figure caption")
+    for i, cap in enumerate(panel_captions or []):
+        check_caption_latex_safe(cap, f"the panel {chr(ord('A') + i)} caption")
+
     # Persist in record for round-trip (canonical — kept even in manuscript
     # mode; only the on-canvas DRAW is suppressed below).
     if caption is not None:

--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -17,6 +17,7 @@ from numpy.typing import NDArray
 
 from .._utils._grid import grid_id, parse_grid_id
 from .._wrappers import RecordingAxes, RecordingFigure
+from ._caption_carry import auto_panel_captions_grid, auto_panel_captions_seq
 from ._crop_aware import _apply_source_style, panel_rel_bbox, replay_panel_suptitle
 from ._panel_labels import (
     _add_panel_labels_grid,
@@ -249,9 +250,14 @@ def _compose_grid_based(
     fig, axes = subplots(nrows=nrows, ncols=ncols, panel_labels=False, **kwargs)
 
     source_data_dirs = {}
+    # Collect each source panel's own caption so compose can carry them forward
+    # into the composed figure (see _auto_panel_captions below). Keyed by grid
+    # position so the assembled list lines up with the row-major axes order.
+    source_captions: Dict[Tuple[int, int], Optional[str]] = {}
 
     for (row, col), source_spec in sources.items():
         source_record, ax_key, source_path = _parse_source_spec_with_path(source_spec)
+        source_captions[(row, col)] = getattr(source_record, "caption", None)
         # Accept either "rRcC" or legacy "ax_R_C" regardless of which form the
         # source record uses for its keys.
         ax_record = source_record.axes.get(ax_key)
@@ -296,6 +302,13 @@ def _compose_grid_based(
     # Add panel labels if requested
     if panel_labels:
         _add_panel_labels_grid(axes, nrows, ncols, label_style)
+
+    # Carry source panel captions forward when the caller didn't pass any:
+    # each panel's own record.caption becomes its (A)/(B)/... entry. Without
+    # this the composed figure silently drops panel captions (same gap class
+    # as composed colorbars).
+    if panel_captions is None:
+        panel_captions = auto_panel_captions_grid(source_captions, nrows, ncols)
 
     # Render caption and panel captions
     render_compose_captions(fig, axes, caption, panel_captions)
@@ -344,6 +357,9 @@ def _compose_mm_based(
 
     axes_list = []
     source_data_dirs = {}
+    # Per-source captions + axes-counts for caption carry-forward (see below).
+    mm_source_captions: List[Optional[str]] = []
+    mm_axis_counts: List[int] = []
 
     sub_idx = 0  # global counter for ax_mm_* keys across all panels + subplots
     for source_path, spec in sources.items():
@@ -386,6 +402,9 @@ def _compose_mm_based(
             selected = dict(source_record.axes)
             if not selected:
                 raise ValueError(f"Source '{source_path}' has no axes to compose.")
+
+        mm_source_captions.append(getattr(source_record, "caption", None))
+        mm_axis_counts.append(len(selected))
 
         data_dir = None
         if path is not None:
@@ -446,6 +465,11 @@ def _compose_mm_based(
 
     if panel_labels:
         _add_panel_labels_mm(mpl_fig, sources, canvas_size_mm, label_style)
+
+    # Carry source panel captions forward when the caller didn't pass any
+    # (only when each source contributed exactly one axes — see helper).
+    if panel_captions is None:
+        panel_captions = auto_panel_captions_seq(mm_source_captions, mm_axis_counts)
 
     # Render caption and panel captions for mm-based
     render_compose_captions(fig, axes_list, caption, panel_captions)

--- a/src/figrecipe/_reproducer/_colorbars.py
+++ b/src/figrecipe/_reproducer/_colorbars.py
@@ -62,6 +62,33 @@ def _find_mappable(record, ax_key, result_cache):
     return None
 
 
+def _rebuild_standalone_mappable(spec):
+    """Rebuild a standalone ScalarMappable from a recorded ``mappable_spec``.
+
+    Used when a manual colorbar was created over a standalone
+    ``cm.ScalarMappable(cmap=, norm=)`` (no source plot call to recover it from
+    -- the NeuroVista shared-comodulogram pattern). ``spec`` carries ``cmap`` and
+    optionally ``vmin``/``vmax``. Returns the mappable (with ``set_array([])`` so
+    it is colorbar-ready) or ``None`` on any failure.
+    """
+    if not spec:
+        return None
+    try:
+        from matplotlib import cm
+        from matplotlib.colors import Normalize
+
+        norm = None
+        vmin = spec.get("vmin")
+        vmax = spec.get("vmax")
+        if vmin is not None and vmax is not None:
+            norm = Normalize(vmin=vmin, vmax=vmax)
+        sm = cm.ScalarMappable(cmap=spec.get("cmap"), norm=norm)
+        sm.set_array([])
+        return sm
+    except Exception:
+        return None
+
+
 def _pin_source_axes(record, axes_2d, ax_keys):
     """Pin each source axes to its recorded (settled) position.
 
@@ -122,15 +149,24 @@ def _replay_colorbars(fig, axes_2d, record, result_cache):
         kwargs = dict(cbar_info.get("kwargs", {}))
         cax_bbox = cbar_info.get("cax_bbox")
 
-        if ax_key is None:
-            continue
-
-        parsed = parse_grid_id(ax_key)
-        if parsed is None:
-            continue
-
-        mappable = _find_mappable(record, ax_key, result_cache)
+        # Resolve the mappable. Prefer the one recorded on a source panel's plot
+        # call; fall back to rebuilding a STANDALONE ScalarMappable from its
+        # recorded ``mappable_spec`` (a manual colorbar over a freestanding
+        # ``cm.ScalarMappable`` -- no plot call to recover it from).
+        parsed = parse_grid_id(ax_key) if ax_key is not None else None
+        mappable = (
+            _find_mappable(record, ax_key, result_cache) if parsed is not None else None
+        )
         if mappable is None:
+            mappable = _rebuild_standalone_mappable(cbar_info.get("mappable_spec"))
+        if mappable is None:
+            continue
+
+        # A rebuilt standalone mappable has no source panel to steal from, so it
+        # can only be placed via the captured ``cax_bbox``. Without it there is
+        # no faithful position -> skip (matches the pre-fix drop, but now only
+        # when geometry is genuinely unavailable).
+        if parsed is None and (cax_bbox is None or len(cax_bbox) != 4):
             continue
 
         if cax_bbox is not None and len(cax_bbox) == 4:
@@ -147,7 +183,12 @@ def _replay_colorbars(fig, axes_2d, record, result_cache):
             # ink (a SIZE/MSE mismatch). The recorded ``cax_bbox`` (geometry),
             # ``cax_ticks`` (labels) and the replayed rcParams already reproduce
             # the colorbar's appearance exactly.
-            ax_keys = cbar_info.get("ax_keys") or [ax_key]
+            # Steal-set: the panels a shared colorbar shrank, to re-pin. Drop
+            # ``None`` so a standalone-mappable colorbar (no source panel, only a
+            # pinned cax) yields an empty set -- nothing to pin or freeze.
+            ax_keys = [
+                k for k in (cbar_info.get("ax_keys") or [ax_key]) if k is not None
+            ]
             _pin_source_axes(record, axes_2d, ax_keys)
             cax = fig.add_axes(cax_bbox)
             pinned_kwargs = {

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -482,6 +482,17 @@ def _replay_call(
         if "color" in kwargs and "edgecolor" in kwargs:
             kwargs["facecolor"] = kwargs.pop("color")
 
+    # Heal legacy recipes whose tick positions/labels counts diverge (warn loud).
+    if method_name in (
+        "set_xticks",
+        "set_yticks",
+        "set_xticklabels",
+        "set_yticklabels",
+    ):
+        from ._tick_heal import heal_tick_call
+
+        args, kwargs = heal_tick_call(ax, method_name, args, kwargs)
+
     # Call the method
     try:
         return method(*args, **kwargs)

--- a/src/figrecipe/_reproducer/_tick_heal.py
+++ b/src/figrecipe/_reproducer/_tick_heal.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+r"""Heal legacy mismatched tick recipes on reproduce.
+
+figrecipe < 0.29.4 could serialize tick POSITIONS with a different count than
+the labels (e.g. positions ``[0, 1]`` vs labels ``['8','16','24']``), so on
+replay matplotlib raises "The number of FixedLocator locations (N) ... does not
+match the number of labels (M)" and the axis renders garbled. These helpers
+truncate/pin to the common length and WARN loudly instead of hard-failing.
+
+This is a heal for ALREADY-SAVED recipes — current figrecipe records ticks
+faithfully (positions paired with labels). Re-save a recipe with a current
+figrecipe for a faithful round-trip.
+"""
+
+import warnings
+from typing import Any, Dict, Tuple
+
+
+def heal_tick_call(
+    ax: Any, method_name: str, args: Tuple, kwargs: Dict[str, Any]
+) -> Tuple[Tuple, Dict[str, Any]]:
+    """Return (args, kwargs) with tick positions/labels reconciled in length."""
+    if method_name in ("set_xticks", "set_yticks") and "labels" in kwargs:
+        pos = args[0] if args else None
+        labels = kwargs.get("labels")
+        if pos is not None and labels is not None and len(pos) != len(labels):
+            n = min(len(pos), len(labels))
+            warnings.warn(
+                f"figrecipe: healing {method_name} on load: positions "
+                f"({len(pos)}) != labels ({len(labels)}) in this recipe; "
+                f"truncating both to {n}. Re-save with a current figrecipe "
+                f"for a faithful round-trip."
+            )
+            args = (list(pos)[:n],) + tuple(args[1:])
+            kwargs = {**kwargs, "labels": list(labels)[:n]}
+    elif method_name in ("set_xticklabels", "set_yticklabels") and args:
+        labels = args[0]
+        axis = method_name[4]  # 'x' or 'y'
+        cur = list(getattr(ax, f"get_{axis}ticks")())
+        if labels is not None and len(labels) != len(cur):
+            warnings.warn(
+                f"figrecipe: healing {method_name} on load: labels "
+                f"({len(labels)}) != current tick positions ({len(cur)}); "
+                f"pinning positions to match. Re-save with a current figrecipe "
+                f"for fidelity."
+            )
+            getattr(ax, f"set_{axis}ticks")(cur)
+            args = (list(labels)[: len(cur)],) + tuple(args[1:])
+    return args, kwargs

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -69,6 +69,10 @@ def save_recipe(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    # Fail loud (with file + which caption/panel) on caption content that breaks
+    # downstream LaTeX (FR-CAP-001) -- the authoritative output-side check.
+    _validate_record_captions(record, path)
+
     # Create data directory for large arrays (only for separate format)
     data_dir = path.parent / f"{path.stem}_data"
 
@@ -160,6 +164,21 @@ def save_recipe(
     # panels: compose later record_inputs these recipes -> clew links sessions.
     record_output(path)
     return path
+
+
+def _validate_record_captions(record: FigureRecord, path: Path) -> None:
+    """Fail loud on caption content that breaks LaTeX (FR-CAP-001), naming the
+    file + which caption/panel offends."""
+    from .._captions._validate import check_caption_latex_safe
+
+    check_caption_latex_safe(
+        getattr(record, "caption", None), f"the figure caption of {path.name}"
+    )
+    panel_caps = getattr(record, "figure_panel_captions", None) or []
+    for i, cap in enumerate(panel_caps):
+        check_caption_latex_safe(
+            cap, f"the panel {chr(ord('A') + i)} caption of {path.name}"
+        )
 
 
 def _assemble_caption_text(record: FigureRecord) -> str:

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -35,6 +35,34 @@ def _panel_prefix(ax_key: str, nrows, ncols) -> str:
     return f"{label}_" if label else ""
 
 
+def _assert_tick_call_faithful(call: Dict[str, Any]) -> None:
+    """Record-time faithfulness guard (FR-FAITHFUL-TICKS): a set_xticks/set_yticks
+    op must carry as many tick POSITIONS as LABELS, else the recipe can't
+    round-trip (replay raises "FixedLocator locations != labels"). Fail loud at
+    save rather than ship a silently-unreproducible recipe."""
+    if call.get("function") not in ("set_xticks", "set_yticks"):
+        return
+    labels = call.get("kwargs", {}).get("labels")
+    args = call.get("args", [])
+    if labels is None or not args:
+        return
+    pos = args[0]
+    if isinstance(pos, dict) and "_array" in pos:
+        n_pos = len(pos["_array"])
+    elif isinstance(pos, dict) and isinstance(pos.get("data"), list):
+        n_pos = len(pos["data"])
+    else:
+        return  # positions length not determinable here; skip
+    if n_pos != len(labels):
+        raise ValueError(
+            f"figrecipe [FR-FAITHFUL-TICKS]: {call.get('function')} recorded "
+            f"{n_pos} tick positions but {len(labels)} labels (call "
+            f"{call.get('id')}). This recipe would not round-trip (replay would "
+            f"raise FixedLocator count != labels) -- indicates a recording/"
+            f"serialization bug. Not shipping a mismatched recipe."
+        )
+
+
 def save_recipe(
     record: FigureRecord,
     path: Union[str, Path],
@@ -279,6 +307,7 @@ def _process_arrays_with_symlinks(
             for call in call_list:
                 call_id = call.get("id", "unknown")
                 safe_call_id = _sanitize_filename(call_id)
+                _assert_tick_call_faithful(call)
 
                 for i, arg in enumerate(call.get("args", [])):
                     source_file_path = arg.pop("_source_file", None)

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -150,11 +150,58 @@ def save_recipe(
         raise
     os.replace(tmp_name, path)
 
+    # Emit a writer-compatible caption-only .tex sidecar next to the recipe
+    # (loose-coupling seam: scitex-writer reads the file, never imports
+    # figrecipe). Only when the recipe actually carries caption text.
+    _emit_caption_sidecar(record, path)
+
     # Record the recipe as a clew output of the active session (no-op without
     # clew). This is the handle that connects a composed figure to its source
     # panels: compose later record_inputs these recipes -> clew links sessions.
     record_output(path)
     return path
+
+
+def _assemble_caption_text(record: FigureRecord) -> str:
+    """Fold the figure caption + per-panel captions into one manuscript caption.
+
+    Returns the figure-level ``record.caption`` followed by ``(A) ...`` lines
+    for each non-empty per-panel caption, in panel order — the complete text a
+    manuscript ``\\caption{...}`` wants. Empty string when there is nothing.
+    """
+    parts = []
+    if record.caption:
+        parts.append(str(record.caption).strip())
+    panel_caps = getattr(record, "figure_panel_captions", None)
+    if panel_caps:
+        for i, cap in enumerate(panel_caps):
+            if cap and str(cap).strip():
+                label = chr(ord("A") + i)
+                parts.append(f"({label}) {str(cap).strip()}")
+    return " ".join(p for p in parts if p)
+
+
+def _emit_caption_sidecar(record: FigureRecord, path: Path) -> None:
+    """Write ``<stem>.tex`` (caption-only fragment) next to the recipe, if any.
+
+    No-op when the recipe carries no caption text, so a figure without a
+    caption produces no stray sidecar.
+    """
+    text = _assemble_caption_text(record)
+    if not text:
+        return
+    from .._captions._formats import format_caption_only_tex
+    from .._captions._manuscript_mode import is_manuscript_mode
+
+    # In manuscript mode the .tex is symlinked into the manuscript under a
+    # different filename and scitex-writer auto-labels by that symlink stem;
+    # a hardcoded \label here would win and break \ref{fig:<filename-stem>}.
+    # So omit the label in manuscript mode; keep it for standalone use.
+    label_slug = None if is_manuscript_mode() else path.stem
+    tex_path = path.with_suffix(".tex")
+    tex_path.write_text(
+        format_caption_only_tex(text, label_slug=label_slug), encoding="utf-8"
+    )
 
 
 def _process_arrays_for_save(

--- a/src/figrecipe/_wrappers/_figure.py
+++ b/src/figrecipe/_wrappers/_figure.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Uni
 
 from matplotlib.figure import Figure
 
-from .._utils._grid import grid_id
 from ._axes import RecordingAxes
+from ._figure_registry import register_recording_figure
 from ._figure_text import FigureTextMixin
 
 if TYPE_CHECKING:
@@ -65,6 +65,11 @@ class RecordingFigure(FigureTextMixin):
             self._fig.canvas.mpl_connect("draw_event", self._on_draw_finalize)
         except AttributeError:
             pass  # headless / mock canvas (e.g. some test fixtures)
+
+        # Register raw-figure -> wrapper so the module-level
+        # ``figrecipe.pyplot.colorbar`` can route a manual ``plt.colorbar(...)``
+        # back through ``self.colorbar`` (recording it for round-trip).
+        register_recording_figure(self._fig, self)
 
     def _on_draw_finalize(self, event):
         """Apply figrecipe finalize hooks once per figure lifetime.
@@ -183,74 +188,17 @@ class RecordingFigure(FigureTextMixin):
 
         ``ax`` may be a single axes OR a list/array of axes (a shared colorbar
         that steals space from several panels, e.g.
-        ``fig.colorbar(im, ax=axes.ravel().tolist())``). Every source axes is
-        recorded in ``ax_keys`` so replay knows the full steal set; the colorbar's
-        resolved geometry is captured later at SAVE time (see
-        ``_capture_colorbar_geometry``) so reproduction can pin it exactly.
+        ``fig.colorbar(im, ax=axes.ravel().tolist())``). An explicit
+        ``cax=<axes>`` (the colorbar is drawn into a caller-provided axes) and a
+        standalone ``ScalarMappable`` are also handled. Every source axes is
+        recorded in ``ax_keys``; the colorbar's resolved geometry is captured
+        later at SAVE time (see ``_capture_colorbar_geometry``) so reproduction
+        can pin it exactly. Recording logic lives in ``_figure_colorbar`` to keep
+        this module within the per-file line budget.
         """
-        # Normalize ``ax`` to a flat list of raw matplotlib axes, unwrapping any
-        # RecordingAxes. Build the matching grid keys in the same order.
-        if isinstance(ax, (list, tuple)):
-            ax_seq = list(ax)
-        elif hasattr(ax, "ravel") and not hasattr(ax, "_ax"):
-            # numpy array of axes
-            ax_seq = list(ax.ravel())
-        elif ax is None:
-            ax_seq = []
-        else:
-            ax_seq = [ax]
+        from ._figure_colorbar import record_colorbar
 
-        mpl_axes = [getattr(a, "_ax", a) for a in ax_seq]
-
-        ax_keys: List[str] = []
-        for mpl_ax in mpl_axes:
-            for row in self._axes:
-                for rec_ax in row:
-                    if rec_ax._ax is mpl_ax:
-                        ax_keys.append(
-                            grid_id(rec_ax._position[0], rec_ax._position[1])
-                        )
-                        break
-
-        # Identify the axes that OWNS the mappable (``mappable.axes``). With a
-        # shared colorbar over a list of panels, the mappable belongs to ONE
-        # specific panel (e.g. the last ``imshow``); its clim drives the
-        # colorbar ticks. Recording this key lets replay pick the SAME mappable
-        # (hence the same clim/ticks) rather than guessing the first panel.
-        mappable_ax_key = None
-        owner_ax = getattr(mappable, "axes", None)
-        if owner_ax is not None:
-            for row in self._axes:
-                for rec_ax in row:
-                    if rec_ax._ax is owner_ax:
-                        mappable_ax_key = grid_id(
-                            rec_ax._position[0], rec_ax._position[1]
-                        )
-                        break
-
-        # First matched key locates the mappable on replay (back-compat field).
-        ax_key = mappable_ax_key or (ax_keys[0] if ax_keys else None)
-
-        ser_kw = {
-            k: v
-            for k, v in kwargs.items()
-            if isinstance(v, (str, int, float, bool, list, type(None)))
-        }
-        record = {"ax_key": ax_key, "kwargs": ser_kw}
-        if ax_keys:
-            record["ax_keys"] = ax_keys
-        if mappable_ax_key is not None:
-            record["mappable_ax_key"] = mappable_ax_key
-        self._recorder.figure_record.colorbars.append(record)
-
-        # ``fig.colorbar`` accepts a single axes or a sequence; pass the
-        # unwrapped form so matplotlib never sees a RecordingAxes wrapper.
-        cbar_ax = mpl_axes if len(mpl_axes) > 1 else (mpl_axes[0] if mpl_axes else None)
-        cbar = self._fig.colorbar(mappable, ax=cbar_ax, **kwargs)
-        # Stash the live colorbar so the save path can read its resolved cax
-        # position (index-aligned with ``colorbars``).
-        self._recorder.figure_record.live_colorbars.append(cbar)
-        return cbar
+        return record_colorbar(self, mappable, ax=ax, **kwargs)
 
     def add_panel_labels(
         self,

--- a/src/figrecipe/_wrappers/_figure_colorbar.py
+++ b/src/figrecipe/_wrappers/_figure_colorbar.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Recording logic for ``RecordingFigure.colorbar`` (manual colorbar calls).
+
+A manual ``fig.colorbar(...)`` / ``plt.colorbar(...)`` is recorded so it survives
+a recipe round-trip: the recorder appends a ``colorbars`` entry (mirroring the
+structure the AUTO path -- ``_maybe_add_colorbar`` -> ``RecordingFigure.colorbar``
+-- already writes) and stashes the live ``Colorbar`` handle in ``live_colorbars``
+so the save path can capture its resolved ``cax`` geometry
+(``_capture_colorbar_geometry``) for an exact replay.
+
+Two call forms beyond the basic ``ax=`` steal are handled here:
+
+* Explicit ``cax=<axes>`` -- the colorbar is drawn into a caller-provided axes
+  (e.g. a gridspec slot). ``cbar.ax`` IS that axes, so its settled geometry is
+  captured at save and the reproducer pins it; no steal-set is needed.
+* A STANDALONE ``ScalarMappable`` (``cm.ScalarMappable(cmap=, norm=)`` with no
+  ``.axes`` -- the NeuroVista shared-comodulogram pattern). Such a mappable is
+  NOT a recorded plot call, so replay cannot recover it from a plot result; we
+  record a ``mappable_spec`` (cmap + clim) so the reproducer can rebuild it.
+
+Extracted from ``_figure.py`` to keep that module within the per-file line
+budget while keeping the colorbar recording rules in one cohesive place.
+"""
+
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from .._utils._grid import grid_id
+
+if TYPE_CHECKING:
+    from ._figure import RecordingFigure
+
+
+def _key_for_axes(wrapped_fig: "RecordingFigure", mpl_ax) -> Optional[str]:
+    """Return the grid id of the panel whose raw axes is ``mpl_ax`` (or None)."""
+    if mpl_ax is None:
+        return None
+    for row in wrapped_fig._axes:
+        for rec_ax in row:
+            if rec_ax._ax is mpl_ax:
+                return grid_id(rec_ax._position[0], rec_ax._position[1])
+    return None
+
+
+def _mappable_spec(mappable) -> Optional[dict]:
+    """Capture cmap + clim so a STANDALONE ScalarMappable can be rebuilt on replay.
+
+    Returns ``None`` when the mappable is tied to an axes (the reproducer then
+    recovers it from that axes' recorded plot call) or when nothing useful can
+    be read. Best-effort: a partial spec (cmap only) is still enough to rebuild.
+    """
+    if getattr(mappable, "axes", None) is not None:
+        # Belongs to a panel -> replay finds it via that panel's plot call.
+        return None
+    spec: dict = {}
+    try:
+        cmap = mappable.get_cmap()
+        name = getattr(cmap, "name", None)
+        if name:
+            spec["cmap"] = name
+    except Exception:
+        pass
+    try:
+        vmin, vmax = mappable.get_clim()
+        if vmin is not None and vmax is not None:
+            spec["vmin"] = float(vmin)
+            spec["vmax"] = float(vmax)
+    except Exception:
+        pass
+    return spec or None
+
+
+def record_colorbar(wrapped_fig: "RecordingFigure", mappable, ax=None, **kwargs) -> Any:
+    """Add a colorbar to ``wrapped_fig`` and record it for reproduction.
+
+    Mirrors the colorbar entry the auto path writes so AUTO and MANUAL colorbars
+    round-trip identically. See the module docstring for the ``cax=`` and
+    standalone-``ScalarMappable`` cases.
+    """
+    # Normalize ``ax`` to a flat list of raw matplotlib axes, unwrapping any
+    # RecordingAxes. Build the matching grid keys in the same order.
+    if isinstance(ax, (list, tuple)):
+        ax_seq = list(ax)
+    elif hasattr(ax, "ravel") and not hasattr(ax, "_ax"):
+        # numpy array of axes
+        ax_seq = list(ax.ravel())
+    elif ax is None:
+        ax_seq = []
+    else:
+        ax_seq = [ax]
+
+    mpl_axes = [getattr(a, "_ax", a) for a in ax_seq]
+
+    ax_keys: List[str] = []
+    for mpl_ax in mpl_axes:
+        key = _key_for_axes(wrapped_fig, mpl_ax)
+        if key is not None:
+            ax_keys.append(key)
+
+    # Identify the axes that OWNS the mappable (``mappable.axes``). With a
+    # shared colorbar over a list of panels, the mappable belongs to ONE
+    # specific panel (e.g. the last ``imshow``); its clim drives the colorbar
+    # ticks. Recording this key lets replay pick the SAME mappable (hence the
+    # same clim/ticks) rather than guessing the first panel. A standalone
+    # ScalarMappable has no ``.axes`` -> this stays None.
+    owner_ax = getattr(mappable, "axes", None)
+    mappable_ax_key = _key_for_axes(wrapped_fig, owner_ax)
+
+    # Explicit ``cax=<axes>``: the colorbar is drawn INTO this axes (unwrap a
+    # RecordingAxes wrapper before handing it to matplotlib). Its settled
+    # geometry is captured at save from the live handle, so we only need to keep
+    # the raw axes; record its grid key too on the rare chance it IS a panel.
+    cax = kwargs.pop("cax", None)
+    cax_mpl = getattr(cax, "_ax", cax) if cax is not None else None
+    cax_key = _key_for_axes(wrapped_fig, cax_mpl)
+
+    # First matched key locates the mappable on replay (back-compat field).
+    ax_key = mappable_ax_key or (ax_keys[0] if ax_keys else None)
+
+    ser_kw = {
+        k: v
+        for k, v in kwargs.items()
+        if isinstance(v, (str, int, float, bool, list, type(None)))
+    }
+    record = {"ax_key": ax_key, "kwargs": ser_kw}
+    if ax_keys:
+        record["ax_keys"] = ax_keys
+    if mappable_ax_key is not None:
+        record["mappable_ax_key"] = mappable_ax_key
+    if cax_key is not None:
+        record["cax_key"] = cax_key
+    # Standalone mappable -> record enough to rebuild it on replay.
+    spec = _mappable_spec(mappable)
+    if spec is not None:
+        record["mappable_spec"] = spec
+    wrapped_fig._recorder.figure_record.colorbars.append(record)
+
+    # ``fig.colorbar`` accepts a single axes, a sequence, or ``cax=`` -- pass the
+    # unwrapped forms so matplotlib never sees a RecordingAxes wrapper.
+    if cax_mpl is not None:
+        cbar = wrapped_fig._fig.colorbar(mappable, cax=cax_mpl, **kwargs)
+    else:
+        cbar_ax = mpl_axes if len(mpl_axes) > 1 else (mpl_axes[0] if mpl_axes else None)
+        cbar = wrapped_fig._fig.colorbar(mappable, ax=cbar_ax, **kwargs)
+    # Stash the live colorbar so the save path can read its resolved cax
+    # position (index-aligned with ``colorbars``).
+    wrapped_fig._recorder.figure_record.live_colorbars.append(cbar)
+    return cbar
+
+
+__all__ = ["record_colorbar"]
+
+# EOF

--- a/src/figrecipe/_wrappers/_figure_registry.py
+++ b/src/figrecipe/_wrappers/_figure_registry.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Weak registry mapping raw matplotlib Figures to their RecordingFigure wrapper.
+
+The module-level ``figrecipe.pyplot.colorbar`` wrapper only ever sees the RAW
+current figure -- via ``plt.gcf()``, a mappable's axes, or an explicit ``cax``
+axes. To record a MANUAL ``plt.colorbar(...)`` call it must find the owning
+``RecordingFigure`` so the call routes through ``RecordingFigure.colorbar`` and
+lands in the recipe (surviving a recipe round-trip). This registry provides that
+raw-figure -> wrapper lookup. ``RecordingFigure.__init__`` registers itself here.
+
+Keyed by ``id(raw_fig)`` (matplotlib ``Figure`` instances are not usable as
+``WeakValueDictionary`` keys), with the wrapper held weakly so a closed/dropped
+figure does not leak.
+"""
+
+from typing import TYPE_CHECKING, Optional
+from weakref import WeakValueDictionary
+
+if TYPE_CHECKING:
+    from ._figure import RecordingFigure
+
+# id(raw matplotlib Figure) -> RecordingFigure wrapper (held weakly).
+_RAW_FIG_TO_WRAPPER: "WeakValueDictionary[int, RecordingFigure]" = WeakValueDictionary()
+
+
+def register_recording_figure(raw_fig, wrapper: "RecordingFigure") -> None:
+    """Register ``wrapper`` as the RecordingFigure for raw ``raw_fig``."""
+    if raw_fig is None:
+        return
+    try:
+        _RAW_FIG_TO_WRAPPER[id(raw_fig)] = wrapper
+    except TypeError:
+        # Some mock/headless figures are not weak-referenceable; recording
+        # via the module-level wrapper is then simply unavailable for them.
+        pass
+
+
+def get_recording_figure(raw_fig) -> Optional["RecordingFigure"]:
+    """Return the ``RecordingFigure`` wrapping ``raw_fig`` (or None)."""
+    if raw_fig is None:
+        return None
+    return _RAW_FIG_TO_WRAPPER.get(id(raw_fig))
+
+
+__all__ = ["register_recording_figure", "get_recording_figure"]
+
+# EOF

--- a/src/figrecipe/pyplot.py
+++ b/src/figrecipe/pyplot.py
@@ -44,6 +44,56 @@ from ._wrappers import RecordingFigure
 subplots = _ps_subplots
 
 
+def colorbar(mappable=None, cax=None, ax=None, **kwargs):
+    """Add a colorbar, recording it when the target figure is recording.
+
+    Drop-in for ``matplotlib.pyplot.colorbar``. A manual colorbar call on a
+    figrecipe figure (``plt.colorbar(im, cax=...)`` / ``plt.colorbar(im, ax=...)``)
+    must be recorded or it is DROPPED when the figure is rebuilt from its recipe.
+    matplotlib's ``plt.colorbar`` only ever sees the RAW current figure, so this
+    wrapper resolves the owning ``RecordingFigure`` -- from an explicit ``cax``/
+    ``ax`` axes, the mappable's axes, or ``plt.gcf()`` -- and delegates to its
+    recording ``.colorbar``. When no recording figure owns the target (plain
+    matplotlib usage), it falls back to the raw ``matplotlib.pyplot.colorbar``.
+
+    Parameters mirror ``matplotlib.pyplot.colorbar``.
+    """
+    from ._wrappers._figure_registry import get_recording_figure
+
+    def _fig_of(obj):
+        a = getattr(obj, "_ax", obj)  # unwrap RecordingAxes
+        return getattr(a, "figure", None)
+
+    # Resolve the raw figure the colorbar will be drawn on, preferring the most
+    # explicit hint, then fall back to the current figure.
+    raw_fig = None
+    for hint in (cax, ax):
+        if hint is not None and not isinstance(hint, (list, tuple)):
+            raw_fig = _fig_of(hint)
+            if raw_fig is not None:
+                break
+    if raw_fig is None and isinstance(ax, (list, tuple)) and ax:
+        raw_fig = _fig_of(ax[0])
+    if raw_fig is None and mappable is not None:
+        raw_fig = getattr(getattr(mappable, "axes", None), "figure", None)
+    if raw_fig is None:
+        raw_fig = _plt.gcf()
+
+    wrapper = get_recording_figure(raw_fig)
+    if wrapper is not None:
+        # RecordingFigure.colorbar takes ``cax`` via **kwargs.
+        if cax is not None:
+            kwargs["cax"] = cax
+        return wrapper.colorbar(mappable, ax=ax, **kwargs)
+
+    # No recording figure -> behave exactly like matplotlib.
+    if cax is not None:
+        kwargs["cax"] = cax
+    if ax is not None:
+        kwargs["ax"] = ax
+    return _plt.colorbar(mappable, **kwargs)
+
+
 def figure(*args, **kwargs):
     """Create a new figure with optional recording support.
 
@@ -129,7 +179,6 @@ hist = _plt.hist
 imshow = _plt.imshow
 contour = _plt.contour
 contourf = _plt.contourf
-colorbar = _plt.colorbar
 axhline = _plt.axhline
 axvline = _plt.axvline
 text = _plt.text

--- a/tests/figrecipe/_captions/test__formats.py
+++ b/tests/figrecipe/_captions/test__formats.py
@@ -4,7 +4,6 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-
 import pytest
 
 
@@ -13,8 +12,50 @@ def test_import__captions__formats_module():
     # Arrange
     # Act
     # Assert
-    module_path = 'figrecipe._captions._formats'
+    module_path = "figrecipe._captions._formats"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+def test_caption_only_tex_has_no_figure_environment():
+    # Arrange
+    from figrecipe._captions._formats import format_caption_only_tex
+
+    # Act
+    out = format_caption_only_tex("Two conditions (n=3).", label_slug="fig01")
+    # Assert: writer-compatible fragment must NOT open a figure float.
+    assert "\\begin{figure}" not in out
+
+
+def test_caption_only_tex_emits_caption_and_label():
+    # Arrange
+    from figrecipe._captions._formats import format_caption_only_tex
+
+    # Act
+    out = format_caption_only_tex("Latency comparison.", label_slug="fig01")
+    # Assert
+    assert "\\caption{Latency comparison.}" in out
+    assert "\\label{fig:fig01}" in out
+
+
+def test_caption_only_tex_escapes_latex_specials():
+    # Arrange
+    from figrecipe._captions._formats import format_caption_only_tex
+
+    # Act: an unescaped % would comment out the rest of the LaTeX line.
+    out = format_caption_only_tex("Throughput up 5% & stable_runs.", label_slug="f")
+    # Assert
+    assert "5\\% \\& stable\\_runs" in out
+
+
+def test_caption_only_tex_omits_label_when_slug_none():
+    # Arrange
+    from figrecipe._captions._formats import format_caption_only_tex
+
+    # Act: no slug -> no \label, so the consumer auto-labels by filename stem.
+    out = format_caption_only_tex("Some caption.", label_slug=None)
+    # Assert
+    assert "\\caption{Some caption.}" in out
+    assert "\\label" not in out

--- a/tests/figrecipe/_captions/test__formats.py
+++ b/tests/figrecipe/_captions/test__formats.py
@@ -36,8 +36,7 @@ def test_caption_only_tex_emits_caption_and_label():
     # Act
     out = format_caption_only_tex("Latency comparison.", label_slug="fig01")
     # Assert
-    assert "\\caption{Latency comparison.}" in out
-    assert "\\label{fig:fig01}" in out
+    assert out == "\\caption{Latency comparison.}\n\\label{fig:fig01}\n"
 
 
 def test_caption_only_tex_escapes_latex_specials():
@@ -56,6 +55,5 @@ def test_caption_only_tex_omits_label_when_slug_none():
 
     # Act: no slug -> no \label, so the consumer auto-labels by filename stem.
     out = format_caption_only_tex("Some caption.", label_slug=None)
-    # Assert
-    assert "\\caption{Some caption.}" in out
-    assert "\\label" not in out
+    # Assert: caption present and NO label line at all.
+    assert out == "\\caption{Some caption.}\n"

--- a/tests/figrecipe/_captions/test__manuscript_mode.py
+++ b/tests/figrecipe/_captions/test__manuscript_mode.py
@@ -1,0 +1,76 @@
+"""Tests for figrecipe._captions._manuscript_mode."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from figrecipe._captions._manuscript_mode import (
+    is_manuscript_mode,
+    manuscript_mode,
+    set_manuscript_mode,
+)
+
+
+def test_default_is_off():
+    # Arrange
+    set_manuscript_mode(False)
+    # Act / Assert
+    assert is_manuscript_mode() is False
+
+
+def test_set_toggles_on_and_off():
+    # Arrange / Act
+    set_manuscript_mode(True)
+    try:
+        # Assert
+        assert is_manuscript_mode() is True
+    finally:
+        set_manuscript_mode(False)
+
+
+def test_context_manager_restores_previous_state():
+    # Arrange
+    set_manuscript_mode(False)
+    # Act
+    with manuscript_mode():
+        inside = is_manuscript_mode()
+    # Assert
+    assert inside is True
+    assert is_manuscript_mode() is False
+
+
+def test_env_var_enables_mode(monkeypatch):
+    # Arrange
+    set_manuscript_mode(False)
+    monkeypatch.setenv("FIGRECIPE_MANUSCRIPT_MODE", "1")
+    # Act / Assert
+    assert is_manuscript_mode() is True
+
+
+def test_add_caption_in_manuscript_mode_records_but_does_not_draw():
+    # Arrange
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+    ax.plot([0, 1], [0, 1], id="line")
+    n_before = len(fig._fig.texts)
+    # Act
+    with manuscript_mode():
+        fr.add_figure_caption(fig, "Off-canvas caption.")
+    # Assert: caption recorded canonically, but no text drawn on the figure.
+    assert fig.record.caption == "Off-canvas caption."
+    assert len(fig._fig.texts) == n_before
+
+
+def test_add_caption_normally_draws_on_canvas():
+    # Arrange
+    import figrecipe as fr
+
+    set_manuscript_mode(False)
+    fig, ax = fr.subplots()
+    ax.plot([0, 1], [0, 1], id="line")
+    n_before = len(fig._fig.texts)
+    # Act
+    fr.add_figure_caption(fig, "Drawn caption.")
+    # Assert
+    assert len(fig._fig.texts) > n_before

--- a/tests/figrecipe/_captions/test__manuscript_mode.py
+++ b/tests/figrecipe/_captions/test__manuscript_mode.py
@@ -1,5 +1,7 @@
 """Tests for figrecipe._captions._manuscript_mode."""
 
+import os
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -14,18 +16,21 @@ from figrecipe._captions._manuscript_mode import (
 def test_default_is_off():
     # Arrange
     set_manuscript_mode(False)
-    # Act / Assert
-    assert is_manuscript_mode() is False
+    # Act
+    active = is_manuscript_mode()
+    # Assert
+    assert active is False
 
 
-def test_set_toggles_on_and_off():
-    # Arrange / Act
+def test_set_enables_mode():
+    # Arrange
+    set_manuscript_mode(False)
+    # Act
     set_manuscript_mode(True)
-    try:
-        # Assert
-        assert is_manuscript_mode() is True
-    finally:
-        set_manuscript_mode(False)
+    active = is_manuscript_mode()
+    set_manuscript_mode(False)
+    # Assert
+    assert active is True
 
 
 def test_context_manager_restores_previous_state():
@@ -34,17 +39,26 @@ def test_context_manager_restores_previous_state():
     # Act
     with manuscript_mode():
         inside = is_manuscript_mode()
+    after = is_manuscript_mode()
     # Assert
-    assert inside is True
-    assert is_manuscript_mode() is False
+    assert (inside, after) == (True, False)
 
 
-def test_env_var_enables_mode(monkeypatch):
+def test_env_var_enables_mode():
     # Arrange
     set_manuscript_mode(False)
-    monkeypatch.setenv("FIGRECIPE_MANUSCRIPT_MODE", "1")
-    # Act / Assert
-    assert is_manuscript_mode() is True
+    prev = os.environ.get("FIGRECIPE_MANUSCRIPT_MODE")
+    os.environ["FIGRECIPE_MANUSCRIPT_MODE"] = "1"
+    # Act
+    try:
+        active = is_manuscript_mode()
+    finally:
+        if prev is None:
+            os.environ.pop("FIGRECIPE_MANUSCRIPT_MODE", None)
+        else:
+            os.environ["FIGRECIPE_MANUSCRIPT_MODE"] = prev
+    # Assert
+    assert active is True
 
 
 def test_add_caption_in_manuscript_mode_records_but_does_not_draw():
@@ -57,9 +71,11 @@ def test_add_caption_in_manuscript_mode_records_but_does_not_draw():
     # Act
     with manuscript_mode():
         fr.add_figure_caption(fig, "Off-canvas caption.")
-    # Assert: caption recorded canonically, but no text drawn on the figure.
-    assert fig.record.caption == "Off-canvas caption."
-    assert len(fig._fig.texts) == n_before
+    # Assert
+    assert (fig.record.caption, len(fig._fig.texts)) == (
+        "Off-canvas caption.",
+        n_before,
+    )
 
 
 def test_add_caption_normally_draws_on_canvas():

--- a/tests/figrecipe/_captions/test__validate.py
+++ b/tests/figrecipe/_captions/test__validate.py
@@ -1,0 +1,91 @@
+"""Tests for figrecipe._captions._validate (FR-CAP-001: no \\footnote in captions)."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+from figrecipe._captions._validate import (
+    FootnoteInCaptionError,
+    check_caption_latex_safe,
+)
+
+
+def test_plain_caption_passes():
+    # Arrange
+    text = "Two-condition comparison (n=3)."
+    # Act
+    result = check_caption_latex_safe(text, "the figure caption")
+    # Assert
+    assert result is None
+
+
+def test_none_is_noop():
+    # Arrange
+    text = None
+    # Act
+    result = check_caption_latex_safe(text, "the figure caption")
+    # Assert
+    assert result is None
+
+
+def test_footnote_command_raises():
+    # Arrange
+    text = "Throughput\\footnote{disclosure} per condition."
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError):
+        check_caption_latex_safe(text, "the figure caption")
+
+
+def test_footnotemark_also_raises():
+    # Arrange
+    text = "See above\\footnotemark."
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError):
+        check_caption_latex_safe(text, "the figure caption")
+
+
+def test_error_names_the_location():
+    # Arrange
+    text = "Panel\\footnote{x}."
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError, match="the panel B caption"):
+        check_caption_latex_safe(text, "the panel B caption")
+
+
+def test_plain_word_footnote_is_allowed():
+    # Arrange: the English word, NOT the \footnote command, must NOT trip.
+    text = "The footnote describes the cohort."
+    # Act
+    result = check_caption_latex_safe(text, "the figure caption")
+    # Assert
+    assert result is None
+
+
+def test_add_figure_caption_rejects_footnote():
+    # Arrange
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+    ax.plot([0, 1], [0, 1], id="line")
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError):
+        fr.add_figure_caption(fig, "x\\footnote{y}")
+
+
+def test_save_rejects_footnote_naming_the_file(tmp_path):
+    # Arrange
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+    ax.plot([0, 1], [0, 1], id="line")
+    fig.record.caption = "x\\footnote{y}"
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError, match="bad.yaml"):
+        fr.save(fig, str(tmp_path / "bad.yaml"))

--- a/tests/figrecipe/_composition/test__caption_carry.py
+++ b/tests/figrecipe/_composition/test__caption_carry.py
@@ -1,0 +1,57 @@
+"""Tests for figrecipe._composition._caption_carry (panel-caption carry-forward)."""
+
+from figrecipe._composition._caption_carry import (
+    auto_panel_captions_grid,
+    auto_panel_captions_seq,
+)
+
+
+def test_grid_assembles_row_major_from_source_captions():
+    # Arrange
+    caps = {(0, 0): "A cap", (0, 1): "B cap"}
+    # Act
+    out = auto_panel_captions_grid(caps, nrows=1, ncols=2)
+    # Assert
+    assert out == ["A cap", "B cap"]
+
+
+def test_grid_fills_missing_cells_with_empty_string():
+    # Arrange: only the first cell carries a caption.
+    caps = {(0, 0): "only A", (0, 1): None}
+    # Act
+    out = auto_panel_captions_grid(caps, nrows=1, ncols=2)
+    # Assert
+    assert out == ["only A", ""]
+
+
+def test_grid_returns_none_when_no_source_has_caption():
+    # Arrange
+    caps = {(0, 0): None, (0, 1): "   "}
+    # Act
+    out = auto_panel_captions_grid(caps, nrows=1, ncols=2)
+    # Assert
+    assert out is None
+
+
+def test_seq_assembles_in_source_order_when_one_axes_each():
+    # Arrange
+    # Act
+    out = auto_panel_captions_seq(["a", "b", "c"], axis_counts=[1, 1, 1])
+    # Assert
+    assert out == ["a", "b", "c"]
+
+
+def test_seq_declines_when_any_source_has_multiple_axes():
+    # Arrange: a multi-subplot source breaks the one-caption-per-axes mapping.
+    # Act
+    out = auto_panel_captions_seq(["a", "b"], axis_counts=[1, 2])
+    # Assert
+    assert out is None
+
+
+def test_seq_returns_none_when_no_caption_present():
+    # Arrange
+    # Act
+    out = auto_panel_captions_seq([None, ""], axis_counts=[1, 1])
+    # Assert
+    assert out is None

--- a/tests/figrecipe/_reproducer/test__colorbars.py
+++ b/tests/figrecipe/_reproducer/test__colorbars.py
@@ -17,6 +17,7 @@ import matplotlib
 matplotlib.use("Agg")
 
 import numpy as np
+import pytest
 
 import figrecipe as fr
 
@@ -37,3 +38,152 @@ def test_shared_colorbar_reproduces_without_artifact(tmp_path):
     # Assert: no "-not-reproduced" artifact -> the colorbar figure reproduced.
     artifact = image_path.parent / f"{image_path.stem}-not-reproduced.png"
     assert not artifact.exists()
+
+
+def _raw_colorbar_axes(reproduced_fig):
+    """Colorbar Axes on the underlying mpl figure of a reproduced RecordingFigure."""
+    mpl_fig = getattr(reproduced_fig, "fig", reproduced_fig)
+    return [a for a in mpl_fig.axes if getattr(a, "_colorbar", None) is not None]
+
+
+@pytest.fixture
+def manual_cax_roundtrip(tmp_path):
+    """Build + save + reproduce a fig whose MANUAL ``plt.colorbar(im, cax=...)``.
+
+    Reproduces the bug where the module-level ``figrecipe.pyplot.colorbar`` was the
+    raw matplotlib function, so a manual colorbar bypassed the recorder, left ZERO
+    ``colorbars`` entries in the recipe, and was DROPPED when the figure was rebuilt.
+
+    Returns ``(fig, recipe_dict, reproduced_fig)``.
+    """
+    import yaml
+
+    import figrecipe.pyplot as plt
+
+    rng = np.random.default_rng(2)
+    fig, ax = plt.subplots(1, 1)
+    ax.imshow(rng.standard_normal((10, 10)), cmap="viridis")
+    im = ax.get_images()[0]
+    cax = fig.add_axes([0.9, 0.1, 0.03, 0.8])
+    plt.colorbar(im, cax=cax)
+
+    image_path = tmp_path / "manual_cax.png"
+    fr.save(fig, str(image_path), validate=False, verbose=False)
+    yaml_path = image_path.with_suffix(".yaml")
+    recipe = yaml.safe_load(yaml_path.read_text())
+
+    reproduced = fr.reproduce(str(yaml_path))
+    rfig = reproduced[0] if isinstance(reproduced, tuple) else reproduced
+    return fig, recipe, rfig
+
+
+def test_manual_plt_colorbar_with_cax_is_recorded(manual_cax_roundtrip):
+    # Arrange
+    fig, _recipe, _rfig = manual_cax_roundtrip
+    # Act
+    n_recorded = len(fig.record.colorbars)
+    # Assert
+    assert n_recorded == 1
+
+
+def test_manual_plt_colorbar_with_cax_serializes_to_recipe(manual_cax_roundtrip):
+    # Arrange
+    _fig, recipe, _rfig = manual_cax_roundtrip
+    # Act
+    colorbars = recipe.get("figure", {}).get("colorbars")
+    # Assert
+    assert colorbars  # used to be empty -> colorbar dropped
+
+
+def test_manual_plt_colorbar_with_cax_captures_geometry(manual_cax_roundtrip):
+    # Arrange
+    _fig, recipe, _rfig = manual_cax_roundtrip
+    # Act
+    cax_bbox = recipe["figure"]["colorbars"][0].get("cax_bbox")
+    # Assert
+    assert cax_bbox is not None
+
+
+def test_manual_plt_colorbar_with_cax_replays_colorbar_axes(manual_cax_roundtrip):
+    # Arrange
+    _fig, _recipe, rfig = manual_cax_roundtrip
+    # Act
+    n_cbar_axes = len(_raw_colorbar_axes(rfig))
+    # Assert
+    assert n_cbar_axes == 1
+
+
+@pytest.fixture
+def standalone_mappable_roundtrip(tmp_path):
+    """Build + save + reproduce a manual colorbar over a STANDALONE ScalarMappable.
+
+    The NeuroVista shared-comodulogram pattern: a freestanding
+    ``cm.ScalarMappable(cmap=, norm=)`` (no source plot call) drawn into a gridspec
+    ``cax``. The recorder captures a ``mappable_spec`` (cmap + clim) so the
+    reproducer can rebuild the mappable and re-create the colorbar.
+
+    Returns ``(fig, recipe_dict, reproduced_fig, (vmin, vmax))``.
+    """
+    import yaml
+    from matplotlib import cm
+    from matplotlib.colors import Normalize
+
+    import figrecipe.pyplot as plt
+
+    rng = np.random.default_rng(3)
+    vmin, vmax = -2.0, 3.0
+    fig, axes = plt.subplots(2, 2)
+    for ax in np.asarray(axes).ravel():
+        ax.imshow(rng.standard_normal((8, 8)), cmap="hot", vmin=vmin, vmax=vmax)
+    cax = fig.add_axes([0.92, 0.15, 0.02, 0.7])
+    sm = cm.ScalarMappable(cmap="hot", norm=Normalize(vmin=vmin, vmax=vmax))
+    sm.set_array([])
+    plt.colorbar(sm, cax=cax)
+
+    image_path = tmp_path / "manual_standalone.png"
+    fr.save(fig, str(image_path), validate=False, verbose=False)
+    yaml_path = image_path.with_suffix(".yaml")
+    recipe = yaml.safe_load(yaml_path.read_text())
+
+    reproduced = fr.reproduce(str(yaml_path))
+    rfig = reproduced[0] if isinstance(reproduced, tuple) else reproduced
+    return fig, recipe, rfig, (vmin, vmax)
+
+
+def test_standalone_mappable_records_cmap_spec(standalone_mappable_roundtrip):
+    # Arrange
+    fig, _recipe, _rfig, _clim = standalone_mappable_roundtrip
+    # Act
+    cmap = fig.record.colorbars[0].get("mappable_spec", {}).get("cmap")
+    # Assert
+    assert cmap == "hot"
+
+
+def test_standalone_mappable_serializes_clim(standalone_mappable_roundtrip):
+    # Arrange
+    _fig, recipe, _rfig, (vmin, vmax) = standalone_mappable_roundtrip
+    # Act
+    spec = recipe["figure"]["colorbars"][0]["mappable_spec"]
+    # Assert
+    assert (spec["vmin"], spec["vmax"]) == (vmin, vmax)
+
+
+def test_standalone_mappable_replays_colorbar_axes(standalone_mappable_roundtrip):
+    # Arrange
+    _fig, _recipe, rfig, _clim = standalone_mappable_roundtrip
+    # Act
+    n_cbar_axes = len(_raw_colorbar_axes(rfig))
+    # Assert
+    assert n_cbar_axes == 1
+
+
+def test_pyplot_colorbar_is_recording_wrapper():
+    # Arrange
+    import matplotlib.pyplot as _mpl_plt
+
+    import figrecipe.pyplot as plt
+
+    # Act
+    is_passthrough = plt.colorbar is _mpl_plt.colorbar
+    # Assert
+    assert not is_passthrough

--- a/tests/figrecipe/_reproducer/test__tick_heal.py
+++ b/tests/figrecipe/_reproducer/test__tick_heal.py
@@ -1,0 +1,37 @@
+"""Tests for figrecipe._reproducer._tick_heal (legacy mismatched-tick heal)."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from figrecipe._reproducer._tick_heal import heal_tick_call
+
+
+def test_set_xticks_mismatch_truncates_to_common_length():
+    # Arrange: legacy recipe with 2 positions but 3 labels.
+    args = ([0, 1],)
+    kwargs = {"labels": ["8", "16", "24"]}
+    # Act
+    new_args, new_kwargs = heal_tick_call(None, "set_xticks", args, kwargs)
+    # Assert
+    assert (len(new_args[0]), len(new_kwargs["labels"])) == (2, 2)
+
+
+def test_set_xticks_matched_counts_unchanged():
+    # Arrange
+    args = ([8, 16, 24],)
+    kwargs = {"labels": ["8", "16", "24"]}
+    # Act
+    new_args, new_kwargs = heal_tick_call(None, "set_xticks", args, kwargs)
+    # Assert
+    assert (new_args[0], new_kwargs["labels"]) == ([8, 16, 24], ["8", "16", "24"])
+
+
+def test_non_tick_method_passes_through():
+    # Arrange
+    args = ([1, 2, 3],)
+    kwargs = {"color": "red"}
+    # Act
+    new_args, new_kwargs = heal_tick_call(None, "plot", args, kwargs)
+    # Assert
+    assert (new_args, new_kwargs) == (args, kwargs)

--- a/tests/integration/test_caption_tex_sidecar.py
+++ b/tests/integration/test_caption_tex_sidecar.py
@@ -1,0 +1,90 @@
+"""End-to-end: caption-only .tex sidecar emit + composed panel-caption carry-forward.
+
+No mocks — real figures saved to ``tmp_path`` and the emitted artifacts read back.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import figrecipe as fr
+
+
+def _panel(tmp_path, name, caption):
+    fig, ax = fr.subplots()
+    ax.plot([1, 2, 3], [1, 2, 3], id="line")
+    fr.add_figure_caption(fig, caption)
+    path = str(tmp_path / name)
+    fr.save(fig, path)
+    return path
+
+
+def test_single_figure_emits_caption_only_tex_sidecar(tmp_path):
+    # Arrange / Act
+    fr.set_manuscript_mode(False)
+    _panel(tmp_path, "fig.yaml", "Latency comparison (n=3).")
+    tex_path = tmp_path / "fig.tex"
+    # Assert
+    assert tex_path.exists()
+    tex = tex_path.read_text()
+    assert "\\begin{figure}" not in tex
+    assert "\\caption{Latency comparison (n=3).}" in tex
+    assert "\\label{fig:fig}" in tex
+
+
+def test_manuscript_mode_sidecar_omits_label(tmp_path):
+    # Arrange: in manuscript mode the .tex is symlinked under another filename
+    # and scitex-writer auto-labels by that stem -> our \label must be omitted.
+    try:
+        with fr.manuscript_mode():
+            _panel(tmp_path, "ms.yaml", "Manuscript caption.")
+        tex = (tmp_path / "ms.tex").read_text()
+        # Assert
+        assert "\\caption{Manuscript caption.}" in tex
+        assert "\\label" not in tex
+    finally:
+        fr.set_manuscript_mode(False)
+
+
+def test_no_caption_emits_no_tex_sidecar(tmp_path):
+    # Arrange
+    fr.set_manuscript_mode(False)
+    fig, ax = fr.subplots()
+    ax.plot([1, 2], [1, 2], id="line")
+    # Act
+    fr.save(fig, str(tmp_path / "plain.yaml"))
+    # Assert
+    assert not (tmp_path / "plain.tex").exists()
+
+
+def test_compose_carries_source_panel_captions_into_sidecar(tmp_path):
+    # Arrange: two panels, each with its own caption, no panel_captions passed.
+    fr.set_manuscript_mode(False)
+    a = _panel(tmp_path, "a.yaml", "Throughput per condition.")
+    b = _panel(tmp_path, "b.yaml", "Error rate per condition.")
+    # Act
+    cfig, _ = fr.compose(layout=(1, 2), sources={(0, 0): a, (0, 1): b})
+    fr.save(cfig, str(tmp_path / "composed.yaml"))
+    # Assert: panel captions auto-pulled, folded into the composed .tex.
+    assert cfig.record.figure_panel_captions == [
+        "Throughput per condition.",
+        "Error rate per condition.",
+    ]
+    tex = (tmp_path / "composed.tex").read_text()
+    assert "(A) Throughput per condition." in tex
+    assert "(B) Error rate per condition." in tex
+
+
+def test_explicit_panel_captions_override_source_carry_forward(tmp_path):
+    # Arrange
+    fr.set_manuscript_mode(False)
+    a = _panel(tmp_path, "a2.yaml", "Source A caption.")
+    b = _panel(tmp_path, "b2.yaml", "Source B caption.")
+    # Act: caller passes panel_captions explicitly -> those win.
+    cfig, _ = fr.compose(
+        layout=(1, 2),
+        sources={(0, 0): a, (0, 1): b},
+        panel_captions=["Override A", "Override B"],
+    )
+    # Assert
+    assert cfig.record.figure_panel_captions == ["Override A", "Override B"]

--- a/tests/integration/test_caption_tex_sidecar.py
+++ b/tests/integration/test_caption_tex_sidecar.py
@@ -20,30 +20,28 @@ def _panel(tmp_path, name, caption):
 
 
 def test_single_figure_emits_caption_only_tex_sidecar(tmp_path):
-    # Arrange / Act
+    # Arrange
     fr.set_manuscript_mode(False)
+    # Act
     _panel(tmp_path, "fig.yaml", "Latency comparison (n=3).")
-    tex_path = tmp_path / "fig.tex"
+    tex = (tmp_path / "fig.tex").read_text()
     # Assert
-    assert tex_path.exists()
-    tex = tex_path.read_text()
-    assert "\\begin{figure}" not in tex
-    assert "\\caption{Latency comparison (n=3).}" in tex
-    assert "\\label{fig:fig}" in tex
+    assert tex == "\\caption{Latency comparison (n=3).}\n\\label{fig:fig}\n"
 
 
 def test_manuscript_mode_sidecar_omits_label(tmp_path):
-    # Arrange: in manuscript mode the .tex is symlinked under another filename
-    # and scitex-writer auto-labels by that stem -> our \label must be omitted.
+    # Arrange
+    fr.set_manuscript_mode(False)
+    # Act: in manuscript mode the .tex is symlinked under another filename and
+    # scitex-writer auto-labels by that stem -> our \label must be omitted.
     try:
         with fr.manuscript_mode():
             _panel(tmp_path, "ms.yaml", "Manuscript caption.")
         tex = (tmp_path / "ms.tex").read_text()
-        # Assert
-        assert "\\caption{Manuscript caption.}" in tex
-        assert "\\label" not in tex
     finally:
         fr.set_manuscript_mode(False)
+    # Assert
+    assert tex == "\\caption{Manuscript caption.}\n"
 
 
 def test_no_caption_emits_no_tex_sidecar(tmp_path):
@@ -65,14 +63,11 @@ def test_compose_carries_source_panel_captions_into_sidecar(tmp_path):
     # Act
     cfig, _ = fr.compose(layout=(1, 2), sources={(0, 0): a, (0, 1): b})
     fr.save(cfig, str(tmp_path / "composed.yaml"))
-    # Assert: panel captions auto-pulled, folded into the composed .tex.
-    assert cfig.record.figure_panel_captions == [
-        "Throughput per condition.",
-        "Error rate per condition.",
-    ]
-    tex = (tmp_path / "composed.tex").read_text()
-    assert "(A) Throughput per condition." in tex
-    assert "(B) Error rate per condition." in tex
+    # Assert: source panel captions auto-pulled + folded as (A)/(B) into the .tex.
+    assert (tmp_path / "composed.tex").read_text() == (
+        "\\caption{(A) Throughput per condition. (B) Error rate per condition.}\n"
+        "\\label{fig:composed}\n"
+    )
 
 
 def test_explicit_panel_captions_override_source_carry_forward(tmp_path):

--- a/tests/integration/test_env_runtime_respect.py
+++ b/tests/integration/test_env_runtime_respect.py
@@ -4,8 +4,10 @@
 
 Two coupled invariants:
 
-1. Importing figrecipe walks parent dirs for ``.env`` (best-effort) and never
-   raises when scitex-config is missing/broken or when no .env exists.
+1. On first figrecipe API use (deferred out of bare import — audit-cli §10),
+   figrecipe walks parent dirs for ``.env`` (best-effort) and never raises when
+   scitex-config is missing/broken or when no .env exists. A bare ``import
+   figrecipe`` that never touches the public API performs no walk.
 2. ``figrecipe._runtime_paths.runtime_dir(sub)`` resolves to
    ``<SCITEX_DIR>/figrecipe/runtime/<sub>/`` and creates it.
 
@@ -120,8 +122,14 @@ def _scitex_config_supports_walk_up() -> bool:
     not _scitex_config_supports_walk_up(),
     reason="installed scitex_config.load_dotenv predates walk_up=True kwarg",
 )
-def test_import_loads_dotenv_from_cwd(tmp_path):
-    """A .env in cwd must populate os.environ for a child `import figrecipe`."""
+def test_first_api_use_loads_dotenv_from_cwd(tmp_path):
+    """A .env in cwd must populate os.environ on first figrecipe API use.
+
+    The .env walk-up is DEFERRED out of bare `import figrecipe` (audit-cli §10:
+    importing scitex_config + the walk_up's filesystem stat calls dominate import
+    on a network filesystem). It runs once, lazily, on the first public-attribute
+    access — touching ``figrecipe.subplots`` here is what triggers it.
+    """
     # Arrange: write a real .env with a sentinel key and a fake HOME so the
     # walk_up terminates at tmp_path.
     work = tmp_path / "with_env"
@@ -130,7 +138,8 @@ def test_import_loads_dotenv_from_cwd(tmp_path):
     script = textwrap.dedent(
         """
         import os
-        import figrecipe  # noqa: F401  -- triggers load_dotenv(walk_up=True)
+        import figrecipe
+        figrecipe.subplots  # first public-attr access triggers load_dotenv(walk_up=True)
         print(os.environ.get("FIGRECIPE_ENV_RESPECT_PROBE", ""))
         """
     )

--- a/tests/integration/test_tick_roundtrip.py
+++ b/tests/integration/test_tick_roundtrip.py
@@ -1,0 +1,76 @@
+"""Regression: set_xticks(positions, labels) must round-trip faithfully.
+
+Guards the figrecipe<0.29.4 bug where tick POSITIONS serialized with a different
+count/values than the labels (positions [8,16,24] -> [0,1]), breaking reproduce.
+No mocks -- a real figure saved to tmp_path and the recipe/CSV read back.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import figrecipe as fr
+
+
+def _tick_csv_values(tmp_path, stem):
+    data_dir = tmp_path / f"{stem}_data"
+    hits = [p for p in data_dir.iterdir() if "tick" in p.name and p.suffix == ".csv"]
+    assert len(hits) == 1, [p.name for p in data_dir.iterdir()]
+    return hits[0].read_text().split()
+
+
+def test_set_xticks_positions_serialize_faithfully(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots()
+    ax.plot([8, 16, 24], [1, 2, 3], id="line")
+    ax.set_xticks([8, 16, 24], labels=["8", "16", "24"])
+    # Act
+    fr.save(fig, str(tmp_path / "t.yaml"))
+    # Assert: the real positions (not an index like [0,1]) are stored.
+    assert _tick_csv_values(tmp_path, "t") == ["8", "16", "24"]
+
+
+def test_set_xticks_recipe_reproduces_without_error(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots()
+    ax.plot([8, 16, 24], [1, 2, 3], id="line")
+    ax.set_xticks([8, 16, 24], labels=["8", "16", "24"])
+    fr.save(fig, str(tmp_path / "t2.yaml"))
+    # Act
+    fig2, ax2 = fr.reproduce(str(tmp_path / "t2.yaml"))
+    # Assert: reproduced axis keeps the 3 tick positions.
+    assert list(ax2._ax.get_xticks()) == [8.0, 16.0, 24.0]
+
+
+def test_faithfulness_guard_raises_on_mismatched_tick_op():
+    # Arrange
+    import pytest
+
+    from figrecipe._serializer._save import _assert_tick_call_faithful
+
+    call = {
+        "function": "set_xticks",
+        "id": "set_xticks_000",
+        "args": [{"name": "ticks", "data": [0, 1]}],
+        "kwargs": {"labels": ["8", "16", "24"]},
+    }
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="FR-FAITHFUL-TICKS"):
+        _assert_tick_call_faithful(call)
+
+
+def test_faithfulness_guard_passes_on_matched_tick_op():
+    # Arrange
+    from figrecipe._serializer._save import _assert_tick_call_faithful
+
+    call = {
+        "function": "set_xticks",
+        "id": "set_xticks_000",
+        "args": [{"name": "ticks", "data": [8, 16, 24]}],
+        "kwargs": {"labels": ["8", "16", "24"]},
+    }
+    # Act
+    result = _assert_tick_call_faithful(call)
+    # Assert
+    assert result is None


### PR DESCRIPTION
Promote develop→main: release pipeline runs in the scitex-ci SIF (test/build) with manual OIDC publish (#246), so v0.29.0 can release fully self-hosted. §10 tolerated via scitex-dev 0.18.2.