### PR TITLE
fix(captions+panel-labels): justify sparse-line cap + auto-label size/family (0.29.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   left-and-right (the caption body matches the panel width), only the sparse and
   last lines ragged-right. Adds test coverage for `align="center"`/`"left"` and
   `position="top"`.
+- **Auto panel labels (A)/(B) now render at the correct size and font.**
+  `fig.add_panel_labels()` (used by `fr.subplots(..., panel_labels=True)`) read
+  the plot-title size (`title_pt`, 8pt) instead of the panel-label convention
+  (`panel_label_pt`, 10pt), and inherited a generic `sans-serif` family rather
+  than the style's explicitly-resolved family — so the labels came out the wrong
+  size and in a different face from the axis labels/ticks. They now use
+  `panel_label_pt` (10pt bold in SCITEX) and the same resolved family as the
+  body (Arial, or its installed fallback), so labels match the rest of the
+  figure.
 
 ## [0.29.7] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.8] - 2026-06-28
+
+### Fixed
+- **Justified captions no longer stretch sparse lines into huge gaps.** With
+  `align="justify"` (the default), a line is now only stretched edge-to-edge
+  when its words already fill at least 60% of the available width; a sparser
+  line (few words on a wide figure) is left-aligned instead of having its
+  inter-word spaces blown up to several times normal. Full lines stay flush
+  left-and-right (the caption body matches the panel width), only the sparse and
+  last lines ragged-right. Adds test coverage for `align="center"`/`"left"` and
+  `position="top"`.
+
 ## [0.29.7] - 2026-06-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.7"
+version = "0.29.8"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_captions/_band.py
+++ b/src/figrecipe/_captions/_band.py
@@ -50,6 +50,12 @@ _RELATIVE_FONT_PT = {
 # Line-height multiple (caption line pitch = font_pt * this / 72 inch).
 _LINE_HEIGHT = 1.35
 
+# A justified line is only stretched edge-to-edge when its words already fill at
+# least this fraction of the available width. Sparser lines (few words on a wide
+# figure) left-align instead, so justify never blows the inter-word gaps up to
+# several times a normal space.
+_JUSTIFY_MIN_FILL = 0.6
+
 # Caption white round bbox (kept identical to the historical look).
 _CAPTION_BBOX = dict(boxstyle="round,pad=0.5", facecolor="white", alpha=0.8)
 
@@ -302,43 +308,39 @@ def place_caption(
 
     content_left = left_margin
     content_right = right_margin
+    span = content_right - content_left
 
     for i, line in enumerate(lines):
         y = top_y - i * line_pitch_frac
         words = line.split()
         is_last = i == n - 1
-        if is_last or len(words) <= 1:
-            # Left-aligned (last line, or a single-word line cannot justify).
-            kwargs = {
-                "ha": "left",
-                "va": "center",
-                "fontsize": fontsize,
-            }
-            mpl_fig.text(content_left, y, line, **kwargs)
-            _record_text(record, content_left, y, line, kwargs)
-            continue
 
-        # Measure each word's width as a figure fraction.
+        # Measure each word's width as a figure fraction. We need the totals to
+        # decide whether the line is full enough to justify without ugly gaps.
         word_fracs: List[float] = []
         for word in words:
             t = mpl_fig.text(0, 0, word, fontsize=fontsize)
             ext = t.get_window_extent(renderer)
             t.remove()
             word_fracs.append(ext.width / (dpi * w_in))
-
         total_words = sum(word_fracs)
         gaps = len(words) - 1
-        span = content_right - content_left
-        slack = span - total_words
-        gap = slack / gaps if gaps > 0 else 0.0
 
+        # Justify only lines that are non-last, multi-word, AND at least
+        # ``_JUSTIFY_MIN_FILL`` of the span full. A sparse line (few words on a
+        # wide figure) would otherwise stretch the inter-word gaps to several
+        # times a normal space — left-align it instead so the body still reads
+        # cleanly while the full lines stay flush left-and-right.
+        if is_last or gaps < 1 or total_words < _JUSTIFY_MIN_FILL * span:
+            kwargs = {"ha": "left", "va": "center", "fontsize": fontsize}
+            mpl_fig.text(content_left, y, line, **kwargs)
+            _record_text(record, content_left, y, line, kwargs)
+            continue
+
+        gap = (span - total_words) / gaps
         x = content_left
         for j, word in enumerate(words):
-            kwargs = {
-                "ha": "left",
-                "va": "center",
-                "fontsize": fontsize,
-            }
+            kwargs = {"ha": "left", "va": "center", "fontsize": fontsize}
             mpl_fig.text(x, y, word, **kwargs)
             _record_text(record, x, y, word, kwargs)
             x += word_fracs[j] + gap

--- a/src/figrecipe/_wrappers/_figure.py
+++ b/src/figrecipe/_wrappers/_figure.py
@@ -163,6 +163,25 @@ class RecordingFigure(FigureTextMixin):
             pass
         return default
 
+    def _get_resolved_font_family(self) -> Optional[str]:
+        """Resolve the actual font family the active style pins.
+
+        Returns the installed family the style applier uses for the body
+        elements (the requested font, e.g. ``Arial``, or its available
+        fallback) so the auto panel labels render in the SAME face. ``None``
+        when nothing can be resolved.
+        """
+        try:
+            from ..styles._fonts import check_font
+            from ..styles._style_loader import _STYLE_CACHE
+
+            requested = "Arial"
+            if _STYLE_CACHE is not None:
+                requested = getattr(_STYLE_CACHE, "font_family", None) or requested
+            return check_font(requested)
+        except Exception:
+            return None
+
     def _get_theme_text_color(self, default: str = "black") -> str:
         """Get text color from loaded style's theme settings."""
         try:
@@ -241,15 +260,28 @@ class RecordingFigure(FigureTextMixin):
         """
         from ._panel_labels import add_panel_labels as _add_panel_labels
 
-        # Get fontsize from style if not specified
+        # Get fontsize from style if not specified. Panel labels follow the
+        # panel_label_pt convention (10pt bold in SCITEX), NOT title_pt (the
+        # plot-title size, 8pt) — the previous title_pt lookup made the auto
+        # (A)/(B) labels the wrong size.
         if fontsize is None:
-            fontsize = self._get_style_fontsize("title_pt", 10)
+            fontsize = self._get_style_fontsize("panel_label_pt", 10)
 
         # Get theme text color (unless user provided 'color' in kwargs)
         if "color" not in kwargs:
             text_color = self._get_theme_text_color()
         else:
             text_color = kwargs.pop("color")
+
+        # Match the body's explicitly-resolved font family. The style applier
+        # pins the resolved family (e.g. Arial, or its DejaVu fallback) on the
+        # axis labels/ticks/title, but the auto panel labels otherwise inherit a
+        # generic 'sans-serif' that can resolve to a different/heavier face,
+        # making the labels look inconsistent with the rest of the figure.
+        if not any(k in kwargs for k in ("fontfamily", "fontname", "family")):
+            family = self._get_resolved_font_family()
+            if family:
+                kwargs["fontfamily"] = family
 
         def record_callback(info):
             self._recorder.figure_record.panel_labels = info

--- a/tests/figrecipe/_captions/test__band.py
+++ b/tests/figrecipe/_captions/test__band.py
@@ -159,3 +159,81 @@ def test_caption_band_round_trips_figsize(tmp_path):
     # Assert
     assert reproduced_figsize == pytest.approx(recorded_figsize, abs=1e-6)
     plt.close(reproduced_mpl)
+
+
+def test_justify_left_aligns_sparse_lines_on_wide_figure():
+    # Arrange
+    import figrecipe as fr
+    from figrecipe._captions._band import wrap_caption_lines
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(1, 1, axes_width_mm=180, axes_height_mm=60)
+    n_lines = len(wrap_caption_lines(_NEUROVISTA_CAPTION, 30))
+
+    # Act: narrow char-wrap on a wide figure -> every line is physically sparse,
+    # so the justify cap left-aligns them all (one recorded text per line, never
+    # split into stretched word fragments).
+    fr.add_figure_caption(
+        fig, _NEUROVISTA_CAPTION, position="bottom", align="justify", wrap_width=30
+    )
+    n_recorded = len(fig.record.figure_texts)
+
+    # Assert
+    assert n_recorded == n_lines
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    plt.close(mpl_fig)
+
+
+def test_align_center_records_a_centered_text():
+    # Arrange
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(1, 1, axes_width_mm=120, axes_height_mm=68)
+
+    # Act
+    fr.add_figure_caption(fig, _NEUROVISTA_CAPTION, position="bottom", align="center")
+    has_centered = any(
+        t.get("kwargs", {}).get("ha") == "center" for t in fig.record.figure_texts
+    )
+
+    # Assert
+    assert has_centered
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    plt.close(mpl_fig)
+
+
+def test_align_left_records_only_left_text():
+    # Arrange
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(1, 1, axes_width_mm=120, axes_height_mm=68)
+
+    # Act
+    fr.add_figure_caption(fig, _NEUROVISTA_CAPTION, position="bottom", align="left")
+    only_left = all(
+        t.get("kwargs", {}).get("ha") == "left" for t in fig.record.figure_texts
+    )
+
+    # Assert
+    assert only_left
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    plt.close(mpl_fig)
+
+
+def test_top_position_places_caption_in_upper_band():
+    # Arrange
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(1, 1, axes_width_mm=120, axes_height_mm=68)
+
+    # Act
+    fr.add_figure_caption(fig, _NEUROVISTA_CAPTION, position="top", align="left")
+    min_caption_y = min((t["y"] for t in fig.record.figure_texts), default=0.0)
+
+    # Assert
+    assert min_caption_y > 0.5
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    plt.close(mpl_fig)

--- a/tests/figrecipe/_wrappers/test__figure.py
+++ b/tests/figrecipe/_wrappers/test__figure.py
@@ -1,20 +1,69 @@
-"""Smoke import mirror for figrecipe._wrappers._figure.
+"""Tests for figrecipe._wrappers._figure (incl. auto panel-label size/family)."""
 
-Auto-generated subpackage mirror placeholder; replace with real tests
-as the module matures. Satisfies the src<->tests mirror audit rule.
-"""
+import string
 
+import matplotlib
 
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
 import pytest
 
 
 def test_import__wrappers__figure_module():
     # Arrange
-    # Arrange
-    # Act
-    # Assert
-    module_path = 'figrecipe._wrappers._figure'
+    module_path = "figrecipe._wrappers._figure"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+def _scitex_panel_label_figure():
+    """Build a 1x2 SCITEX figure with auto panel labels; return (mpl_fig, ax0)."""
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, axes = fr.subplots(
+        1, 2, axes_width_mm=90, axes_height_mm=70, panel_labels=True
+    )
+    for ax in axes:
+        ax.plot([0, 1, 2], [0, 1, 2])
+        ax.set_xlabel("x")
+    mpl_fig = fig._fig if hasattr(fig, "_fig") else fig
+    mpl_fig.canvas.draw()
+    return mpl_fig, mpl_fig.axes[0]
+
+
+def _panel_label_text(mpl_fig):
+    """Return the first auto panel-label (single uppercase letter) Text."""
+    for a in mpl_fig.axes:
+        for t in a.texts:
+            if t.get_text() in set(string.ascii_uppercase):
+                return t
+    return None
+
+
+def test_auto_panel_labels_use_panel_label_pt_size():
+    # Arrange
+    mpl_fig, _ax0 = _scitex_panel_label_figure()
+
+    # Act
+    label = _panel_label_text(mpl_fig)
+
+    # Assert: SCITEX panel_label_pt is 10 (NOT title_pt=8).
+    assert label.get_fontsize() == 10.0
+    plt.close(mpl_fig)
+
+
+def test_auto_panel_labels_match_body_font_family():
+    # Arrange
+    mpl_fig, ax0 = _scitex_panel_label_figure()
+
+    # Act
+    label = _panel_label_text(mpl_fig)
+    same_family = label.get_fontfamily() == ax0.xaxis.label.get_fontfamily()
+
+    # Assert
+    assert same_family
+    plt.close(mpl_fig)


### PR DESCRIPTION
## Summary
- **Justify sparse-line cap**: `align="justify"` (default) only stretches a line edge-to-edge when its words fill ≥60% of the width; sparser lines left-align instead of blowing inter-word gaps to 3-4x. Full lines stay flush left-and-right (caption body = panel width). Fixes the ugly gaps neurovista hit on wide figures.
- **Auto panel-label fix**: `fig.add_panel_labels()` (`fr.subplots(..., panel_labels=True)`) now uses `panel_label_pt` (10pt bold in SCITEX), not `title_pt` (8pt), and sets the same explicitly-resolved font family as the body (Arial or its fallback) instead of a generic `sans-serif` — so auto (A)/(B) labels match the rest of the figure.

Both reported by the neurovista operator while rebuilding manuscript Figs 3–6.

## Test plan
- [x] `tests/figrecipe/_captions/test__band.py` — justify-cap + align center/left + position top (9 total)
- [x] `tests/figrecipe/_wrappers/test__figure.py` — auto labels = panel_label_pt size + body-matching family
- [x] Full local testmon suite green