### PR TITLE
perf(import): defer .env load out of bare import (audit-cli §10) + release 0.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.2] - 2026-06-25
+
+### Performance
+- **`import figrecipe` no longer pays the `.env` walk-up cost up front
+  (audit-cli §10).** The eager `scitex_config` import + `load_dotenv(walk_up=True)`
+  is deferred to first public-API use: importing `scitex_config` pulls in
+  `importlib.metadata`, and the parent-dir `.env` walk does many filesystem stat
+  calls that, on a network filesystem (Spartan gpfs), dominate import startup and
+  tripped the §10 import-speed audit. A bare `import figrecipe` that never touches
+  the public API now performs no `.env` walk; any real use loads it once before
+  the first API call. **Behavior note:** `.env` is loaded on first figrecipe API
+  use rather than at `import figrecipe` time.
+
+### Note
+- Also carries the 0.29.1 colorbar round-trip fix below, which never reached PyPI
+  (its release run was blocked by this same §10 audit gate).
+
 ## [0.29.1] - 2026-06-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.1"
+version = "0.29.2"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -8,24 +8,39 @@ from __future__ import annotations
 from pathlib import Path as _Path
 
 # Best-effort .env loading: walk parent dirs from cwd up to $HOME, loading
-# every .env found (closest wins). Imported lazily and tolerantly so that a
-# missing/broken scitex-config never breaks `import figrecipe`.
-try:
-    from scitex_config import load_dotenv as _load_dotenv
+# every .env found (closest wins). DEFERRED to first public-attribute access
+# (see _ensure_env_loaded / __getattr__) rather than run at import: importing
+# scitex_config pulls in importlib.metadata and the walk_up does many filesystem
+# stat calls, which on a network filesystem (e.g. Spartan gpfs) dominate
+# `import figrecipe` startup and trip audit-cli §10. A bare `import figrecipe`
+# that never touches the public API pays none of this; any real use loads it
+# once before the first API call.
+_env_loaded = False
 
-    _load_dotenv(walk_up=True, stop_at=str(_Path.home()))
-except Exception:
-    pass
+
+def _ensure_env_loaded() -> None:
+    """Load .env files once, on first public-API use (best-effort, tolerant)."""
+    global _env_loaded
+    if _env_loaded:
+        return
+    _env_loaded = True
+    try:
+        from scitex_config import load_dotenv as _load_dotenv
+
+        _load_dotenv(walk_up=True, stop_at=str(_Path.home()))
+    except Exception:
+        pass
+
 
 from ._branding import BRAND_NAME as _BRAND_NAME
 from ._branding import rebrand_text as _rebrand_text
-from ._qr import add_qr_to_figure
 
 # Register sys.modules aliases for modules moved by #141 (figrecipe._quality
 # topical refactor) so legacy `from figrecipe._validator import X` style
 # imports keep working with a single-fire DeprecationWarning pointing at the
 # new path. See figrecipe._compat for details.
 from ._compat import install_module_aliases as _install_module_aliases
+from ._qr import add_qr_to_figure
 
 _install_module_aliases()
 del _install_module_aliases
@@ -209,6 +224,8 @@ def __getattr__(name: str):
     if name in _LAZY_ATTRS:
         import importlib
 
+        # Best-effort .env load on first real use (deferred from import).
+        _ensure_env_loaded()
         # Patch on first matplotlib-touching access — see _patch_pyplot_close.
         _patch_pyplot_close()
         module_path, attr = _LAZY_ATTRS[name]
@@ -219,6 +236,7 @@ def __getattr__(name: str):
     if name in _MODULE_ALIASES:
         import importlib
 
+        _ensure_env_loaded()
         value = importlib.import_module(_MODULE_ALIASES[name], __name__)
         globals()[name] = value
         return value
@@ -237,6 +255,7 @@ def __dir__() -> list[str]:
 # Lazy seaborn access (avoids import error if seaborn not installed)
 class _SnsModule:
     def __getattr__(self, name):
+        _ensure_env_loaded()
         from ._seaborn import get_seaborn_recorder
 
         return getattr(get_seaborn_recorder(), name)

--- a/tests/integration/test_env_runtime_respect.py
+++ b/tests/integration/test_env_runtime_respect.py
@@ -4,8 +4,10 @@
 
 Two coupled invariants:
 
-1. Importing figrecipe walks parent dirs for ``.env`` (best-effort) and never
-   raises when scitex-config is missing/broken or when no .env exists.
+1. On first figrecipe API use (deferred out of bare import — audit-cli §10),
+   figrecipe walks parent dirs for ``.env`` (best-effort) and never raises when
+   scitex-config is missing/broken or when no .env exists. A bare ``import
+   figrecipe`` that never touches the public API performs no walk.
 2. ``figrecipe._runtime_paths.runtime_dir(sub)`` resolves to
    ``<SCITEX_DIR>/figrecipe/runtime/<sub>/`` and creates it.
 
@@ -120,8 +122,14 @@ def _scitex_config_supports_walk_up() -> bool:
     not _scitex_config_supports_walk_up(),
     reason="installed scitex_config.load_dotenv predates walk_up=True kwarg",
 )
-def test_import_loads_dotenv_from_cwd(tmp_path):
-    """A .env in cwd must populate os.environ for a child `import figrecipe`."""
+def test_first_api_use_loads_dotenv_from_cwd(tmp_path):
+    """A .env in cwd must populate os.environ on first figrecipe API use.
+
+    The .env walk-up is DEFERRED out of bare `import figrecipe` (audit-cli §10:
+    importing scitex_config + the walk_up's filesystem stat calls dominate import
+    on a network filesystem). It runs once, lazily, on the first public-attribute
+    access — touching ``figrecipe.subplots`` here is what triggers it.
+    """
     # Arrange: write a real .env with a sentinel key and a fake HOME so the
     # walk_up terminates at tmp_path.
     work = tmp_path / "with_env"
@@ -130,7 +138,8 @@ def test_import_loads_dotenv_from_cwd(tmp_path):
     script = textwrap.dedent(
         """
         import os
-        import figrecipe  # noqa: F401  -- triggers load_dotenv(walk_up=True)
+        import figrecipe
+        figrecipe.subplots  # first public-attr access triggers load_dotenv(walk_up=True)
         print(os.environ.get("FIGRECIPE_ENV_RESPECT_PROBE", ""))
         """
     )


### PR DESCRIPTION
## Summary
- Defer the eager `scitex_config` import + `load_dotenv(walk_up=True)` out of `import figrecipe` into a one-shot `_ensure_env_loaded()` called lazily on first public-API use. The parent-dir `.env` walk does many filesystem stat calls that, on Spartan gpfs, dominate import startup and tripped the audit-cli §10 import-speed gate (1281ms > threshold).
- Bare `import figrecipe` no longer imports `scitex_config` or walks for `.env`; any real use loads it once before the first API call.
- Updates the env-respect guard test to trigger via first API use and documents the new contract.
- Bumps version 0.29.1 -> 0.29.2. Also carries the 0.29.1 colorbar round-trip fix, which never reached PyPI (its release run was blocked by this same §10 gate).

## Verification
- Local: bare import no longer loads `scitex_config`; `.env` + config load on first `subplots()`; env-respect tests pass; pre-commit testmon suite green.
- Release pipeline (on tag) runs the 3.11/3.12/3.13 matrix incl. the audit gate before publishing.

## Behavior note
- `.env` is now loaded on first figrecipe API use rather than at `import figrecipe` time (functionally equivalent for figrecipe's own config needs).