### PR TITLE
feat(captions): composed caption carry-forward + caption-only .tex sidecar + manuscript mode (0.29.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.3] - 2026-06-26
+
+### Added
+- **Composed figures now carry their source panels' captions forward.**
+  `compose()` pulls each source panel's own `record.caption`, prefixes its
+  `(A)/(B)/...` label, and assembles them into the composed figure's
+  `figure.panel_captions` when the caller passes no explicit `panel_captions`
+  (grid mode always; mm/tiled when each source contributes one axes). Closes
+  the gap where composed figures silently dropped panel captions — the same
+  defect class as the composed-colorbar drop. Caller-supplied `panel_captions`
+  still take precedence.
+- **Writer-compatible caption-only `.tex` sidecar.** Saving a recipe that
+  carries caption text now emits `<stem>.tex` next to the `.png`/`.yaml`,
+  derived from the canonical `record.caption` (+ folded per-panel captions).
+  It is a bare `\caption{...}\label{fig:<stem>}` fragment with NO
+  `\begin{figure}` wrapper, so it `\input`s directly inside a manuscript's own
+  float without nesting figure environments. New `format_caption_only_tex()`.
+- **Manuscript mode** (`fr.set_manuscript_mode()`, `fr.manuscript_mode()`
+  context manager, or `FIGRECIPE_MANUSCRIPT_MODE=1`). When active, captions are
+  recorded canonically (`metadata.caption`) and the `.tex` sidecar is still
+  emitted, but the caption is NOT drawn onto the canvas — so a manuscript build
+  doesn't double-render the caption (baked pixels + LaTeX `\caption`).
+
 ## [0.29.2] - 2026-06-25
 
 ### Performance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.2"
+version = "0.29.3"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -156,6 +156,9 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     # ._captions (public caption API)
     "add_figure_caption": ("._captions._public", "add_figure_caption"),
     "add_panel_captions": ("._captions._public", "add_panel_captions"),
+    "set_manuscript_mode": ("._captions._manuscript_mode", "set_manuscript_mode"),
+    "manuscript_mode": ("._captions._manuscript_mode", "manuscript_mode"),
+    "is_manuscript_mode": ("._captions._manuscript_mode", "is_manuscript_mode"),
     # ._composition
     "align_panels": ("._composition", "align_panels"),
     "align_smart": ("._composition", "align_smart"),
