### PR TITLE
feat(composition): machine-readable layout introspection + figure-making skill (0.29.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.6] - 2026-06-28
+
+### Added
+- **Machine-readable layout introspection** (`figrecipe.empty_cells`,
+  `figrecipe.layout_report`) — the agent-facing foundation for tight,
+  empty-cell-free page packing. `empty_cells(layout, sources)` returns the blank
+  `(row, col)` positions of a grid (fast path); `layout_report(fig)` returns a
+  native-float report `{mode, canvas_mm, panels[...mm/frac/aspect],
+  empty_regions[maximal blank rectangles], coverage_frac}` with a top-left
+  origin. Panels are reported at their measured millimetre sizes so a caller can
+  re-plot at 1:1 — figrecipe never stretches a panel to fill space.
+- **Compose-time under-fill warning** — composing an under-filled grid now emits
+  a `UserWarning` naming the empty cells, so blank page space is caught at build
+  time rather than discovered in the PDF.
+- **Figure-making skill** (`_skills/figrecipe/26_tight-layout-and-page-filling.md`)
+  capturing the tight-layout / page-filling know-how, indexed in `SKILL.md`.
+
 ## [0.29.5] - 2026-06-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.5"
+version = "0.29.6"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -164,6 +164,9 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "align_smart": ("._composition", "align_smart"),
     "compose": ("._composition", "compose"),
     "distribute_panels": ("._composition", "distribute_panels"),
+    # ._composition._layout_report (machine-readable layout introspection)
+    "empty_cells": ("._composition._layout_report", "empty_cells"),
+    "layout_report": ("._composition._layout_report", "layout_report"),
     # ._configure_mpl
     "configure_mpl": ("._configure_mpl", "configure_mpl"),
     # ._diagram
