### PR TITLE
chore(release): figrecipe 0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.1] - 2026-06-25
+
+### Fixed
+- **Manual `plt.colorbar`/`fig.colorbar` calls now survive the recipe
+  round-trip.** Colorbars added via the manual matplotlib API (rather than
+  figrecipe's wrappers) were not recorded, so `reproduce` dropped them.
+  The recorder now captures these calls and the reproducer replays them,
+  keeping the colorbar (and its mappable spec, clim, and axes geometry)
+  faithful through record → save → reproduce.
+
 ## [0.28.20] - 2026-06-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.0"
+version = "0.29.1"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
- Bump version 0.29.0 -> 0.29.1
- Release covers the manual `plt.colorbar`/`fig.colorbar` round-trip fix already on develop (`4aab47e`): these calls are now recorded and replayed by reproduce, keeping the colorbar (mappable spec, clim, axes geometry) faithful through record -> save -> reproduce.
- Adds a CHANGELOG 0.29.1 entry.

## Verification
- Colorbar round-trip suite green locally: `tests/figrecipe/_reproducer/test__colorbars.py` + `_utils/test__colorbar.py` + `_utils/test__mk_colorbar.py` -> 11 passed.
- Tag-triggered release CI runs the 3.11/3.12/3.13 test matrix before publishing.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, tag `v0.29.1` to trigger PyPI publish + GitHub release