### PR TITLE
fix(captions): additive caption band — never overlap axes + align/justify (0.29.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.7] - 2026-06-28
+
+### Fixed
+- **In-image captions never overlap the axes anymore.** `add_figure_caption`
+  is now ADDITIVE: instead of reserving space by shrinking the axes (the old
+  fixed `subplots_adjust(bottom=0.15)` + per-axes `set_position`, which let a
+  multi-line caption grow into the x/ylabels on mm-precise figures), it GROWS
+  the figure by a measured caption band and keeps the axes at their EXACT mm
+  size and position. The band height is derived from the wrapped line count and
+  font size; the axes are pinned across the figrecipe constrained-layout engine
+  so they never move. Applies to single figures **and** composed figures
+  (`fr.compose(caption=...)`), whose per-panel `(A)/(B)` labels are re-placed
+  against the post-band panel positions.
+
+### Added
+- **Justified in-image captions.** `add_figure_caption(..., align=...)` accepts
+  `"justify"` (default — full-width lines, last line left-aligned), `"center"`,
+  and `"left"`, plus a `pad_mm` knob for the band gap. In-image captions are for
+  casual researcher communication / reports / grant figures; the manuscript path
+  is unchanged (the `.tex` caption sidecar / manuscript mode). The band and
+  justified word fragments round-trip faithfully through `save`→`reproduce`.
+
 ## [0.29.6] - 2026-06-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.6"
