### PR TITLE
fix(ci): unique per-run SIF TMPDIR (fixes duplicate-trigger collision)

### DIFF
--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -29,8 +29,12 @@ export LC_ALL=C.UTF-8 LANG=C.UTF-8
 # Real writable scratch. The runner profile exports TMPDIR=~/.cache/tmp, a host
 # path that does NOT resolve inside the container; tests (tmp_path) and the
 # install target both need a working, writable tmp. Node-local /tmp is writable
-# + ephemeral and per-version-isolated so concurrent matrix legs don't collide.
-export TMPDIR="/tmp/ci-figrecipe-$V"
+# + ephemeral. Scoped per-RUN, not just per-version: the workflow triggers on
+# BOTH push:[develop] and pull_request, so two same-version jobs can run
+# concurrently on one self-hosted runner — a per-version dir collides (one job's
+# `rm -rf` nukes the other's tmp_path → FileNotFoundError / "Directory not
+# empty"). $GITHUB_RUN_ID + attempt make each job's scratch unique.
+export TMPDIR="/tmp/ci-figrecipe-$V-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}"
 rm -rf "$TMPDIR"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 


### PR DESCRIPTION
pytest-matrix triggers on push:[develop] AND pull_request → a promote runs two same-version jobs concurrently on one self-hosted runner sharing /tmp/ci-figrecipe-$V → one's rm -rf nukes the other's tmp_path (FileNotFoundError / Directory not empty). Scope TMPDIR per-run ($GITHUB_RUN_ID+attempt). This is what failed #248's py3.12 (2475/2476 passed; §10 already handled by scitex-dev 0.18.2).