### PR TITLE
feat(captions): error on \footnote in captions (FR-CAP-001) + release 0.29.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.4] - 2026-06-27
+
+### Added
+- **Caption validation FR-CAP-001: `\footnote` in a caption now errors loud.**
+  figrecipe owns captions canonically, so it rejects caption text containing the
+  `\footnote` command (and the `\footnotemark`/`\footnotetext` family) — which
+  breaks LaTeX in spanning floats (`figure*`): `\caption@ydblarg` "extra }" + a
+  runaway `\@xfootnote`. Checked at input (`add_figure_caption`, `compose`
+  `caption=`/`panel_captions=`) and at the save/`.tex`-emit output (naming the
+  file + which caption/panel). Raises `figrecipe._captions.FootnoteInCaptionError`
+  (a `ValueError`). Inline the footnote text into the caption instead. This is
+  figrecipe's own independent rule (scitex-writer enforces its own on the
+  manuscript-LaTeX side).
+
 ## [0.29.3] - 2026-06-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.3"
+version = "0.29.4"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_captions/__init__.py
+++ b/src/figrecipe/_captions/__init__.py
@@ -42,8 +42,12 @@ from ._formats import (
     format_caption_for_tex,
     format_caption_for_txt,
 )
+from ._validate import FootnoteInCaptionError, check_caption_latex_safe
 
 __all__ = [
+    # Validation (FR-CAP-001)
+    "FootnoteInCaptionError",
+    "check_caption_latex_safe",
     # Core class
     "ScientificCaption",
     "caption_manager",

--- a/src/figrecipe/_captions/_public.py
+++ b/src/figrecipe/_captions/_public.py
@@ -68,6 +68,11 @@ def add_figure_caption(
     str
         The rendered caption text (Markdown-stripped).
     """
+    # Fail loud on caption content that breaks downstream LaTeX (FR-CAP-001).
+    from ._validate import check_caption_latex_safe
+
+    check_caption_latex_safe(caption, "the figure caption")
+
     # Resolve the underlying matplotlib Figure (RecordingFigure wraps it).
     mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
 

--- a/src/figrecipe/_captions/_validate.py
+++ b/src/figrecipe/_captions/_validate.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+r"""Caption content validation — figrecipe's own (independent) rules.
+
+figrecipe owns figure captions canonically (``metadata.caption`` /
+``figure.panel_captions`` in the recipe YAML, plus the caption-only ``<stem>.tex``
+it emits). These checks fail LOUD on caption text that is known to break
+downstream LaTeX, so the problem is caught at figure-build/save time rather than
+at manuscript-compile time.
+
+This rule is INTENTIONALLY independent of scitex-writer's equivalent
+manuscript-side rule — each tool owns and enforces its own copy.
+
+Rule FR-CAP-001 — no ``\footnote`` in captions:
+    ``\footnote`` (and the ``\footnotemark``/``\footnotetext`` family) inside a
+    figure caption breaks LaTeX in spanning floats (``figure*``): the ``\caption``
+    argument is read in a context where ``\footnote`` triggers
+    ``\caption@ydblarg`` "Argument ... has an extra }" and a runaway
+    ``\@xfootnote``. Inline the footnote text into the caption instead.
+"""
+
+from typing import Optional
+
+__all__ = ["FootnoteInCaptionError", "check_caption_latex_safe"]
+
+# The LaTeX command (with backslash). Matching this substring also catches
+# \footnotemark / \footnotetext, which are equally unwelcome in a caption.
+_FOOTNOTE_TOKEN = "\\footnote"
+
+
+class FootnoteInCaptionError(ValueError):
+    """Raised when a figure caption contains a ``\\footnote`` command."""
+
+
+def check_caption_latex_safe(text: Optional[str], where: str) -> None:
+    r"""Raise :class:`FootnoteInCaptionError` if *text* contains ``\footnote``.
+
+    Parameters
+    ----------
+    text : str or None
+        Caption text to check. ``None``/empty is allowed (no-op).
+    where : str
+        Human description of the caption's origin, surfaced in the error so the
+        caller knows exactly which caption/panel (and file) is offending —
+        e.g. ``"the figure caption"`` or ``"the panel B caption of fig01.yaml"``.
+    """
+    if not text:
+        return
+    if _FOOTNOTE_TOKEN in str(text):
+        raise FootnoteInCaptionError(
+            f"figrecipe [FR-CAP-001]: \\footnote is not allowed in {where}. "
+            r"\footnote inside a figure caption breaks LaTeX in spanning floats "
+            r"(figure*): it triggers \caption@ydblarg 'extra }' and a runaway "
+            r"\@xfootnote. Inline the footnote text into the caption instead."
+        )

--- a/src/figrecipe/_composition/_caption_render.py
+++ b/src/figrecipe/_composition/_caption_render.py
@@ -49,6 +49,13 @@ def render_compose_captions(
     flat = _flatten_axes(axes)
     mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
 
+    # Fail loud on caption content that breaks downstream LaTeX (FR-CAP-001).
+    from .._captions._validate import check_caption_latex_safe
+
+    check_caption_latex_safe(caption, "the composed figure caption")
+    for i, cap in enumerate(panel_captions or []):
+        check_caption_latex_safe(cap, f"the panel {chr(ord('A') + i)} caption")
+
     # Persist in record for round-trip (canonical — kept even in manuscript
     # mode; only the on-canvas DRAW is suppressed below).
     if caption is not None:

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -69,6 +69,10 @@ def save_recipe(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    # Fail loud (with file + which caption/panel) on caption content that breaks
+    # downstream LaTeX (FR-CAP-001) -- the authoritative output-side check.
+    _validate_record_captions(record, path)
+
     # Create data directory for large arrays (only for separate format)
     data_dir = path.parent / f"{path.stem}_data"
 
@@ -160,6 +164,21 @@ def save_recipe(
     # panels: compose later record_inputs these recipes -> clew links sessions.
     record_output(path)
     return path
+
+
+def _validate_record_captions(record: FigureRecord, path: Path) -> None:
+    """Fail loud on caption content that breaks LaTeX (FR-CAP-001), naming the
+    file + which caption/panel offends."""
+    from .._captions._validate import check_caption_latex_safe
+
+    check_caption_latex_safe(
+        getattr(record, "caption", None), f"the figure caption of {path.name}"
+    )
+    panel_caps = getattr(record, "figure_panel_captions", None) or []
+    for i, cap in enumerate(panel_caps):
+        check_caption_latex_safe(
+            cap, f"the panel {chr(ord('A') + i)} caption of {path.name}"
+        )
 
 
 def _assemble_caption_text(record: FigureRecord) -> str:

--- a/tests/figrecipe/_captions/test__validate.py
+++ b/tests/figrecipe/_captions/test__validate.py
@@ -1,0 +1,91 @@
+"""Tests for figrecipe._captions._validate (FR-CAP-001: no \\footnote in captions)."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+from figrecipe._captions._validate import (
+    FootnoteInCaptionError,
+    check_caption_latex_safe,
+)
+
+
+def test_plain_caption_passes():
+    # Arrange
+    text = "Two-condition comparison (n=3)."
+    # Act
+    result = check_caption_latex_safe(text, "the figure caption")
+    # Assert
+    assert result is None
+
+
+def test_none_is_noop():
+    # Arrange
+    text = None
+    # Act
+    result = check_caption_latex_safe(text, "the figure caption")
+    # Assert
+    assert result is None
+
+
+def test_footnote_command_raises():
+    # Arrange
+    text = "Throughput\\footnote{disclosure} per condition."
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError):
+        check_caption_latex_safe(text, "the figure caption")
+
+
+def test_footnotemark_also_raises():
+    # Arrange
+    text = "See above\\footnotemark."
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError):
+        check_caption_latex_safe(text, "the figure caption")
+
+
+def test_error_names_the_location():
+    # Arrange
+    text = "Panel\\footnote{x}."
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError, match="the panel B caption"):
+        check_caption_latex_safe(text, "the panel B caption")
+
+
+def test_plain_word_footnote_is_allowed():
+    # Arrange: the English word, NOT the \footnote command, must NOT trip.
+    text = "The footnote describes the cohort."
+    # Act
+    result = check_caption_latex_safe(text, "the figure caption")
+    # Assert
+    assert result is None
+
+
+def test_add_figure_caption_rejects_footnote():
+    # Arrange
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+    ax.plot([0, 1], [0, 1], id="line")
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError):
+        fr.add_figure_caption(fig, "x\\footnote{y}")
+
+
+def test_save_rejects_footnote_naming_the_file(tmp_path):
+    # Arrange
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+    ax.plot([0, 1], [0, 1], id="line")
+    fig.record.caption = "x\\footnote{y}"
+    # Act
+    # Assert
+    with pytest.raises(FootnoteInCaptionError, match="bad.yaml"):
+        fr.save(fig, str(tmp_path / "bad.yaml"))


### PR DESCRIPTION
## Summary
Operator dogfooding request: footnotes in figure captions break LaTeX in spanning floats (`figure*`). figrecipe owns captions canonically, so it now validates and ERRORS (FR-CAP-001) when a caption contains the `\footnote` command (and the `\footnotemark`/`\footnotetext` family).

- Checked at input (`add_figure_caption`, `compose` `caption=`/`panel_captions=`) and at the save/`.tex`-emit output (error names the file + which caption/panel).
- Raises `figrecipe._captions.FootnoteInCaptionError` (a `ValueError`). Plain-text "footnote" (no backslash) is allowed.
- Independent of scitex-writer's own manuscript-side rule (each tool owns its copy).
- New `_captions/_validate.py` + tests.

## Verification
- 8 new tests; smoke test confirms rejection at all three points + normal captions unaffected; ruff + the test-quality audit clean locally.