@@ -286,6 +289,9 @@ __all__ = [
     # Caption API
     "add_figure_caption",
     "add_panel_captions",
+    "set_manuscript_mode",
+    "manuscript_mode",
+    "is_manuscript_mode",
     "panel_label",
     # Bundle format
     "Figz",

--- a/src/figrecipe/_captions/_formats.py
+++ b/src/figrecipe/_captions/_formats.py
@@ -5,6 +5,7 @@
 __all__ = [
     "format_caption_for_txt",
     "format_caption_for_tex",
+    "format_caption_only_tex",
     "format_caption_for_md",
     "escape_latex",
     "create_text_figure_list",
@@ -14,7 +15,7 @@ __all__ = [
 
 import textwrap
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 def escape_latex(text: str) -> str:
@@ -136,6 +137,48 @@ def format_caption_for_tex(
     \\label{{fig:{label_slug}}}
 \\end{{figure}}
 """
+
+
+def format_caption_only_tex(
+    caption: str,
+    label_slug: Optional[str] = None,
+) -> str:
+    r"""Format a caption as a bare ``\caption{...}`` (+ optional ``\label``).
+
+    Unlike :func:`format_caption_for_tex`, this emits NO ``\begin{figure}``
+    wrapper, so the fragment can be ``\input`` directly inside a manuscript's
+    own float (e.g. scitex-writer's ``\begin{figure*}``) without nesting two
+    figure environments.
+
+    The figure NUMBER is intentionally never injected: LaTeX numbers the float
+    where the fragment is included, so a hardcoded ``Figure N.`` here would
+    fight the manuscript's own numbering. The caption text is emitted verbatim
+    (LaTeX-escaped); any bold lead-in is the caption author's responsibility.
+
+    Parameters
+    ----------
+    caption : str
+        Caption text (already assembled; for composed figures this is the
+        figure-level caption with per-panel ``(A) ...`` lines folded in).
+    label_slug : str, optional
+        When given, append ``\label{fig:<slug>}`` (typically the recipe stem),
+        so a standalone fragment can ``\ref{fig:<stem>}``. When ``None`` (the
+        manuscript-symlink path), the ``\label`` is OMITTED so the consumer
+        (scitex-writer) can deterministically auto-label by the SYMLINK
+        filename stem — a hardcoded label would otherwise win and break
+        ``\ref{fig:<filename-stem>}``.
+
+    Returns
+    -------
+    str
+        ``"\\caption{...}\n"`` and, when ``label_slug`` is set, a following
+        ``"\\label{fig:<slug>}\n"``.
+    """
+    tex_caption = escape_latex(caption)
+    out = f"\\caption{{{tex_caption}}}\n"
+    if label_slug:
+        out += f"\\label{{fig:{label_slug}}}\n"
+    return out
 
 
 def format_caption_for_md(

--- a/src/figrecipe/_captions/_manuscript_mode.py
+++ b/src/figrecipe/_captions/_manuscript_mode.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Manuscript mode: keep captions canonical, suppress the on-canvas copy.
+
+In a manuscript build the figure caption is typeset by LaTeX (from the emitted
+``<stem>.tex`` sidecar), so baking the caption onto the PNG would double-render
+it (pixels + ``\\caption``). Manuscript mode makes ``add_figure_caption`` /
+compose record the caption in the recipe (``metadata.caption`` /
+``figure.panel_captions``) and emit the ``.tex`` sidecar, but NOT draw the
+caption onto the canvas (and not record it as a replayed ``figure_texts``
+entry). The drawn copy and the ``.tex`` are derived views; the YAML stays the
+single source of truth.
+
+Toggle via :func:`set_manuscript_mode`, the :func:`manuscript_mode` context
+manager, or the ``FIGRECIPE_MANUSCRIPT_MODE`` environment variable.
+"""
+
+import os
+from contextlib import contextmanager
+
+__all__ = ["set_manuscript_mode", "is_manuscript_mode", "manuscript_mode"]
+
+_MANUSCRIPT_MODE = False
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def set_manuscript_mode(on: bool = True) -> None:
+    """Enable/disable manuscript mode process-wide."""
+    global _MANUSCRIPT_MODE
+    _MANUSCRIPT_MODE = bool(on)
+
+
+def is_manuscript_mode() -> bool:
+    """True when manuscript mode is active (explicit flag OR env var)."""
+    if _MANUSCRIPT_MODE:
+        return True
+    return os.environ.get("FIGRECIPE_MANUSCRIPT_MODE", "").strip().lower() in _TRUTHY
+
+
+@contextmanager
+def manuscript_mode(on: bool = True):
+    """Context manager that sets manuscript mode for the enclosed block."""
+    global _MANUSCRIPT_MODE
+    prev = _MANUSCRIPT_MODE
+    _MANUSCRIPT_MODE = bool(on)
+    try:
+        yield
+    finally:
+        _MANUSCRIPT_MODE = prev

--- a/src/figrecipe/_captions/_public.py
+++ b/src/figrecipe/_captions/_public.py
@@ -71,6 +71,30 @@ def add_figure_caption(
     # Resolve the underlying matplotlib Figure (RecordingFigure wraps it).
     mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
 
+    # Manuscript mode: record the caption (canonical YAML + numbering/sidecar)
+    # but do NOT reserve canvas space or draw it — LaTeX typesets the caption
+    # from the emitted .tex sidecar, so baking it onto the PNG would double-
+    # render. The image stays clean; the drawn copy is a derived view.
+    from ._manuscript_mode import is_manuscript_mode
+
+    if is_manuscript_mode():
+        if hasattr(fig, "record"):
+            fig.record.caption = caption
+        caption_manager.add_figure_caption(
+            fig,
+            caption,
+            figure_label=figure_label,
+            style=style,
+            position=position,
+            width_ratio=width_ratio,
+            font_size=font_size,
+            wrap_width=wrap_width,
+            save_to_file=save_to_file,
+            file_path=file_path,
+            render=False,
+        )
+        return _strip_markdown(caption)
+
     # Reserve room for the caption BEFORE rendering, by adjusting axes
     # positions when they encroach on the caption strip.  The previous
     # implementation called ``mpl_fig.subplots_adjust(bottom=0.15)`` and

--- a/src/figrecipe/_composition/_caption_carry.py
+++ b/src/figrecipe/_composition/_caption_carry.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Carry per-source panel captions forward into a composed figure.
+
+When ``compose()`` is called without explicit ``panel_captions``, each source
+panel's own ``record.caption`` should become its ``(A)/(B)/...`` entry on the
+composed figure — otherwise composed figures silently drop panel captions (the
+same gap class as composed colorbars). These helpers assemble that list from
+the per-source captions collected during composition.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+__all__ = ["auto_panel_captions_grid", "auto_panel_captions_seq"]
+
+
+def _nonempty(cap: Optional[str]) -> bool:
+    return bool(cap and str(cap).strip())
+
+
+def auto_panel_captions_grid(
+    source_captions: Dict[Tuple[int, int], Optional[str]],
+    nrows: int,
+    ncols: int,
+) -> Optional[List[str]]:
+    """Build a row-major panel-caption list from per-source captions.
+
+    Index ``row * ncols + col`` matches the flattened (row-major) axes order
+    that ``render_compose_captions`` iterates, so each cell's caption lands on
+    the right panel. Missing/empty cells become ``""`` (rendered as a no-op).
+    Returns ``None`` when no source carried a caption, leaving compose's
+    caption rendering a no-op exactly as before.
+    """
+    if not any(_nonempty(c) for c in source_captions.values()):
+        return None
+    out: List[str] = []
+    for row in range(nrows):
+        for col in range(ncols):
+            cap = source_captions.get((row, col))
+            out.append(str(cap).strip() if _nonempty(cap) else "")
+    return out
+
+
+def auto_panel_captions_seq(
+    captions: List[Optional[str]],
+    axis_counts: List[int],
+) -> Optional[List[str]]:
+    """Build a panel-caption list for sequential (mm/tiled) composition.
+
+    Only safe when every source contributed exactly one axes — otherwise the
+    one-caption-per-source mapping can't align with the per-axes label order,
+    so we decline (return ``None``) and leave it to the caller. Returns
+    ``None`` when no source carried a caption.
+    """
+    if any(n != 1 for n in axis_counts):
+        return None
+    if not any(_nonempty(c) for c in captions):
+        return None
+    return [str(c).strip() if _nonempty(c) else "" for c in captions]

--- a/src/figrecipe/_composition/_caption_render.py
+++ b/src/figrecipe/_composition/_caption_render.py
@@ -49,20 +49,31 @@ def render_compose_captions(
     flat = _flatten_axes(axes)
     mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
 
-    # Persist in record for round-trip
+    # Persist in record for round-trip (canonical — kept even in manuscript
+    # mode; only the on-canvas DRAW is suppressed below).
     if caption is not None:
         fig.record.caption = caption
     if panel_captions:
         fig.record.figure_panel_captions = panel_captions
 
+    from .._captions._manuscript_mode import is_manuscript_mode
+
+    _manuscript = is_manuscript_mode()
+
     # --- Per-panel captions: render label + text above each panel ---
-    if panel_captions:
+    # Suppressed in manuscript mode (LaTeX typesets them from the .tex sidecar).
+    if panel_captions and not _manuscript:
         import string
 
         n = len(flat)
         labels = list(string.ascii_uppercase[:n])
 
         for i, (ax, label, cap_text) in enumerate(zip(flat, labels, panel_captions)):
+            # Skip panels with no caption text so auto-assembled lists with
+            # gaps (some sources carry a caption, some don't) don't draw a
+            # bare "(C)" label with nothing after it.
+            if not (cap_text and str(cap_text).strip()):
+                continue
             raw = ax._ax if hasattr(ax, "_ax") else ax
             pos = raw.get_position()
             x_center = pos.x0 + pos.width / 2.0

--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -17,6 +17,7 @@ from numpy.typing import NDArray
 
 from .._utils._grid import grid_id, parse_grid_id
 from .._wrappers import RecordingAxes, RecordingFigure
+from ._caption_carry import auto_panel_captions_grid, auto_panel_captions_seq
 from ._crop_aware import _apply_source_style, panel_rel_bbox, replay_panel_suptitle
 from ._panel_labels import (
     _add_panel_labels_grid,
@@ -249,9 +250,14 @@ def _compose_grid_based(
     fig, axes = subplots(nrows=nrows, ncols=ncols, panel_labels=False, **kwargs)
 
     source_data_dirs = {}
+    # Collect each source panel's own caption so compose can carry them forward
+    # into the composed figure (see _auto_panel_captions below). Keyed by grid
+    # position so the assembled list lines up with the row-major axes order.
+    source_captions: Dict[Tuple[int, int], Optional[str]] = {}
 
     for (row, col), source_spec in sources.items():
         source_record, ax_key, source_path = _parse_source_spec_with_path(source_spec)
+        source_captions[(row, col)] = getattr(source_record, "caption", None)
         # Accept either "rRcC" or legacy "ax_R_C" regardless of which form the
         # source record uses for its keys.
         ax_record = source_record.axes.get(ax_key)
@@ -296,6 +302,13 @@ def _compose_grid_based(
     # Add panel labels if requested
     if panel_labels:
         _add_panel_labels_grid(axes, nrows, ncols, label_style)
+
+    # Carry source panel captions forward when the caller didn't pass any:
+    # each panel's own record.caption becomes its (A)/(B)/... entry. Without
+    # this the composed figure silently drops panel captions (same gap class
+    # as composed colorbars).
+    if panel_captions is None:
+        panel_captions = auto_panel_captions_grid(source_captions, nrows, ncols)
 
     # Render caption and panel captions
     render_compose_captions(fig, axes, caption, panel_captions)
@@ -344,6 +357,9 @@ def _compose_mm_based(
 
     axes_list = []
     source_data_dirs = {}
+    # Per-source captions + axes-counts for caption carry-forward (see below).
+    mm_source_captions: List[Optional[str]] = []
+    mm_axis_counts: List[int] = []
 
     sub_idx = 0  # global counter for ax_mm_* keys across all panels + subplots
     for source_path, spec in sources.items():
@@ -386,6 +402,9 @@ def _compose_mm_based(
             selected = dict(source_record.axes)
             if not selected:
                 raise ValueError(f"Source '{source_path}' has no axes to compose.")
+
+        mm_source_captions.append(getattr(source_record, "caption", None))
+        mm_axis_counts.append(len(selected))
 
         data_dir = None
         if path is not None:
@@ -446,6 +465,11 @@ def _compose_mm_based(
 
     if panel_labels:
         _add_panel_labels_mm(mpl_fig, sources, canvas_size_mm, label_style)
+
+    # Carry source panel captions forward when the caller didn't pass any
+    # (only when each source contributed exactly one axes — see helper).
+    if panel_captions is None:
+        panel_captions = auto_panel_captions_seq(mm_source_captions, mm_axis_counts)
 
     # Render caption and panel captions for mm-based
     render_compose_captions(fig, axes_list, caption, panel_captions)

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -150,11 +150,58 @@ def save_recipe(
         raise
     os.replace(tmp_name, path)
 
+    # Emit a writer-compatible caption-only .tex sidecar next to the recipe
+    # (loose-coupling seam: scitex-writer reads the file, never imports
+    # figrecipe). Only when the recipe actually carries caption text.
+    _emit_caption_sidecar(record, path)
+
     # Record the recipe as a clew output of the active session (no-op without
     # clew). This is the handle that connects a composed figure to its source
     # panels: compose later record_inputs these recipes -> clew links sessions.
     record_output(path)
     return path
+
+
+def _assemble_caption_text(record: FigureRecord) -> str:
+    """Fold the figure caption + per-panel captions into one manuscript caption.
+
+    Returns the figure-level ``record.caption`` followed by ``(A) ...`` lines
+    for each non-empty per-panel caption, in panel order — the complete text a
+    manuscript ``\\caption{...}`` wants. Empty string when there is nothing.
+    """
+    parts = []
+    if record.caption:
+        parts.append(str(record.caption).strip())
+    panel_caps = getattr(record, "figure_panel_captions", None)
+    if panel_caps:
+        for i, cap in enumerate(panel_caps):
+            if cap and str(cap).strip():
+                label = chr(ord("A") + i)
+                parts.append(f"({label}) {str(cap).strip()}")
+    return " ".join(p for p in parts if p)
+
+
+def _emit_caption_sidecar(record: FigureRecord, path: Path) -> None:
+    """Write ``<stem>.tex`` (caption-only fragment) next to the recipe, if any.
+
+    No-op when the recipe carries no caption text, so a figure without a
+    caption produces no stray sidecar.
+    """
+    text = _assemble_caption_text(record)
+    if not text:
+        return
+    from .._captions._formats import format_caption_only_tex
+    from .._captions._manuscript_mode import is_manuscript_mode
+
+    # In manuscript mode the .tex is symlinked into the manuscript under a
+    # different filename and scitex-writer auto-labels by that symlink stem;
+    # a hardcoded \label here would win and break \ref{fig:<filename-stem>}.
+    # So omit the label in manuscript mode; keep it for standalone use.
+    label_slug = None if is_manuscript_mode() else path.stem
+    tex_path = path.with_suffix(".tex")
+    tex_path.write_text(
+        format_caption_only_tex(text, label_slug=label_slug), encoding="utf-8"
+    )
 
 
 def _process_arrays_for_save(

--- a/tests/figrecipe/_captions/test__formats.py
+++ b/tests/figrecipe/_captions/test__formats.py
@@ -4,7 +4,6 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-
 import pytest
 
 
@@ -13,8 +12,50 @@ def test_import__captions__formats_module():
     # Arrange
     # Act
     # Assert
-    module_path = 'figrecipe._captions._formats'
+    module_path = "figrecipe._captions._formats"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+def test_caption_only_tex_has_no_figure_environment():
+    # Arrange
+    from figrecipe._captions._formats import format_caption_only_tex
+
+    # Act
+    out = format_caption_only_tex("Two conditions (n=3).", label_slug="fig01")
+    # Assert: writer-compatible fragment must NOT open a figure float.
+    assert "\\begin{figure}" not in out
+
+
+def test_caption_only_tex_emits_caption_and_label():
+    # Arrange
+    from figrecipe._captions._formats import format_caption_only_tex
+
+    # Act
+    out = format_caption_only_tex("Latency comparison.", label_slug="fig01")
+    # Assert
+    assert "\\caption{Latency comparison.}" in out
+    assert "\\label{fig:fig01}" in out
+
+
+def test_caption_only_tex_escapes_latex_specials():
+    # Arrange
+    from figrecipe._captions._formats import format_caption_only_tex
+
+    # Act: an unescaped % would comment out the rest of the LaTeX line.
+    out = format_caption_only_tex("Throughput up 5% & stable_runs.", label_slug="f")
+    # Assert
+    assert "5\\% \\& stable\\_runs" in out
+
+
+def test_caption_only_tex_omits_label_when_slug_none():
+    # Arrange
+    from figrecipe._captions._formats import format_caption_only_tex
+
+    # Act: no slug -> no \label, so the consumer auto-labels by filename stem.
+    out = format_caption_only_tex("Some caption.", label_slug=None)
+    # Assert
+    assert "\\caption{Some caption.}" in out
+    assert "\\label" not in out

--- a/tests/figrecipe/_captions/test__formats.py
+++ b/tests/figrecipe/_captions/test__formats.py
@@ -36,8 +36,7 @@ def test_caption_only_tex_emits_caption_and_label():
     # Act
     out = format_caption_only_tex("Latency comparison.", label_slug="fig01")
     # Assert
-    assert "\\caption{Latency comparison.}" in out
-    assert "\\label{fig:fig01}" in out
+    assert out == "\\caption{Latency comparison.}\n\\label{fig:fig01}\n"
 
 
 def test_caption_only_tex_escapes_latex_specials():
@@ -56,6 +55,5 @@ def test_caption_only_tex_omits_label_when_slug_none():
 
     # Act: no slug -> no \label, so the consumer auto-labels by filename stem.
     out = format_caption_only_tex("Some caption.", label_slug=None)
-    # Assert
-    assert "\\caption{Some caption.}" in out
-    assert "\\label" not in out
+    # Assert: caption present and NO label line at all.
+    assert out == "\\caption{Some caption.}\n"

--- a/tests/figrecipe/_captions/test__manuscript_mode.py
+++ b/tests/figrecipe/_captions/test__manuscript_mode.py
@@ -1,0 +1,76 @@
+"""Tests for figrecipe._captions._manuscript_mode."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from figrecipe._captions._manuscript_mode import (
+    is_manuscript_mode,
+    manuscript_mode,
+    set_manuscript_mode,
+)
+
+
+def test_default_is_off():
+    # Arrange
+    set_manuscript_mode(False)
+    # Act / Assert
+    assert is_manuscript_mode() is False
+
+
+def test_set_toggles_on_and_off():
+    # Arrange / Act
+    set_manuscript_mode(True)
+    try:
+        # Assert
+        assert is_manuscript_mode() is True
+    finally:
+        set_manuscript_mode(False)
+
+
+def test_context_manager_restores_previous_state():
+    # Arrange
+    set_manuscript_mode(False)
+    # Act
+    with manuscript_mode():
+        inside = is_manuscript_mode()
+    # Assert
+    assert inside is True
+    assert is_manuscript_mode() is False
+
+
+def test_env_var_enables_mode(monkeypatch):
+    # Arrange
+    set_manuscript_mode(False)
+    monkeypatch.setenv("FIGRECIPE_MANUSCRIPT_MODE", "1")
+    # Act / Assert
+    assert is_manuscript_mode() is True
+
+
+def test_add_caption_in_manuscript_mode_records_but_does_not_draw():
+    # Arrange
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+    ax.plot([0, 1], [0, 1], id="line")
+    n_before = len(fig._fig.texts)
+    # Act
+    with manuscript_mode():
+        fr.add_figure_caption(fig, "Off-canvas caption.")
+    # Assert: caption recorded canonically, but no text drawn on the figure.
+    assert fig.record.caption == "Off-canvas caption."
+    assert len(fig._fig.texts) == n_before
+
+
+def test_add_caption_normally_draws_on_canvas():
+    # Arrange
+    import figrecipe as fr
+
+    set_manuscript_mode(False)
+    fig, ax = fr.subplots()
+    ax.plot([0, 1], [0, 1], id="line")
+    n_before = len(fig._fig.texts)
+    # Act
+    fr.add_figure_caption(fig, "Drawn caption.")
+    # Assert
+    assert len(fig._fig.texts) > n_before

--- a/tests/figrecipe/_captions/test__manuscript_mode.py
+++ b/tests/figrecipe/_captions/test__manuscript_mode.py
@@ -1,5 +1,7 @@
 """Tests for figrecipe._captions._manuscript_mode."""
 
+import os
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -14,18 +16,21 @@ from figrecipe._captions._manuscript_mode import (
 def test_default_is_off():
     # Arrange
     set_manuscript_mode(False)
-    # Act / Assert
-    assert is_manuscript_mode() is False
+    # Act
+    active = is_manuscript_mode()
+    # Assert
+    assert active is False
 
 
-def test_set_toggles_on_and_off():
-    # Arrange / Act
+def test_set_enables_mode():
+    # Arrange
+    set_manuscript_mode(False)
+    # Act
     set_manuscript_mode(True)
-    try:
-        # Assert
-        assert is_manuscript_mode() is True
-    finally:
-        set_manuscript_mode(False)
+    active = is_manuscript_mode()
+    set_manuscript_mode(False)
+    # Assert
+    assert active is True
 
 
 def test_context_manager_restores_previous_state():
@@ -34,17 +39,26 @@ def test_context_manager_restores_previous_state():
     # Act
     with manuscript_mode():
         inside = is_manuscript_mode()
+    after = is_manuscript_mode()
     # Assert
-    assert inside is True
-    assert is_manuscript_mode() is False
+    assert (inside, after) == (True, False)
 
 
-def test_env_var_enables_mode(monkeypatch):
+def test_env_var_enables_mode():
     # Arrange
     set_manuscript_mode(False)
-    monkeypatch.setenv("FIGRECIPE_MANUSCRIPT_MODE", "1")
-    # Act / Assert
-    assert is_manuscript_mode() is True
+    prev = os.environ.get("FIGRECIPE_MANUSCRIPT_MODE")
+    os.environ["FIGRECIPE_MANUSCRIPT_MODE"] = "1"
+    # Act
+    try:
+        active = is_manuscript_mode()
+    finally:
+        if prev is None:
+            os.environ.pop("FIGRECIPE_MANUSCRIPT_MODE", None)
+        else:
+            os.environ["FIGRECIPE_MANUSCRIPT_MODE"] = prev
+    # Assert
+    assert active is True
 
 
 def test_add_caption_in_manuscript_mode_records_but_does_not_draw():
@@ -57,9 +71,11 @@ def test_add_caption_in_manuscript_mode_records_but_does_not_draw():
     # Act
     with manuscript_mode():
         fr.add_figure_caption(fig, "Off-canvas caption.")
-    # Assert: caption recorded canonically, but no text drawn on the figure.
-    assert fig.record.caption == "Off-canvas caption."
-    assert len(fig._fig.texts) == n_before
+    # Assert
+    assert (fig.record.caption, len(fig._fig.texts)) == (
+        "Off-canvas caption.",
+        n_before,
+    )
 
 
 def test_add_caption_normally_draws_on_canvas():

--- a/tests/figrecipe/_composition/test__caption_carry.py
+++ b/tests/figrecipe/_composition/test__caption_carry.py
@@ -1,0 +1,57 @@
+"""Tests for figrecipe._composition._caption_carry (panel-caption carry-forward)."""
+
+from figrecipe._composition._caption_carry import (
+    auto_panel_captions_grid,
+    auto_panel_captions_seq,
+)
+
+
+def test_grid_assembles_row_major_from_source_captions():
+    # Arrange
+    caps = {(0, 0): "A cap", (0, 1): "B cap"}
+    # Act
+    out = auto_panel_captions_grid(caps, nrows=1, ncols=2)
+    # Assert
+    assert out == ["A cap", "B cap"]
+
+
+def test_grid_fills_missing_cells_with_empty_string():
+    # Arrange: only the first cell carries a caption.
+    caps = {(0, 0): "only A", (0, 1): None}
+    # Act
+    out = auto_panel_captions_grid(caps, nrows=1, ncols=2)
+    # Assert
+    assert out == ["only A", ""]
+
+
+def test_grid_returns_none_when_no_source_has_caption():
+    # Arrange
+    caps = {(0, 0): None, (0, 1): "   "}
+    # Act
+    out = auto_panel_captions_grid(caps, nrows=1, ncols=2)
+    # Assert
+    assert out is None
+
+
+def test_seq_assembles_in_source_order_when_one_axes_each():
+    # Arrange
+    # Act
+    out = auto_panel_captions_seq(["a", "b", "c"], axis_counts=[1, 1, 1])
+    # Assert
+    assert out == ["a", "b", "c"]
+
+
+def test_seq_declines_when_any_source_has_multiple_axes():
+    # Arrange: a multi-subplot source breaks the one-caption-per-axes mapping.
+    # Act
+    out = auto_panel_captions_seq(["a", "b"], axis_counts=[1, 2])
+    # Assert
+    assert out is None
+
+
+def test_seq_returns_none_when_no_caption_present():
+    # Arrange
+    # Act
+    out = auto_panel_captions_seq([None, ""], axis_counts=[1, 1])
+    # Assert
+    assert out is None

--- a/tests/integration/test_caption_tex_sidecar.py
+++ b/tests/integration/test_caption_tex_sidecar.py
@@ -1,0 +1,90 @@
+"""End-to-end: caption-only .tex sidecar emit + composed panel-caption carry-forward.
+
+No mocks — real figures saved to ``tmp_path`` and the emitted artifacts read back.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import figrecipe as fr
+
+
+def _panel(tmp_path, name, caption):
+    fig, ax = fr.subplots()
+    ax.plot([1, 2, 3], [1, 2, 3], id="line")
+    fr.add_figure_caption(fig, caption)
+    path = str(tmp_path / name)
+    fr.save(fig, path)
+    return path
+
+
+def test_single_figure_emits_caption_only_tex_sidecar(tmp_path):
+    # Arrange / Act
+    fr.set_manuscript_mode(False)
+    _panel(tmp_path, "fig.yaml", "Latency comparison (n=3).")
+    tex_path = tmp_path / "fig.tex"
+    # Assert
+    assert tex_path.exists()
+    tex = tex_path.read_text()
+    assert "\\begin{figure}" not in tex
+    assert "\\caption{Latency comparison (n=3).}" in tex
+    assert "\\label{fig:fig}" in tex
+
+
+def test_manuscript_mode_sidecar_omits_label(tmp_path):
+    # Arrange: in manuscript mode the .tex is symlinked under another filename
+    # and scitex-writer auto-labels by that stem -> our \label must be omitted.
+    try:
+        with fr.manuscript_mode():
+            _panel(tmp_path, "ms.yaml", "Manuscript caption.")
+        tex = (tmp_path / "ms.tex").read_text()
+        # Assert
+        assert "\\caption{Manuscript caption.}" in tex
+        assert "\\label" not in tex
+    finally:
+        fr.set_manuscript_mode(False)
+
+
+def test_no_caption_emits_no_tex_sidecar(tmp_path):
+    # Arrange
+    fr.set_manuscript_mode(False)
+    fig, ax = fr.subplots()
+    ax.plot([1, 2], [1, 2], id="line")
+    # Act
+    fr.save(fig, str(tmp_path / "plain.yaml"))
+    # Assert
+    assert not (tmp_path / "plain.tex").exists()
+
+
+def test_compose_carries_source_panel_captions_into_sidecar(tmp_path):
+    # Arrange: two panels, each with its own caption, no panel_captions passed.
+    fr.set_manuscript_mode(False)
+    a = _panel(tmp_path, "a.yaml", "Throughput per condition.")
+    b = _panel(tmp_path, "b.yaml", "Error rate per condition.")
+    # Act
+    cfig, _ = fr.compose(layout=(1, 2), sources={(0, 0): a, (0, 1): b})
+    fr.save(cfig, str(tmp_path / "composed.yaml"))
+    # Assert: panel captions auto-pulled, folded into the composed .tex.
+    assert cfig.record.figure_panel_captions == [
+        "Throughput per condition.",
+        "Error rate per condition.",
+    ]
+    tex = (tmp_path / "composed.tex").read_text()
+    assert "(A) Throughput per condition." in tex
+    assert "(B) Error rate per condition." in tex
+
+
+def test_explicit_panel_captions_override_source_carry_forward(tmp_path):
+    # Arrange
+    fr.set_manuscript_mode(False)
+    a = _panel(tmp_path, "a2.yaml", "Source A caption.")
+    b = _panel(tmp_path, "b2.yaml", "Source B caption.")
+    # Act: caller passes panel_captions explicitly -> those win.
+    cfig, _ = fr.compose(
+        layout=(1, 2),
+        sources={(0, 0): a, (0, 1): b},
+        panel_captions=["Override A", "Override B"],
+    )
+    # Assert
+    assert cfig.record.figure_panel_captions == ["Override A", "Override B"]

--- a/tests/integration/test_caption_tex_sidecar.py
+++ b/tests/integration/test_caption_tex_sidecar.py
@@ -20,30 +20,28 @@ def _panel(tmp_path, name, caption):
 
 
 def test_single_figure_emits_caption_only_tex_sidecar(tmp_path):
-    # Arrange / Act
+    # Arrange
     fr.set_manuscript_mode(False)
+    # Act
     _panel(tmp_path, "fig.yaml", "Latency comparison (n=3).")
-    tex_path = tmp_path / "fig.tex"
+    tex = (tmp_path / "fig.tex").read_text()
     # Assert
-    assert tex_path.exists()
-    tex = tex_path.read_text()
-    assert "\\begin{figure}" not in tex
-    assert "\\caption{Latency comparison (n=3).}" in tex
-    assert "\\label{fig:fig}" in tex
+    assert tex == "\\caption{Latency comparison (n=3).}\n\\label{fig:fig}\n"
 
 
 def test_manuscript_mode_sidecar_omits_label(tmp_path):
-    # Arrange: in manuscript mode the .tex is symlinked under another filename
-    # and scitex-writer auto-labels by that stem -> our \label must be omitted.
+    # Arrange
+    fr.set_manuscript_mode(False)
+    # Act: in manuscript mode the .tex is symlinked under another filename and
+    # scitex-writer auto-labels by that stem -> our \label must be omitted.
     try:
         with fr.manuscript_mode():
             _panel(tmp_path, "ms.yaml", "Manuscript caption.")
         tex = (tmp_path / "ms.tex").read_text()
-        # Assert
-        assert "\\caption{Manuscript caption.}" in tex
-        assert "\\label" not in tex
     finally:
         fr.set_manuscript_mode(False)
+    # Assert
+    assert tex == "\\caption{Manuscript caption.}\n"
 
 
 def test_no_caption_emits_no_tex_sidecar(tmp_path):
@@ -65,14 +63,11 @@ def test_compose_carries_source_panel_captions_into_sidecar(tmp_path):
     # Act
     cfig, _ = fr.compose(layout=(1, 2), sources={(0, 0): a, (0, 1): b})
     fr.save(cfig, str(tmp_path / "composed.yaml"))
-    # Assert: panel captions auto-pulled, folded into the composed .tex.
-    assert cfig.record.figure_panel_captions == [
-        "Throughput per condition.",
-        "Error rate per condition.",
-    ]
-    tex = (tmp_path / "composed.tex").read_text()
-    assert "(A) Throughput per condition." in tex
-    assert "(B) Error rate per condition." in tex
+    # Assert: source panel captions auto-pulled + folded as (A)/(B) into the .tex.
+    assert (tmp_path / "composed.tex").read_text() == (
+        "\\caption{(A) Throughput per condition. (B) Error rate per condition.}\n"
+        "\\label{fig:composed}\n"
+    )
 
 
 def test_explicit_panel_captions_override_source_carry_forward(tmp_path):


### PR DESCRIPTION
## Summary
Stage 1 of the caption-tex manuscript pipeline (operator-approved).

- **Composer carry-forward**: `compose()` pulls each source panel's `record.caption`, auto-labels `(A)/(B)/...`, and assembles into the composed `figure.panel_captions` when no explicit `panel_captions` are passed (grid always; mm/tiled when each source = one axes). Closes the composed panel-caption drop (same defect class as composed colorbars). Caller-supplied captions still win.
- **Caption-only `.tex` sidecar**: `save_recipe()` emits `<stem>.tex` next to `.png`/`.yaml` from canonical `record.caption` (+ folded panel captions). Bare `\caption{...}` (+ optional `\label`), NO `\begin{figure}` wrapper, so it `\input`s inside a manuscript float without nesting. New `format_caption_only_tex()`.
- **Manuscript mode** (`set_manuscript_mode` / `manuscript_mode()` / `FIGRECIPE_MANUSCRIPT_MODE`): records the caption + emits `.tex` but does NOT draw it on the canvas (no double-render). In manuscript mode the `.tex` omits `\label` so the consumer (scitex-writer) auto-labels by the symlink filename stem — a hardcoded label would otherwise break `\ref{fig:<filename-stem>}`.
- Extracted carry-forward helpers to `_composition/_caption_carry.py` to keep `_compose.py` under the line limit.

## Verification
- New tests: caption-carry units, caption-only-tex formatter (incl. label-omission), manuscript-mode behaviour, end-to-end sidecar + carry-forward. Existing captions/compose/save suites pass (no regressions). Lint + format clean.
- Release matrix (on tag) re-runs 3.11/3.12/3.13 + audit gate before publishing.

## Behavior note
- `.env` already loads on first API use (0.29.2). This PR adds the caption surface; `metadata.caption` stays the single source of truth, drawn copy + `.tex` are derived views.