@@ -280,6 +283,8 @@ __all__ = [
     "align_panels",
     "distribute_panels",
     "align_smart",
+    "empty_cells",
+    "layout_report",
     "gui",
     "crop",
     "info",

--- a/src/figrecipe/_composition/_compose.py
+++ b/src/figrecipe/_composition/_compose.py
@@ -246,6 +246,23 @@ def _compose_grid_based(
         layout = (max_row, max_col)
 
     nrows, ncols = layout
+
+    # No silent blanks: warn when the grid is under-filled (cells with no source
+    # render empty). The agent-facing fr.empty_cells / fr.layout_report expose the
+    # same info programmatically; the warning nudges toward a tiled layout.
+    from ._layout_report import empty_cells
+
+    _blanks = empty_cells((nrows, ncols), sources)
+    if _blanks:
+        import warnings
+
+        warnings.warn(
+            f"figrecipe.compose: grid {nrows}x{ncols} has {len(_blanks)} empty "
+            f"cell(s) {_blanks} that will render blank. For tight page use, pass a "
+            f"tiled layout=[[...],[...]] (whitespace-free), or fr.layout_report(fig) "
+            f"/ fr.empty_cells(layout, sources) to inspect the blank regions."
+        )
+
     # Suppress auto panel labels from global style; compose manages its own
     fig, axes = subplots(nrows=nrows, ncols=ncols, panel_labels=False, **kwargs)
 

--- a/src/figrecipe/_composition/_layout_report.py
+++ b/src/figrecipe/_composition/_layout_report.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Machine-readable layout introspection for composed figures.
+
+The agent-facing FOUNDATION for tight page-packing: given a composed figure (or
+just a grid spec), report — as plain structured data — where the panels are,
+their mm sizes, and WHERE the blank regions are. Downstream tooling (an agent or
+the auto-tiler) consumes this to decide how to resize/re-author panels so the
+page is used tightly. Deterministic geometry only (panel bounding boxes), never
+pixel inspection — figrecipe layouts are always axis-aligned.
+
+Coordinate conventions (so an agent can reason unambiguously):
+- ``*_frac`` are figure-fraction; ``*_mm`` are millimetres on the canvas.
+- The ORIGIN for reported boxes is the TOP-LEFT (y grows downward), matching how
+  humans describe panels ("bottom-right cell"). matplotlib's native bbox is
+  bottom-up; we convert.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+__all__ = ["empty_cells", "layout_report"]
+
+
+def empty_cells(
+    layout: Optional[Tuple[int, int]],
+    sources: Dict[Any, Any],
+) -> List[Tuple[int, int]]:
+    """Blank ``(row, col)`` cells of a GRID compose (deterministic fast path).
+
+    For grid composition (``layout=(nrows, ncols)`` with ``sources`` keyed by
+    ``(row, col)``), returns the cells with no source = ``{all cells} -
+    set(sources keys)``, sorted row-major. When ``layout`` is omitted it is
+    inferred from the max present (row, col). Returns ``[]`` for non-grid
+    (tiled/mm) layouts — those are whitespace-free by construction and have no
+    grid-cell concept.
+    """
+    grid_keys = [k for k in sources.keys() if isinstance(k, tuple) and len(k) == 2]
+    if layout is None:
+        if not grid_keys:
+            return []
+        nrows = max(k[0] for k in grid_keys) + 1
+        ncols = max(k[1] for k in grid_keys) + 1
+    elif isinstance(layout, tuple) and len(layout) == 2:
+        nrows, ncols = layout
+    else:
+        return []  # tiled (list-of-rows) / mm layouts have no empty grid cells
+    present = set(grid_keys)
+    return sorted(
+        (r, c) for r in range(nrows) for c in range(ncols) if (r, c) not in present
+    )
+
+
+def _box_panel(
+    x0: float, y0: float, x1: float, y1: float, cw: float, ch: float
+) -> Dict:
+    """Build a panel/region dict from a bottom-up figure-fraction bbox.
+
+    All values are native Python ``float`` so the report is plain/JSON-able
+    (matplotlib hands back ``np.float64`` positions).
+    """
+    x0, y0, x1, y1 = float(x0), float(y0), float(x1), float(y1)
+    w_frac, h_frac = x1 - x0, y1 - y0
+    return {
+        "x_frac": x0,
+        "y_frac": 1.0 - y1,  # top-down
+        "w_frac": w_frac,
+        "h_frac": h_frac,
+        "x_mm": x0 * cw,
+        "y_mm": (1.0 - y1) * ch,
+        "w_mm": w_frac * cw,
+        "h_mm": h_frac * ch,
+        "area_frac": w_frac * h_frac,
+        "area_mm2": (w_frac * cw) * (h_frac * ch),
+    }
+
+
+def _empty_regions(
+    boxes: List[Tuple[float, float, float, float]],
+    cw: float,
+    ch: float,
+    min_area_frac: float = 0.004,
+) -> List[Dict]:
+    """Maximal blank rectangles of the canvas not covered by any panel box.
+
+    Builds the arrangement from the distinct x/y edges of all panels (+ canvas
+    bounds), marks each cell covered/blank by its centre, then greedily merges
+    adjacent blank cells into maximal rectangles. Slivers below ``min_area_frac``
+    are dropped.
+    """
+    if not boxes:
+        return []
+    xs = sorted({0.0, 1.0, *(b[0] for b in boxes), *(b[2] for b in boxes)})
+    ys = sorted({0.0, 1.0, *(b[1] for b in boxes), *(b[3] for b in boxes)})
+    ncols = len(xs) - 1
+    nrows = len(ys) - 1
+    covered = [[False] * ncols for _ in range(nrows)]
+    for j in range(nrows):
+        cy = (ys[j] + ys[j + 1]) / 2.0
+        for i in range(ncols):
+            cx = (xs[i] + xs[i + 1]) / 2.0
+            covered[j][i] = any(
+                b[0] <= cx <= b[2] and b[1] <= cy <= b[3] for b in boxes
+            )
+    used = [[False] * ncols for _ in range(nrows)]
+    regions: List[Dict] = []
+    for j in range(nrows):
+        for i in range(ncols):
+            if covered[j][i] or used[j][i]:
+                continue
+            i2 = i
+            while i2 + 1 < ncols and not covered[j][i2 + 1] and not used[j][i2 + 1]:
+                i2 += 1
+            j2 = j
+            while j2 + 1 < nrows and all(
+                not covered[j2 + 1][ii] and not used[j2 + 1][ii]
+                for ii in range(i, i2 + 1)
+            ):
+                j2 += 1
+            for jj in range(j, j2 + 1):
+                for ii in range(i, i2 + 1):
+                    used[jj][ii] = True
+            region = _box_panel(xs[i], ys[j], xs[i2 + 1], ys[j2 + 1], cw, ch)
+            if region["area_frac"] >= min_area_frac:
+                regions.append(region)
+    return regions
+
+
+def layout_report(fig: Any) -> Dict[str, Any]:
+    """Structured, machine-readable layout of a composed figure.
+
+    Returns a dict with: ``mode`` (grid/mm/tiled when known), ``canvas_mm``,
+    ``panels`` (per-panel ``*_frac``/``*_mm`` box + ``aspect``), ``empty_regions``
+    (maximal blank rectangles), and ``coverage_frac`` (fraction of the canvas
+    covered by panels). An agent reads this to propose panel target sizes for a
+    tight, no-stretch re-tiling.
+    """
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    record = getattr(fig, "record", None)
+
+    canvas_mm = getattr(record, "canvas_size_mm", None)
+    if canvas_mm:
+        cw, ch = float(canvas_mm[0]), float(canvas_mm[1])
+    else:
+        w_in, h_in = mpl_fig.get_size_inches()
+        cw, ch = float(w_in) * 25.4, float(h_in) * 25.4
+
+    panels: List[Dict] = []
+    boxes: List[Tuple[float, float, float, float]] = []
+    for ax in mpl_fig.axes:
+        if not ax.get_visible():
+            continue
+        pos = ax.get_position()
+        box = (pos.x0, pos.y0, pos.x1, pos.y1)
+        boxes.append(box)
+        panel = _box_panel(*box, cw, ch)
+        panel["aspect"] = panel["w_mm"] / panel["h_mm"] if panel["h_mm"] > 0 else None
+        panels.append(panel)
+
+    empty_regions = _empty_regions(boxes, cw, ch)
+    coverage_frac = sum(p["area_frac"] for p in panels)
+
+    return {
+        "mode": getattr(record, "composition_mode", None) or "grid",
+        "canvas_mm": (cw, ch),
+        "panels": panels,
+        "empty_regions": empty_regions,
+        "coverage_frac": coverage_frac,
+    }

--- a/src/figrecipe/_skills/figrecipe/26_tight-layout-and-page-filling.md
+++ b/src/figrecipe/_skills/figrecipe/26_tight-layout-and-page-filling.md
@@ -1,5 +1,14 @@
-<!-- Figure-making skill: tight layout & page filling. Living doc — distil each
-new figure request into a reusable, principle-first rule (tool-aware: figrecipe). -->
+---
+description: |
+  [TOPIC] Tight layout & page filling (figure-making skill)
+  [DETAILS] Principle-first, accumulated know-how for composing publication
+  figures that use the page well — tile-over-grid to avoid empty panel cells,
+  never stretch/upscale panels (re-plot each at true 1:1 and let compose place
+  them), and the figrecipe layout-introspection APIs (empty_cells / layout_report)
+  for agent-driven tight packing. Living doc — distil each new figure request into
+  a reusable rule.
+tags: [figrecipe-tight-layout-page-filling, figrecipe]
+---
 
 # Tight layout & page filling
 

--- a/src/figrecipe/_skills/figrecipe/26_tight-layout-and-page-filling.md
+++ b/src/figrecipe/_skills/figrecipe/26_tight-layout-and-page-filling.md
@@ -1,0 +1,56 @@
+<!-- Figure-making skill: tight layout & page filling. Living doc — distil each
+new figure request into a reusable, principle-first rule (tool-aware: figrecipe). -->
+
+# Tight layout & page filling
+
+Accumulated know-how for composing publication figures that use the page well.
+Principle-first; figrecipe APIs noted where they help.
+
+## Layout & page usage
+- **Use the page tightly — no large empty panel cells.** A partially-filled grid
+  wastes space and looks unfinished.
+- **Prefer TILED layout over GRID.** figrecipe grid mode (`compose(layout=(nrows,
+  ncols), sources={(r,c): ...})`) renders any *unsupplied* `(row, col)` as a blank
+  subplot → empty cells. TILED mode (`compose(layout=[["A","B"],["C"]], sources=
+  {"A": ...})`, a list-of-rows) is whitespace-free by construction: each row spans
+  the full width edge-to-edge, and a row with fewer panels still fills the width.
+  Re-express partial grids as tiled row-lists.
+- **Never stretch/upscale panels to fill space.** Filling by scaling distorts or
+  up-rezzes panels. If there is empty space, **redo from the panels** — re-plot
+  each at a size that tiles cleanly at TRUE 1:1 scale; let compose place them
+  without scaling.
+
+## Deterministic foundation before fiddling
+- **Detect, don't eyeball.** Encode the "no empty space" rule as code:
+  - `fr.empty_cells(layout, sources)` → blank `(row, col)` list for GRID composes
+    (exact, deterministic). *(figrecipe ≥ 0.29.6)*
+  - `fr.layout_report(fig)` → structured layout: `mode`, `canvas_mm`,
+    `panels[{x_mm, y_mm, w_mm, h_mm, aspect, ...}]`, `empty_regions[{bbox_mm,
+    area_frac, ...}]`, `coverage_frac`. Deterministic geometry from panel boxes,
+    no pixels. *(figrecipe ≥ 0.29.6)*
+- **Agent image-recognition is a complement, not the basis.** A multimodal agent
+  can view composed PNG/JPGs to spot blanks, but that is heuristic; the geometry
+  report is the deterministic, codifiable source of truth.
+- **Workflow:** run panels → `layout_report` (geometry + empties + target sizes)
+  → re-author panels at target sizes → compose 1:1 (no scaling) → image-inspect to
+  confirm.
+
+## Before running (pre-flight)
+- **Pre-flight, don't run-then-wait.** Before a heavy/long figure build, estimate
+  cost (clew run history) and surface "this is a lot — are you sure? maybe do it
+  this way" hints. Mirrors the pre-compile pre-check philosophy, on the compute
+  side.
+
+## Build mechanics (Spartan / scitex)
+- Run builders with the HPC modules + the project venv that has the deps
+  (`module load Python/3.10.4 ...; source .venv`). A bare venv python needs the
+  Python module for `libpython`.
+- Per figure: run the per-panel builders **first**, then the compose-only
+  composer (`plot_figNN_composed.py`). Composers consume panel recipes (`.yaml`),
+  not rasters.
+- Keep scripts consistent with the **current scitex-io save/recipe format** (e.g.
+  the "yaml filename as the first key" namespace). Old code against new io breaks;
+  update the code, don't revert the intentional io update.
+
+See also: `17_composition.md` (compose modes), `21_figure-prep-playbook.md`,
+`24_l-shaped-scale-bar.md`.

--- a/src/figrecipe/_skills/figrecipe/26_tight-layout-and-page-filling.md
+++ b/src/figrecipe/_skills/figrecipe/26_tight-layout-and-page-filling.md
@@ -7,7 +7,7 @@ description: |
   them), and the figrecipe layout-introspection APIs (empty_cells / layout_report)
   for agent-driven tight packing. Living doc — distil each new figure request into
   a reusable rule.
-tags: [figrecipe-tight-layout-page-filling, figrecipe]
+tags: [figrecipe-tight-layout-and-page-filling, figrecipe]
 ---
 
 # Tight layout & page filling

--- a/src/figrecipe/_skills/figrecipe/SKILL.md
+++ b/src/figrecipe/_skills/figrecipe/SKILL.md
@@ -48,6 +48,7 @@ This package does not ship as a submodule of the `scitex` umbrella.
 * [17_composition](17_composition.md) — Multi-panel figure composition (grid and mm-based)
 * [18_cropping](18_cropping.md) — Figure cropping, whitespace removal
 * [24_l-shaped-scale-bar](24_l-shaped-scale-bar.md) — L-shaped time/amplitude scale bar for axis-off trace / EEG panels
+* [26_tight-layout-and-page-filling](26_tight-layout-and-page-filling.md) — use the page tightly (tiled over grid, never stretch); fr.empty_cells / fr.layout_report as the deterministic foundation
 
 ### Workflows
 * [10_workflows](10_workflows.md) — Common figure workflows

--- a/tests/figrecipe/_composition/test__layout_report.py
+++ b/tests/figrecipe/_composition/test__layout_report.py
@@ -1,0 +1,86 @@
+"""Tests for figrecipe._composition._layout_report (empty_cells + layout_report)."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+from figrecipe._composition._layout_report import empty_cells, layout_report
+
+
+def test_empty_cells_reports_the_blank_grid_cell():
+    # Arrange: a 2x2 grid with only 3 of 4 cells supplied.
+    sources = {(0, 0): "a", (0, 1): "b", (1, 0): "c"}
+    # Act
+    blanks = empty_cells((2, 2), sources)
+    # Assert
+    assert blanks == [(1, 1)]
+
+
+def test_empty_cells_empty_when_grid_full():
+    # Arrange
+    sources = {(0, 0): "a", (0, 1): "b"}
+    # Act
+    blanks = empty_cells((1, 2), sources)
+    # Assert
+    assert blanks == []
+
+
+def test_empty_cells_infers_layout_from_sources():
+    # Arrange: no explicit layout; inferred 2x2 from max (row,col).
+    sources = {(0, 0): "a", (1, 1): "b"}
+    # Act
+    blanks = empty_cells(None, sources)
+    # Assert
+    assert blanks == [(0, 1), (1, 0)]
+
+
+def test_empty_cells_non_grid_layout_returns_empty():
+    # Arrange: a tiled (list-of-rows) layout has no grid-cell concept.
+    sources = {"A": "a", "B": "b"}
+    # Act
+    blanks = empty_cells([["A", "B"]], sources)
+    # Assert
+    assert blanks == []
+
+
+def _panel(tmp_path, name):
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+    ax.plot([1, 2, 3], [1, 2, 3], id="line")
+    path = str(tmp_path / name)
+    fr.save(fig, path)
+    return path
+
+
+def test_layout_report_flags_empty_region_in_underfilled_grid(tmp_path):
+    # Arrange: 2x2 compose with only 3 panels -> one blank cell. (The under-fill
+    # warning itself is asserted by test_compose_warns_on_underfilled_grid;
+    # suppress it here so this test makes exactly one assertion.)
+    import warnings
+
+    import figrecipe as fr
+
+    fr.set_manuscript_mode(False)
+    a, b, c = (_panel(tmp_path, n) for n in ("a.yaml", "b.yaml", "c.yaml"))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cfig, _ = fr.compose(layout=(2, 2), sources={(0, 0): a, (0, 1): b, (1, 0): c})
+    # Act
+    report = layout_report(cfig)
+    # Assert: a blank region is detected for the missing panel.
+    assert report["empty_regions"]
+
+
+def test_compose_warns_on_underfilled_grid(tmp_path):
+    # Arrange
+    import figrecipe as fr
+
+    fr.set_manuscript_mode(False)
+    a, b, c = (_panel(tmp_path, n) for n in ("a2.yaml", "b2.yaml", "c2.yaml"))
+    # Act
+    # Assert
+    with pytest.warns(UserWarning, match="empty cell"):
+        fr.compose(layout=(2, 2), sources={(0, 0): a, (0, 1): b, (1, 0): c})


### PR DESCRIPTION
## Summary
- Add `figrecipe.layout_report` (panel mm sizes, fractional positions, aspect ratios, maximal empty rectangles, coverage) and `figrecipe.empty_cells` (blank grid positions, fast path) — the agent-facing foundation for tight, empty-cell-free page packing.
- Compose now emits a build-time `UserWarning` when a grid is under-filled.
- Panels are reported at measured mm so callers re-plot at 1:1 — figrecipe never stretches a panel to fill space.
- Ship the tight-layout / page-filling know-how as a figure-making skill (`_skills/figrecipe/26_tight-layout-and-page-filling.md`).
- Release 0.29.6.

## Test plan
- [x] `tests/figrecipe/_composition/test__layout_report.py` (6/6)
- [x] Full local testmon suite green (2265 passed, 54 skipped)