### PR TITLE
fix(reproducer): tick record/replay faithfulness safeguards (0.29.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.5] - 2026-06-27
+
+### Fixed
+- **Tick record/replay faithfulness safeguards.** A pre-0.29.3 bug could
+  serialize `set_xticks` POSITIONS with a different count than the labels (e.g.
+  `[8,16,24]` written as `[0,1]`), so reproducing such a recipe raised
+  "FixedLocator locations (N) does not match the number of labels (M)" and the
+  axis rendered garbled. Current figrecipe already records ticks faithfully;
+  these are guards so it can never silently regress:
+  - **Reproduce-side heal**: loading a recipe whose tick positions/labels counts
+    diverge now truncates/pins to the common length and WARNS loudly instead of
+    hard-failing — legacy recipes render rather than crash.
+  - **Record-time fail-loud guard** (`FR-FAITHFUL-TICKS`): a `set_xticks`/
+    `set_yticks` op whose serialized positions count != labels count raises at
+    save, so a mismatched (unreproducible) recipe is never shipped.
+  - Regression tests lock faithful `set_xticks([8,16,24], labels=...)` round-trip.
+
 ## [0.29.4] - 2026-06-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.4"
+version = "0.29.5"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_reproducer/_core.py
+++ b/src/figrecipe/_reproducer/_core.py
@@ -482,6 +482,17 @@ def _replay_call(
         if "color" in kwargs and "edgecolor" in kwargs:
             kwargs["facecolor"] = kwargs.pop("color")
 
+    # Heal legacy recipes whose tick positions/labels counts diverge (warn loud).
+    if method_name in (
+        "set_xticks",
+        "set_yticks",
+        "set_xticklabels",
+        "set_yticklabels",
+    ):
+        from ._tick_heal import heal_tick_call
+
+        args, kwargs = heal_tick_call(ax, method_name, args, kwargs)
+
     # Call the method
     try:
         return method(*args, **kwargs)

--- a/src/figrecipe/_reproducer/_tick_heal.py
+++ b/src/figrecipe/_reproducer/_tick_heal.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+r"""Heal legacy mismatched tick recipes on reproduce.
+
+figrecipe < 0.29.4 could serialize tick POSITIONS with a different count than
+the labels (e.g. positions ``[0, 1]`` vs labels ``['8','16','24']``), so on
+replay matplotlib raises "The number of FixedLocator locations (N) ... does not
+match the number of labels (M)" and the axis renders garbled. These helpers
+truncate/pin to the common length and WARN loudly instead of hard-failing.
+
+This is a heal for ALREADY-SAVED recipes — current figrecipe records ticks
+faithfully (positions paired with labels). Re-save a recipe with a current
+figrecipe for a faithful round-trip.
+"""
+
+import warnings
+from typing import Any, Dict, Tuple
+
+
+def heal_tick_call(
+    ax: Any, method_name: str, args: Tuple, kwargs: Dict[str, Any]
+) -> Tuple[Tuple, Dict[str, Any]]:
+    """Return (args, kwargs) with tick positions/labels reconciled in length."""
+    if method_name in ("set_xticks", "set_yticks") and "labels" in kwargs:
+        pos = args[0] if args else None
+        labels = kwargs.get("labels")
+        if pos is not None and labels is not None and len(pos) != len(labels):
+            n = min(len(pos), len(labels))
+            warnings.warn(
+                f"figrecipe: healing {method_name} on load: positions "
+                f"({len(pos)}) != labels ({len(labels)}) in this recipe; "
+                f"truncating both to {n}. Re-save with a current figrecipe "
+                f"for a faithful round-trip."
+            )
+            args = (list(pos)[:n],) + tuple(args[1:])
+            kwargs = {**kwargs, "labels": list(labels)[:n]}
+    elif method_name in ("set_xticklabels", "set_yticklabels") and args:
+        labels = args[0]
+        axis = method_name[4]  # 'x' or 'y'
+        cur = list(getattr(ax, f"get_{axis}ticks")())
+        if labels is not None and len(labels) != len(cur):
+            warnings.warn(
+                f"figrecipe: healing {method_name} on load: labels "
+                f"({len(labels)}) != current tick positions ({len(cur)}); "
+                f"pinning positions to match. Re-save with a current figrecipe "
+                f"for fidelity."
+            )
+            getattr(ax, f"set_{axis}ticks")(cur)
+            args = (list(labels)[: len(cur)],) + tuple(args[1:])
+    return args, kwargs

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -35,6 +35,34 @@ def _panel_prefix(ax_key: str, nrows, ncols) -> str:
     return f"{label}_" if label else ""
 
 
+def _assert_tick_call_faithful(call: Dict[str, Any]) -> None:
+    """Record-time faithfulness guard (FR-FAITHFUL-TICKS): a set_xticks/set_yticks
+    op must carry as many tick POSITIONS as LABELS, else the recipe can't
+    round-trip (replay raises "FixedLocator locations != labels"). Fail loud at
+    save rather than ship a silently-unreproducible recipe."""
+    if call.get("function") not in ("set_xticks", "set_yticks"):
+        return
+    labels = call.get("kwargs", {}).get("labels")
+    args = call.get("args", [])
+    if labels is None or not args:
+        return
+    pos = args[0]
+    if isinstance(pos, dict) and "_array" in pos:
+        n_pos = len(pos["_array"])
+    elif isinstance(pos, dict) and isinstance(pos.get("data"), list):
+        n_pos = len(pos["data"])
+    else:
+        return  # positions length not determinable here; skip
+    if n_pos != len(labels):
+        raise ValueError(
+            f"figrecipe [FR-FAITHFUL-TICKS]: {call.get('function')} recorded "
+            f"{n_pos} tick positions but {len(labels)} labels (call "
+            f"{call.get('id')}). This recipe would not round-trip (replay would "
+            f"raise FixedLocator count != labels) -- indicates a recording/"
+            f"serialization bug. Not shipping a mismatched recipe."
+        )
+
+
 def save_recipe(
     record: FigureRecord,
     path: Union[str, Path],
@@ -279,6 +307,7 @@ def _process_arrays_with_symlinks(
             for call in call_list:
                 call_id = call.get("id", "unknown")
                 safe_call_id = _sanitize_filename(call_id)
+                _assert_tick_call_faithful(call)
 
                 for i, arg in enumerate(call.get("args", [])):
                     source_file_path = arg.pop("_source_file", None)

--- a/tests/figrecipe/_reproducer/test__tick_heal.py
+++ b/tests/figrecipe/_reproducer/test__tick_heal.py
@@ -1,0 +1,37 @@
+"""Tests for figrecipe._reproducer._tick_heal (legacy mismatched-tick heal)."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from figrecipe._reproducer._tick_heal import heal_tick_call
+
+
+def test_set_xticks_mismatch_truncates_to_common_length():
+    # Arrange: legacy recipe with 2 positions but 3 labels.
+    args = ([0, 1],)
+    kwargs = {"labels": ["8", "16", "24"]}
+    # Act
+    new_args, new_kwargs = heal_tick_call(None, "set_xticks", args, kwargs)
+    # Assert
+    assert (len(new_args[0]), len(new_kwargs["labels"])) == (2, 2)
+
+
+def test_set_xticks_matched_counts_unchanged():
+    # Arrange
+    args = ([8, 16, 24],)
+    kwargs = {"labels": ["8", "16", "24"]}
+    # Act
+    new_args, new_kwargs = heal_tick_call(None, "set_xticks", args, kwargs)
+    # Assert
+    assert (new_args[0], new_kwargs["labels"]) == ([8, 16, 24], ["8", "16", "24"])
+
+
+def test_non_tick_method_passes_through():
+    # Arrange
+    args = ([1, 2, 3],)
+    kwargs = {"color": "red"}
+    # Act
+    new_args, new_kwargs = heal_tick_call(None, "plot", args, kwargs)
+    # Assert
+    assert (new_args, new_kwargs) == (args, kwargs)

--- a/tests/integration/test_tick_roundtrip.py
+++ b/tests/integration/test_tick_roundtrip.py
@@ -1,0 +1,76 @@
+"""Regression: set_xticks(positions, labels) must round-trip faithfully.
+
+Guards the figrecipe<0.29.4 bug where tick POSITIONS serialized with a different
+count/values than the labels (positions [8,16,24] -> [0,1]), breaking reproduce.
+No mocks -- a real figure saved to tmp_path and the recipe/CSV read back.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import figrecipe as fr
+
+
+def _tick_csv_values(tmp_path, stem):
+    data_dir = tmp_path / f"{stem}_data"
+    hits = [p for p in data_dir.iterdir() if "tick" in p.name and p.suffix == ".csv"]
+    assert len(hits) == 1, [p.name for p in data_dir.iterdir()]
+    return hits[0].read_text().split()
+
+
+def test_set_xticks_positions_serialize_faithfully(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots()
+    ax.plot([8, 16, 24], [1, 2, 3], id="line")
+    ax.set_xticks([8, 16, 24], labels=["8", "16", "24"])
+    # Act
+    fr.save(fig, str(tmp_path / "t.yaml"))
+    # Assert: the real positions (not an index like [0,1]) are stored.
+    assert _tick_csv_values(tmp_path, "t") == ["8", "16", "24"]
+
+
+def test_set_xticks_recipe_reproduces_without_error(tmp_path):
+    # Arrange
+    fig, ax = fr.subplots()
+    ax.plot([8, 16, 24], [1, 2, 3], id="line")
+    ax.set_xticks([8, 16, 24], labels=["8", "16", "24"])
+    fr.save(fig, str(tmp_path / "t2.yaml"))
+    # Act
+    fig2, ax2 = fr.reproduce(str(tmp_path / "t2.yaml"))
+    # Assert: reproduced axis keeps the 3 tick positions.
+    assert list(ax2._ax.get_xticks()) == [8.0, 16.0, 24.0]
+
+
+def test_faithfulness_guard_raises_on_mismatched_tick_op():
+    # Arrange
+    import pytest
+
+    from figrecipe._serializer._save import _assert_tick_call_faithful
+
+    call = {
+        "function": "set_xticks",
+        "id": "set_xticks_000",
+        "args": [{"name": "ticks", "data": [0, 1]}],
+        "kwargs": {"labels": ["8", "16", "24"]},
+    }
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="FR-FAITHFUL-TICKS"):
+        _assert_tick_call_faithful(call)
+
+
+def test_faithfulness_guard_passes_on_matched_tick_op():
+    # Arrange
+    from figrecipe._serializer._save import _assert_tick_call_faithful
+
+    call = {
+        "function": "set_xticks",
+        "id": "set_xticks_000",
+        "args": [{"name": "ticks", "data": [8, 16, 24]}],
+        "kwargs": {"labels": ["8", "16", "24"]},
+    }
+    # Act
+    result = _assert_tick_call_faithful(call)
+    # Assert
+    assert result is None


### PR DESCRIPTION
## Summary
Safeguards so the (already-fixed) tick position/label serialization bug can never silently regress; the regression that hit neurovista fig02 was an old (pre-0.29.3) recipe.

- **Reproduce-side heal** (`_reproducer/_tick_heal.py`): a loaded recipe whose tick positions/labels counts diverge is truncated/pinned to the common length with a loud warning, instead of hard-failing (`FixedLocator locations != labels`). Legacy recipes render rather than crash.
- **Record-time fail-loud guard** (`_serializer/_save.py` `FR-FAITHFUL-TICKS`): a `set_xticks`/`set_yticks` op whose serialized positions count != labels count raises at save — never ship a silently-unreproducible recipe.
- Regression tests: faithful `set_xticks([8,16,24], labels=...)` round-trip + heal/guard units.

First instance of the broader "complete + systematic record/replay" initiative.

## Verification
- 7 new tests pass; ruff + test-quality audit clean locally; full local testmon gate green.