+version = "0.29.7"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_captions/_band.py
+++ b/src/figrecipe/_captions/_band.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Additive caption band helpers.
+
+These pure, testable helpers implement the *additive* in-image caption: the
+figure GROWS by a caption band whose height is reserved by extending the
+figure canvas, while the axes keep their EXACT mm size and position
+(identical to the no-caption figure). The band is NEVER created by shrinking
+the axes.
+
+The flow (driven from ``_public.add_figure_caption``):
+
+1. ``resolve_caption_font_pt``  -> caption font size in points.
+2. ``wrap_caption_lines``       -> wrapped lines (>= 1, never empty).
+3. ``caption_band_inches``      -> band height in inches.
+4. ``extend_figure_for_caption`` -> grow the figure + rewrite subplotpars so
+   the axes stay put; mirror the new geometry into ``record`` so it
+   round-trips through save -> reproduce.
+5. ``place_caption``            -> draw the caption text into the new band and
+   append every drawn fragment to ``record.figure_texts`` (so the reproducer,
+   which replays ``figure_texts`` verbatim, recreates it pixel-for-pixel —
+   including justified word fragments).
+"""
+
+from typing import Any, Dict, List
+
+from .._utils._units import inch_to_mm, mm_to_inch
+
+__all__ = [
+    "resolve_caption_font_pt",
+    "wrap_caption_lines",
+    "caption_band_inches",
+    "extend_figure_for_caption",
+    "place_caption",
+]
+
+# Matplotlib's relative font-size names scale off rcParams["font.size"].
+# The factors below are matplotlib's standard relative scale (FontManager),
+# expressed as the resulting points at the default base size of 10.0.
+_RELATIVE_FONT_PT = {
+    "xx-small": 5.79,
+    "x-small": 6.94,
+    "small": 8.33,
+    "medium": 10.0,
+    "large": 12.0,
+    "x-large": 14.4,
+    "xx-large": 17.28,
+}
+
+# Line-height multiple (caption line pitch = font_pt * this / 72 inch).
+_LINE_HEIGHT = 1.35
+
+# Caption white round bbox (kept identical to the historical look).
+_CAPTION_BBOX = dict(boxstyle="round,pad=0.5", facecolor="white", alpha=0.8)
+
+
+def resolve_caption_font_pt(font_size: Any, mpl_fig: Any) -> float:
+    """Resolve a caption font size to absolute points.
+
+    int -> used directly. Relative names ({"xx-small"..."xx-large"}) scale off
+    ``matplotlib.rcParams["font.size"]`` (the table is expressed at base 10, so
+    we rescale by base/10). Anything else is tried as ``float``; on failure we
+    fall back to "small" (8.33pt).
+    """
+    if isinstance(font_size, bool):  # bool is an int subclass — reject early
+        return _RELATIVE_FONT_PT["small"]
+    if isinstance(font_size, int):
+        return float(font_size)
+    if isinstance(font_size, str):
+        key = font_size.strip().lower()
+        if key in _RELATIVE_FONT_PT:
+            import matplotlib
+
+            base = float(matplotlib.rcParams.get("font.size", 10.0))
+            return _RELATIVE_FONT_PT[key] * base / 10.0
+        try:
+            return float(font_size)
+        except (TypeError, ValueError):
+            return _RELATIVE_FONT_PT["small"]
+    try:
+        return float(font_size)
+    except (TypeError, ValueError):
+        return _RELATIVE_FONT_PT["small"]
+
+
+def wrap_caption_lines(text: str, wrap_width: int) -> List[str]:
+    """Wrap caption text into lines via ``textwrap.wrap`` (>= 1 line)."""
+    import textwrap
+
+    lines = textwrap.wrap(text, width=max(1, int(wrap_width)))
+    if not lines:
+        # textwrap.wrap("") returns [] — never let the band collapse to 0 lines.
+        return [text]
+    return lines
+
+
+def caption_band_inches(n_lines: int, font_pt: float, pad_mm: float) -> float:
+    """Caption band height in inches for ``n_lines`` lines.
+
+    Height = text block (n_lines * line pitch) + a ``pad_mm`` gap on BOTH the
+    axes-facing side and the figure-edge-facing side.
+    """
+    text_in = max(1, int(n_lines)) * (font_pt * _LINE_HEIGHT / 72.0)
+    return text_in + 2.0 * mm_to_inch(pad_mm)
+
+
+def extend_figure_for_caption(
+    mpl_fig: Any,
+    record: Any,
+    band_in: float,
+    position: str,
+) -> Dict[str, float]:
+    """Grow the figure by ``band_in`` inches, keeping the axes mm-fixed.
+
+    This is layout-engine-agnostic. figrecipe's SCITEX figures run a
+    ConstrainedLayoutEngine, which OWNS the axes rectangle and silently ignores
+    ``subplots_adjust`` — so naively renormalising subplotpars lets the engine
+    re-expand the axes into the new canvas (axes size would change). Instead we:
+
+      1. draw once so the live geometry is the engine's solved fixed point;
+      2. snapshot every axes' ABSOLUTE position in inches;
+      3. grow the canvas by ``band_in`` (band on the bottom or top);
+      4. DETACH the layout engine and pin each axes back to its snapshot inch
+         rect (shifted up by ``band_in`` for a bottom band) — so the axes keep
+         their EXACT mm size/position regardless of the engine;
+      5. mirror the resolved geometry into ``record`` (figsize + subplotpars +
+         ``constrained_layout=False``) so save -> reproduce recreates the SAME
+         pinned canvas via the non-constrained subplots_adjust path.
+
+    Returns the resolved subplotpars dict.
+    """
+    # 1) Settle the engine so snapshots are the converged geometry. A single
+    # draw leaves constrained_layout part-way (it solves iteratively), which
+    # would make the snapshot — and therefore the pinned axes size — depend on
+    # draw count. Settling makes the axes rect a pure function of the content.
+    try:
+        from .._api._save_layout import settle_constrained_layout
+
+        settle_constrained_layout(mpl_fig)
+    except Exception:
+        mpl_fig.canvas.draw()
+
+    w_in, h_in = mpl_fig.get_size_inches()
+    new_h = h_in + band_in
+
+    axes = [ax for ax in mpl_fig.axes if ax.get_visible()]
+    # Snapshot absolute axes rects in INCHES (figure-fraction * size).
+    snapshots = []
+    for ax in axes:
+        pos = ax.get_position()
+        snapshots.append(
+            (
+                ax,
+                pos.x0 * w_in,
+                pos.y0 * h_in,
+                pos.width * w_in,
+                pos.height * h_in,
+            )
+        )
+
+    y_shift_in = band_in if position != "top" else 0.0
+
+    # 3) Grow the canvas, then 4) detach the engine and re-pin in new fractions.
+    mpl_fig.set_size_inches(w_in, new_h)
+    try:
+        mpl_fig.set_layout_engine("none")
+    except Exception:
+        # Older matplotlib: clear constrained_layout the legacy way.
+        try:
+            mpl_fig.set_constrained_layout(False)
+        except Exception:
+            pass
+
+    for ax, x0_in, y0_in, w0_in, h0_in in snapshots:
+        ax.set_position(
+            [
+                x0_in / w_in,
+                (y0_in + y_shift_in) / new_h,
+                w0_in / w_in,
+                h0_in / new_h,
+            ]
+        )
+
+    # Resolved uniform subplotpars (for record.layout / reproduce). Derived from
+    # the bounding rect of all pinned axes so the non-constrained reproduce path
+    # lands them in the same place.
+    xs0 = min(s[1] for s in snapshots) / w_in
+    xs1 = max(s[1] + s[3] for s in snapshots) / w_in
+    ys0 = (min(s[2] for s in snapshots) + y_shift_in) / new_h
+    ys1 = (max(s[2] + s[4] for s in snapshots) + y_shift_in) / new_h
+    sp = mpl_fig.subplotpars
+    new_layout = {
+        "left": float(xs0),
+        "right": float(xs1),
+        "bottom": float(ys0),
+        "top": float(ys1),
+        "wspace": float(sp.wspace),
+        "hspace": float(sp.hspace),
+    }
+
+    # 5) Mirror into the record so save -> reproduce recreates the same canvas.
+    if hasattr(record, "figsize"):
+        record.figsize = (float(w_in), float(new_h))
+    if hasattr(record, "layout"):
+        record.layout = dict(new_layout)
+    # The figure no longer runs constrained_layout (we pinned the axes), so the
+    # reproducer must use the subplots_adjust path, not re-solve the engine.
+    if hasattr(record, "constrained_layout"):
+        record.constrained_layout = False
+
+    # Keep mm_layout's reserved strip in sync so auto-crop does NOT crop the
+    # band away. The mm_layout has no single "height" key; the figure height in
+    # mm is margin_bottom_mm + nrows*axes_height_mm + (nrows-1)*space_h_mm +
+    # margin_top_mm. We therefore grow the band-side INTERNAL margin by the band
+    # height in mm, which both (a) enlarges the reserved canvas the crop keeps
+    # and (b) matches where the band physically lives.
+    mm_layout = getattr(record, "mm_layout", None)
+    if isinstance(mm_layout, dict):
+        band_mm = inch_to_mm(band_in)
+        if position == "top" and "margin_top_mm" in mm_layout:
+            mm_layout["margin_top_mm"] = mm_layout["margin_top_mm"] + band_mm
+        elif "margin_bottom_mm" in mm_layout:
+            mm_layout["margin_bottom_mm"] = mm_layout["margin_bottom_mm"] + band_mm
+
+    return new_layout
+
+
+def _record_text(record: Any, x: float, y: float, s: str, kwargs: Dict[str, Any]):
+    """Append a drawn fragment to ``record.figure_texts`` for verbatim replay."""
+    if hasattr(record, "figure_texts"):
+        record.figure_texts.append(
+            {"x": float(x), "y": float(y), "s": s, "kwargs": dict(kwargs)}
+        )
+
+
+def place_caption(
+    mpl_fig: Any,
+    record: Any,
+    lines: List[str],
+    font_pt: float,
+    position: str,
+    align: str,
+    band_in: float,
+    width_ratio: float,
+) -> None:
+    """Draw the caption into the reserved band and record every fragment.
+
+    ``align`` in {"left", "center"} draws a single multi-line text. ``align``
+    == "justify" (default) draws each non-last line word-by-word with the
+    inter-word slack distributed evenly so the line spans the full content
+    width; the LAST line is left-aligned. Every drawn ``mpl_fig.text`` is also
+    appended to ``record.figure_texts`` so the reproducer recreates it exactly.
+    """
+    w_in, new_h = mpl_fig.get_size_inches()
+    band_frac = band_in / new_h
+
+    # Content x-extent = axes bounding rect (matches the pinned axes the band
+    # sits under). ``record.layout`` holds the resolved left/right after extend;
+    # fall back to live subplotpars for a bare Figure.
+    layout = getattr(record, "layout", None)
+    if isinstance(layout, dict) and "left" in layout and "right" in layout:
+        left_margin = float(layout["left"])
+        right_margin = float(layout["right"])
+    else:
+        left_margin = float(mpl_fig.subplotpars.left)
+        right_margin = float(mpl_fig.subplotpars.right)
+
+    if position == "top":
+        y_center = 1.0 - band_frac / 2.0
+    else:
+        y_center = band_frac / 2.0
+
+    fontsize = font_pt
+
+    if align in ("left", "center"):
+        if align == "center":
+            x = 0.5
+            ha = "center"
+        else:
+            x = left_margin
+            ha = "left"
+        kwargs = {
+            "ha": ha,
+            "va": "center",
+            "fontsize": fontsize,
+            "bbox": dict(_CAPTION_BBOX),
+        }
+        mpl_fig.text(x, y_center, "\n".join(lines), **kwargs)
+        _record_text(record, x, y_center, "\n".join(lines), kwargs)
+        return
+
+    # align == "justify": full-width lines, last line left-aligned.
+    mpl_fig.canvas.draw()
+    renderer = mpl_fig.canvas.get_renderer()
+    dpi = mpl_fig.dpi
+
+    line_pitch_in = font_pt * _LINE_HEIGHT / 72.0
+    line_pitch_frac = line_pitch_in / new_h
+    n = len(lines)
+    # Stack lines vertically, centred on the band centre.
+    top_y = y_center + (n - 1) / 2.0 * line_pitch_frac
+
+    content_left = left_margin
+    content_right = right_margin
+
+    for i, line in enumerate(lines):
+        y = top_y - i * line_pitch_frac
+        words = line.split()
+        is_last = i == n - 1
+        if is_last or len(words) <= 1:
+            # Left-aligned (last line, or a single-word line cannot justify).
+            kwargs = {
+                "ha": "left",
+                "va": "center",
+                "fontsize": fontsize,
+            }
+            mpl_fig.text(content_left, y, line, **kwargs)
+            _record_text(record, content_left, y, line, kwargs)
+            continue
+
+        # Measure each word's width as a figure fraction.
+        word_fracs: List[float] = []
+        for word in words:
+            t = mpl_fig.text(0, 0, word, fontsize=fontsize)
+            ext = t.get_window_extent(renderer)
+            t.remove()
+            word_fracs.append(ext.width / (dpi * w_in))
+
+        total_words = sum(word_fracs)
+        gaps = len(words) - 1
+        span = content_right - content_left
+        slack = span - total_words
+        gap = slack / gaps if gaps > 0 else 0.0
+
+        x = content_left
+        for j, word in enumerate(words):
+            kwargs = {
+                "ha": "left",
+                "va": "center",
+                "fontsize": fontsize,
+            }
+            mpl_fig.text(x, y, word, **kwargs)
+            _record_text(record, x, y, word, kwargs)
+            x += word_fracs[j] + gap

--- a/src/figrecipe/_captions/_public.py
+++ b/src/figrecipe/_captions/_public.py
@@ -21,6 +21,22 @@ def _strip_markdown(text: str) -> str:
     return text.replace("**", "").replace("*", "")
 
 
+class _NullRecord:
+    """Stand-in record for a bare matplotlib Figure (no ``fig.record``).
+
+    The band helpers mirror geometry into a record so the recipe round-trips;
+    when there is nothing to round-trip (a plain ``Figure``), they harmlessly
+    write to this throwaway object instead.
+    """
+
+    def __init__(self) -> None:
+        self.figsize = None
+        self.layout = None
+        self.mm_layout = None
+        self.figure_texts: list = []
+        self.caption = None
+
+
 def add_figure_caption(
     fig: Any,
     caption: str,
@@ -31,6 +47,8 @@ def add_figure_caption(
     width_ratio: float = 0.9,
     font_size: Union[str, int] = "small",
     wrap_width: int = 80,
+    align: str = "justify",
+    pad_mm: float = 2.0,
     save_to_file: bool = False,
     file_path: Optional[str] = None,
 ) -> str:
@@ -58,6 +76,12 @@ def add_figure_caption(
         Font size for caption text.
     wrap_width : int
         Character width for text wrapping.
+    align : str
+        Caption alignment: "justify" (default), "left", or "center".
+        "justify" spans the full content width with the last line
+        left-aligned.
+    pad_mm : float
+        Gap (mm) between the caption band and the axes / figure edge.
     save_to_file : bool
         Whether to also save caption to a separate file.
     file_path : str, optional
@@ -100,80 +124,48 @@ def add_figure_caption(
         )
         return _strip_markdown(caption)
 
-    # Reserve room for the caption BEFORE rendering, by adjusting axes
-    # positions when they encroach on the caption strip.  The previous
-    # implementation called ``mpl_fig.subplots_adjust(bottom=0.15)`` and
-    # trusted that to move the panels, but on figrecipe's mm-laid figures
-    # (the paper-figure default) the bottom-row axes stayed near y0≈0.05
-    # and the caption text at y=0.02 landed on top of them.  We now
-    # nudge each axes via ``set_position`` so the fix is robust to the
-    # mm-layout path AND the plain subplots_adjust path.
-    reserved = 0.15  # caption strip height in figure-fraction
-    pad = 0.02  # gap between caption and nearest axes
-    if position == "bottom":
-        mpl_fig.subplots_adjust(bottom=reserved)
-        mpl_fig.canvas.draw()
-        mpl_axes = [ax for ax in mpl_fig.axes if ax.get_visible()]
-        if mpl_axes:
-            lowest = min(ax.get_position().y0 for ax in mpl_axes)
-            if lowest < reserved + pad:
-                delta = (reserved + pad) - lowest
-                for ax in mpl_axes:
-                    pos = ax.get_position()
-                    new_height = max(0.05, pos.height - delta)
-                    ax.set_position([pos.x0, pos.y0 + delta, pos.width, new_height])
-        y_pos, va = 0.02, "bottom"
-    else:
-        mpl_fig.subplots_adjust(top=1.0 - reserved)
-        mpl_fig.canvas.draw()
-        mpl_axes = [ax for ax in mpl_fig.axes if ax.get_visible()]
-        if mpl_axes:
-            highest = max(ax.get_position().y1 for ax in mpl_axes)
-            if highest > 1.0 - reserved - pad:
-                delta = highest - (1.0 - reserved - pad)
-                for ax in mpl_axes:
-                    pos = ax.get_position()
-                    new_height = max(0.05, pos.height - delta)
-                    ax.set_position([pos.x0, pos.y0, pos.width, new_height])
-        y_pos, va = 0.98, "top"
+    # ADDITIVE caption band: the figure GROWS by a caption band and the axes
+    # keep their EXACT mm size/position (identical to the no-caption figure).
+    # The previous implementation reserved space by SHRINKING the axes (a fixed
+    # 0.15 strip + per-axes ``set_position``), which on figrecipe's mm-precise
+    # figures grew the multi-line caption into the axes/xlabel and crowded the
+    # ylabel. We never shrink axes now: ``extend_figure_for_caption`` enlarges
+    # the canvas + rewrites subplotpars so the axes land at the same physical
+    # place, and ``place_caption`` draws the caption into the freed band and
+    # records every drawn fragment for verbatim save->reproduce replay.
+    from ._band import (
+        caption_band_inches,
+        extend_figure_for_caption,
+        place_caption,
+        resolve_caption_font_pt,
+        wrap_caption_lines,
+    )
 
     clean_caption = _strip_markdown(caption)
 
-    # Persist caption in the recipe record for round-trip.
+    font_pt = resolve_caption_font_pt(font_size, mpl_fig)
+    lines = wrap_caption_lines(clean_caption, wrap_width)
+    band_in = caption_band_inches(len(lines), font_pt, pad_mm)
+
+    # Persist the caption text itself for round-trip metadata.
     if hasattr(fig, "record"):
         fig.record.caption = caption
-        fig.record.figure_texts.append(
-            {
-                "x": 0.5,
-                "y": y_pos,
-                "s": clean_caption,
-                "kwargs": {
-                    "ha": "center",
-                    "va": va,
-                    "fontsize": font_size,
-                    "wrap": True,
-                    "bbox": dict(
-                        boxstyle="round,pad=0.5", facecolor="white", alpha=0.8
-                    ),
-                },
-            }
-        )
 
-    # Render the caption text — ONCE.  This is the single source of
-    # visual truth; ``caption_manager.add_figure_caption`` below is
-    # called with ``render=False`` so it only registers metadata
-    # (numbering, registry, optional file save) and does NOT draw a
-    # second copy of the caption (the previous double-render bug stacked
-    # two captions on the same y-anchor and they overlapped each other).
-    mpl_fig.text(
-        0.5,
-        y_pos,
-        clean_caption,
-        ha="center",
-        va=va,
-        fontsize=font_size,
-        wrap=True,
-        bbox=dict(boxstyle="round,pad=0.5", facecolor="white", alpha=0.8),
+    record = fig.record if hasattr(fig, "record") else _NullRecord()
+
+    extend_figure_for_caption(mpl_fig, record, band_in, position)
+    # Render the caption text — ONCE. This is the single source of visual truth;
+    # ``caption_manager.add_figure_caption`` below is called with render=False so
+    # it only registers metadata and does NOT draw a second copy.
+    place_caption(
+        mpl_fig,
+        record,
+        lines,
+        font_pt,
+        position,
+        align,
+        band_in,
+        width_ratio,
     )
 
     # Register with internal manager for numbering/export ONLY.

--- a/src/figrecipe/_composition/_caption_render.py
+++ b/src/figrecipe/_composition/_caption_render.py
@@ -67,6 +67,16 @@ def render_compose_captions(
 
     _manuscript = is_manuscript_mode()
 
+    # --- Figure-level caption (rendered FIRST so the additive caption band has
+    # already grown the figure and shifted the panels up; the per-panel captions
+    # below are then placed against the final post-band panel positions instead
+    # of stale pre-band ones). add_figure_caption suppresses its own draw in
+    # manuscript mode, so this stays a no-op on the canvas there. ---
+    if caption:
+        from .._captions._public import add_figure_caption
+
+        add_figure_caption(fig, caption, position="bottom")
+
     # --- Per-panel captions: render label + text above each panel ---
     # Suppressed in manuscript mode (LaTeX typesets them from the .tex sidecar).
     if panel_captions and not _manuscript:
@@ -109,12 +119,6 @@ def render_compose_captions(
                         "kwargs": dict(text_kwargs),
                     }
                 )
-
-    # --- Figure-level caption ---
-    if caption:
-        from .._captions._public import add_figure_caption
-
-        add_figure_caption(fig, caption, position="bottom")
 
 
 __all__ = [

--- a/tests/figrecipe/_captions/test__band.py
+++ b/tests/figrecipe/_captions/test__band.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Additive caption-band tests (operator-approved redesign).
+
+``fr.add_figure_caption(fig, caption, position="bottom")`` must be ADDITIVE:
+the figure GROWS by a caption band, the axes keep their EXACT mm size and
+position, and the caption NEVER overlaps the axes. The default ``align`` is
+"justify" (full-width lines, last line left-aligned), which records each word
+fragment separately so the band reproduces verbatim through save -> reproduce.
+
+Tests are AAA-structured (STX-TQ002) with one assertion each (STX-TQ007), one
+behaviour per test, no mocks/monkeypatch (STX-TQ rules).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import pytest
+
+# A multi-line scientific caption that reproduces the neurovista overlap bug.
+_NEUROVISTA_CAPTION = (
+    "Prospective Sz-vs-IC prediction (Bayesian logistic, leakage-free "
+    "expanding window; test = clinical Sz vs time-matched IC only). x = "
+    "number of clinical seizures in training. Gray = clinical only; crimson "
+    "= SLE added to training only. Bands = 95% bootstrap CI; faint = "
+    "patients; in-plot counts = median training sizes."
+)
+
+
+def _neurovista_fig():
+    """Build the neurovista repro figure with a bottom caption.
+
+    Returns (fig, mpl_fig, mpl_ax).
+    """
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(1, 1, axes_width_mm=120, axes_height_mm=68)
+    raw = ax._ax if hasattr(ax, "_ax") else ax
+    raw.plot(
+        [0, 1, 2, 3, 4, 5],
+        [0.59, 0.66, 0.65, 0.66, 0.71, 0.80],
+        marker="o",
+        label="x",
+    )
+    raw.set_xlabel("number of clinical seizures n in training")
+    raw.set_ylabel("prospective AUC")
+    raw.legend(frameon=False)
+    fr.add_figure_caption(fig, _NEUROVISTA_CAPTION, position="bottom")
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    return fig, mpl_fig, raw
+
+
+def test_caption_band_never_overlaps_axes():
+    # Arrange
+    _fig, mpl_fig, raw_ax = _neurovista_fig()
+    mpl_fig.canvas.draw()
+    renderer = mpl_fig.canvas.get_renderer()
+    inv = mpl_fig.transFigure.inverted()
+    caption_top = max(
+        t.get_window_extent(renderer).transformed(inv).y1 for t in mpl_fig.texts
+    )
+    axes_bottom = raw_ax.get_position().y0
+
+    # Act
+    no_overlap = caption_top <= axes_bottom + 1e-9
+
+    # Assert
+    assert no_overlap
+    plt.close(mpl_fig)
+
+
+def test_caption_is_additive_grows_figure_height():
+    # Arrange
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(1, 1, axes_width_mm=120, axes_height_mm=68)
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    height_before = mpl_fig.get_size_inches()[1]
+
+    # Act
+    fr.add_figure_caption(fig, _NEUROVISTA_CAPTION, position="bottom")
+    height_after = mpl_fig.get_size_inches()[1]
+
+    # Assert
+    assert height_after > height_before
+    plt.close(mpl_fig)
+
+
+def test_caption_preserves_axes_size_in_inches():
+    # Arrange
+    import figrecipe as fr
+    from figrecipe._api._save_layout import settle_constrained_layout
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(1, 1, axes_width_mm=120, axes_height_mm=68)
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    raw = ax._ax if hasattr(ax, "_ax") else ax
+    # Settle the layout engine so the axes rect is its converged fixed point
+    # (the no-caption baseline); the additive band must leave THIS rect intact.
+    settle_constrained_layout(mpl_fig)
+    w0, h0 = mpl_fig.get_size_inches()
+    pos0 = raw.get_position()
+    ax_w_in_before = pos0.width * w0
+    ax_h_in_before = pos0.height * h0
+
+    # Act
+    fr.add_figure_caption(fig, _NEUROVISTA_CAPTION, position="bottom")
+    mpl_fig.canvas.draw()
+    w1, h1 = mpl_fig.get_size_inches()
+    pos1 = raw.get_position()
+    ax_size_in_after = (pos1.width * w1, pos1.height * h1)
+
+    # Assert
+    assert ax_size_in_after == pytest.approx((ax_w_in_before, ax_h_in_before), abs=1e-6)
+    plt.close(mpl_fig)
+
+
+def test_justify_default_records_word_fragments():
+    # Arrange
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(1, 1, axes_width_mm=120, axes_height_mm=68)
+
+    # Act
+    fr.add_figure_caption(fig, _NEUROVISTA_CAPTION, position="bottom")
+    n_recorded = len(fig.record.figure_texts)
+
+    # Assert: justify splits non-last lines into separate word fragments.
+    assert n_recorded > 1
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    plt.close(mpl_fig)
+
+
+def test_caption_band_round_trips_figsize(tmp_path):
+    # Arrange
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(1, 1, axes_width_mm=120, axes_height_mm=68)
+    raw = ax._ax if hasattr(ax, "_ax") else ax
+    raw.plot([0, 1, 2], [0, 1, 2])
+    fr.add_figure_caption(fig, _NEUROVISTA_CAPTION, position="bottom")
+    recorded_figsize = tuple(fig.record.figsize)
+    recipe = tmp_path / "fig.png"
+    fr.save(fig, str(recipe), verbose=False, validate=False)
+
+    # Act
+    rfig, _rax = fr.reproduce(str(recipe))
+    reproduced_mpl = rfig._fig if hasattr(rfig, "_fig") else rfig
+    reproduced_figsize = tuple(reproduced_mpl.get_size_inches())
+
+    # Assert
+    assert reproduced_figsize == pytest.approx(recorded_figsize, abs=1e-6)
+    plt.close(reproduced_mpl)

--- a/tests/figrecipe/_composition/test__caption_render.py
+++ b/tests/figrecipe/_composition/test__caption_render.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Composed-figure caption-band tests (operator-approved redesign).
+
+A composed figure's FIGURE-LEVEL caption routes through the same additive
+``add_figure_caption`` as single figures, so it must obey the same rule: the
+composed figure GROWS by a caption band and the caption NEVER overlaps the
+panels (or the per-panel ``(A)/(B)`` labels, which are re-placed against the
+post-band panel positions).
+
+AAA-structured (STX-TQ002), one assertion each (STX-TQ007), no mocks.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+
+_COMPOSED_CAPTION = (
+    "Prospective seizure-vs-interictal prediction across an expanding, "
+    "leakage-free training window, comparing the clinical-only model against "
+    "the SLE-augmented model. Panel A shows the learning curve; panel B shows "
+    "the matched sample-size growth. Bands are 95% bootstrap confidence "
+    "intervals; faint traces are individual patients."
+)
+
+
+def _two_source_recipes(tmp_path):
+    """Save two single-axes recipes and return their paths."""
+    import figrecipe as fr
+
+    paths = []
+    for i in range(2):
+        fig, ax = fr.subplots(1, 1, axes_width_mm=60, axes_height_mm=45)
+        ax.plot([0, 1, 2, 3], [0, 1, 4, 9])
+        recipe = tmp_path / f"src{i}.yaml"
+        fr.save(fig, str(recipe), validate=False, verbose=False)
+        mpl = fig._fig if hasattr(fig, "_fig") else fig
+        plt.close(mpl)
+        paths.append(str(recipe))
+    return paths
+
+
+def _rects_overlap(a, b):
+    """True when two (x0, y0, x1, y1) rectangles overlap with positive area."""
+    return a[0] < b[2] and b[0] < a[2] and a[1] < b[3] and b[1] < a[3]
+
+
+def test_composed_caption_never_overlaps_any_panel(tmp_path):
+    # Arrange
+    import figrecipe as fr
+
+    r0, r1 = _two_source_recipes(tmp_path)
+    fig, _axes = fr.compose(
+        layout=(1, 2),
+        sources={(0, 0): r0, (0, 1): r1},
+        caption=_COMPOSED_CAPTION,
+    )
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    mpl_fig.canvas.draw()
+    renderer = mpl_fig.canvas.get_renderer()
+    inv = mpl_fig.transFigure.inverted()
+    axes_rects = [
+        (
+            ax.get_position().x0,
+            ax.get_position().y0,
+            ax.get_position().x1,
+            ax.get_position().y1,
+        )
+        for ax in mpl_fig.axes
+        if ax.get_visible()
+    ]
+    text_rects = [
+        (
+            ext.x0,
+            ext.y0,
+            ext.x1,
+            ext.y1,
+        )
+        for t in mpl_fig.texts
+        for ext in [t.get_window_extent(renderer).transformed(inv)]
+    ]
+
+    # Act
+    any_overlap = any(_rects_overlap(tr, ar) for tr in text_rects for ar in axes_rects)
+
+    # Assert
+    assert not any_overlap
+    plt.close(mpl_fig)
+
+
+def test_composed_caption_grows_figure_height(tmp_path):
+    # Arrange
+    import figrecipe as fr
+
+    r0, r1 = _two_source_recipes(tmp_path)
+    plain, _a = fr.compose(layout=(1, 2), sources={(0, 0): r0, (0, 1): r1})
+    plain_mpl = plain._fig if hasattr(plain, "_fig") else plain
+    height_plain = plain_mpl.get_size_inches()[1]
+    plt.close(plain_mpl)
+
+    # Act
+    captioned, _b = fr.compose(
+        layout=(1, 2),
+        sources={(0, 0): r0, (0, 1): r1},
+        caption=_COMPOSED_CAPTION,
+    )
+    captioned_mpl = captioned._fig if hasattr(captioned, "_fig") else captioned
+    height_captioned = captioned_mpl.get_size_inches()[1]
+
+    # Assert
+    assert height_captioned > height_plain
+    plt.close(captioned_mpl)


### PR DESCRIPTION
## Summary
- `add_figure_caption` is now **additive**: the figure grows by a measured caption band and the axes keep their exact mm size/position — a multi-line caption can no longer overlap the axes / x / y labels. (Previously it shrank the axes via a fixed `subplots_adjust(bottom=0.15)`.)
- New `align` param: **`justify`** (default — full-width, last line left), `center`, `left`; plus a `pad_mm` band-gap knob.
- Applies to **composed figures** too (`fr.compose(caption=...)`): the figure-level caption grows the figure first, then per-panel `(A)/(B)` labels are placed against the post-band positions (no misalignment).
- Round-trips through `save`→`reproduce` (figsize/layout/mm_layout + recorded text fragments). Manuscript path unchanged (`.tex` sidecar).

In-image captions are for casual researcher communication / reports / grant figures — never the manuscript.

## Test plan
- [x] `tests/figrecipe/_captions/test__band.py` (5) — never-overlap (neurovista repro), additive, axes-preserved, justify fragments, round-trip
- [x] `tests/figrecipe/_composition/test__caption_render.py` (2) — composed caption never overlaps panels + additive
- [x] Full local testmon suite green