### PR TITLE
fix(figure): title-aware panel labels + imshow aspect + numpy-scalar recipe save (0.29.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.9] - 2026-06-28
+
+### Fixed
+- **Auto panel labels no longer overlap the axes title.** `fr.subplots(...,
+  panel_labels=True)` adds the (A)/(B)/(C)/(D) labels at construction time —
+  before titles exist — so a fixed `y=1.05` offset landed the label on a title
+  set later via `set_xyt`. Labels are now lifted clear of the title at save
+  time: a title-aware label sits just above the title (scaled by the title
+  height), while an axes with no title keeps the default placement (back-compat),
+  and an explicit user `offset` is honored verbatim.
+- **`imshow` honors an explicitly-passed `aspect` (e.g. `"auto"`).** The imshow
+  styler now distinguishes "caller passed no aspect" (defaults to the style's
+  `"equal"`) from an explicit aspect, so `ax.imshow(..., aspect="auto")` is never
+  silently coerced back to `"equal"` by the styler. (Note: for a square heatmap
+  filling square mm axes, also use a dedicated colorbar axes — e.g.
+  `make_axes_locatable(...).append_axes(...)` — so the colorbar doesn't shrink
+  the host axes off-square.)
+- **Recipe save no longer crashes on numpy-scalar labels/values.** A numpy
+  scalar reaching the recipe serializer (most commonly `np.str_` from a
+  DataFrame column, but also `np.complex*`, `np.datetime64`, etc.) was handed
+  straight to the YAML representer and raised
+  `RepresenterError: cannot represent np.str_('…')`. The numpy→native coercion
+  now has an `np.generic` catch-all (`.item()`) so any numpy scalar normalises to
+  its native Python type before serialization. (Previously only `np.ndarray`/
+  `np.integer`/`np.floating`/`np.bool_` were handled.)
+
 ## [0.29.8] - 2026-06-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.8"
+version = "0.29.9"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_api/_save.py
+++ b/src/figrecipe/_api/_save.py
@@ -146,6 +146,12 @@ def save_figure(
         finalize_ticks(ax)
         finalize_special_plots(ax, style_dict)
 
+    # Lift auto panel labels above their axes titles (titles set via set_xyt
+    # exist by now; panel_labels=True added the labels before them).
+    from .._wrappers._panel_labels import finalize_panel_labels
+
+    finalize_panel_labels(fig.fig)
+
     # Runtime axis-range-alignment check (complements static STX-FIG001).
     # Default warning-level — per operator preference (figrecipe #134), never
     # kill the script after the PNG has been written.

--- a/src/figrecipe/_serializer/_utils.py
+++ b/src/figrecipe/_serializer/_utils.py
@@ -17,6 +17,14 @@ def _convert_numpy_types(obj: Any) -> Any:
         return float(obj)
     elif isinstance(obj, np.bool_):
         return bool(obj)
+    elif isinstance(obj, np.generic):
+        # Catch-all for any remaining numpy scalar — np.str_, np.bytes_,
+        # np.complex*, np.datetime64, etc. `.item()` returns the native Python
+        # equivalent. Labels/ticks coming from a DataFrame column or numpy array
+        # commonly arrive as np.str_ / np.float64; without this they reach the
+        # YAML representer untouched and crash recipe save (ruamel
+        # RepresenterError: cannot represent np.str_(...)).
+        return obj.item()
     elif isinstance(obj, dict):
         return {k: _convert_numpy_types(v) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple)):

--- a/src/figrecipe/_wrappers/_figure.py
+++ b/src/figrecipe/_wrappers/_figure.py
@@ -286,6 +286,11 @@ class RecordingFigure(FigureTextMixin):
         def record_callback(info):
             self._recorder.figure_record.panel_labels = info
 
+        # Title-awareness applies only to the default upper-position placement.
+        # When the user passes an explicit offset we honor it verbatim (the
+        # label is then their responsibility), preserving back-compat.
+        title_aware = loc == "upper left" and offset == (-0.1, 1.05)
+
         return _add_panel_labels(
             all_axes=self.flat,
             labels=labels,
@@ -295,6 +300,7 @@ class RecordingFigure(FigureTextMixin):
             fontweight=fontweight,
             text_color=text_color,
             record_callback=record_callback,
+            title_aware=title_aware,
             **kwargs,
         )
 

--- a/src/figrecipe/_wrappers/_panel_labels.py
+++ b/src/figrecipe/_wrappers/_panel_labels.py
@@ -18,6 +18,7 @@ def add_panel_labels(
     fontweight: str,
     text_color: str,
     record_callback: Any,
+    title_aware: bool = False,
     **kwargs,
 ) -> List[Any]:
     """Add panel labels (A, B, C, D, etc.) to axes.
@@ -40,6 +41,13 @@ def add_panel_labels(
         Text color.
     record_callback : callable
         Callback to record panel labels info.
+    title_aware : bool
+        When True (the default-offset upper-position path), each label's y is
+        lifted ABOVE its axes title at draw time so the label never renders ON
+        the title. The lift is evaluated lazily because ``panel_labels=True``
+        adds labels BEFORE the user sets titles (via ``set_xyt``). Has no effect
+        for an axes without a title (back-compat). When False (an explicit
+        user offset) the offset is honored verbatim.
     **kwargs
         Additional arguments passed to ax.text().
 
@@ -88,9 +96,84 @@ def add_panel_labels(
             va=va,
             **kwargs,
         )
+        if title_aware:
+            # Tag the label so the save-time finalizer can lift it clear of
+            # the axes title. We tag (rather than position now) because
+            # ``panel_labels=True`` adds labels BEFORE the user sets titles via
+            # ``set_xyt``; the title height is only known at draw/save time.
+            text._figrecipe_panel_label_base_y = y
         text_objects.append(text)
 
     return text_objects
+
+
+def finalize_panel_labels(mpl_fig: Any) -> None:
+    """Lift title-aware panel labels above titles for a whole figure.
+
+    Save-time entry point: draws the figure once (so titles exist and extents
+    are measurable), then adjusts every axes' panel labels. Safe to call when
+    no title-aware labels are present (it is a no-op then).
+
+    Parameters
+    ----------
+    mpl_fig : matplotlib.figure.Figure
+        The figure whose axes' panel labels to finalize.
+    """
+    mpl_fig.canvas.draw()
+    renderer = mpl_fig.canvas.get_renderer()
+    for mpl_ax in mpl_fig.get_axes():
+        clear_panel_labels_above_titles(mpl_ax, renderer)
+
+
+def clear_panel_labels_above_titles(mpl_ax: Any, renderer: Any) -> None:
+    """Lift title-aware panel labels above their axes title.
+
+    Called at save/finalize time (when titles exist and a renderer is
+    available) for every axes. For each panel label tagged title-aware (see
+    ``add_panel_labels``), if the axes has a non-empty title the label's y is
+    raised to sit ABOVE the title by the title's height in axes-fraction plus a
+    small pad, so it never renders on the title. When the axes has no title the
+    label keeps its original base y -- preserving the default placement
+    (back-compat). Idempotent: re-running recomputes from the stored base y.
+
+    Parameters
+    ----------
+    mpl_ax : matplotlib.axes.Axes
+        The axes whose panel-label texts to adjust.
+    renderer : RendererBase
+        An active renderer for measuring title/axes extents.
+    """
+    pad_fraction = 0.02  # gap between title top and label, in axes-fraction
+
+    fig = mpl_ax.figure
+    title = mpl_ax.get_title()
+
+    ax_bbox = mpl_ax.get_window_extent(renderer)
+    ax_height_pt = ax_bbox.height * 72.0 / fig.dpi
+
+    for text in list(mpl_ax.texts):
+        base_y = getattr(text, "_figrecipe_panel_label_base_y", None)
+        if base_y is None:
+            continue
+
+        if not title or ax_height_pt <= 0:
+            # No title -> restore default placement.
+            _set_label_y(text, base_y)
+            continue
+
+        title_bbox = mpl_ax.title.get_window_extent(renderer)
+        title_height_pt = title_bbox.height * 72.0 / fig.dpi
+        title_height_frac = title_height_pt / ax_height_pt
+
+        target_y = max(base_y, 1.0 + title_height_frac + pad_fraction)
+        _set_label_y(text, target_y)
+
+
+def _set_label_y(text: Any, y: float) -> None:
+    """Set a Text's y position (axes-fraction) without disturbing its x."""
+    x, cur_y = text.get_position()
+    if cur_y != y:
+        text.set_position((x, y))
 
 
 def _calculate_position(
@@ -122,7 +205,12 @@ def _calculate_position(
     return x, y, ha, va
 
 
-__all__ = ["add_panel_labels", "panel_label"]
+__all__ = [
+    "add_panel_labels",
+    "panel_label",
+    "clear_panel_labels_above_titles",
+    "finalize_panel_labels",
+]
 
 
 def panel_label(
@@ -175,5 +263,6 @@ def panel_label(
         va=va,
         **kwargs,
     )
+
 
 # EOF

--- a/src/figrecipe/styles/plot_stylers/_imshow.py
+++ b/src/figrecipe/styles/plot_stylers/_imshow.py
@@ -8,6 +8,13 @@ from typing import Any, Optional
 
 from ._base import PlotStyler
 
+# Sentinel distinguishing "caller did not pass aspect" (-> default to the
+# style's "equal") from an explicit aspect the caller DID pass (including the
+# string "auto"). Using ``None`` for the default is not enough: ``None`` is a
+# legitimate value a caller might forward, and historically caused an explicit
+# user aspect to be clobbered back to "equal" when the styler was re-applied.
+_ASPECT_UNSET = object()
+
 
 class ImshowStyler(PlotStyler):
     """Styler for matplotlib imshow elements.
@@ -37,7 +44,7 @@ class ImshowStyler(PlotStyler):
         image: Any,
         ax: Optional[Any] = None,
         interpolation: Optional[str] = None,
-        aspect: Optional[str] = None,
+        aspect: Any = _ASPECT_UNSET,
         cmap: Optional[str] = None,
     ) -> Any:
         """Apply styling to an imshow plot.
@@ -51,7 +58,10 @@ class ImshowStyler(PlotStyler):
         interpolation : str, optional
             Interpolation method. Default from style or "nearest".
         aspect : str, optional
-            Aspect ratio. Default: "equal".
+            Aspect ratio. If the caller passes one EXPLICITLY (e.g. "auto"),
+            it wins and is applied as-is. Only when the caller omits ``aspect``
+            entirely does this default to the style's "equal" -- so a user's
+            ``ax.imshow(..., aspect="auto")`` is never clobbered to "equal".
         cmap : str, optional
             Colormap to apply.
 
@@ -63,7 +73,9 @@ class ImshowStyler(PlotStyler):
         # Get parameters with defaults from style
         if interpolation is None:
             interpolation = self.get_param("interpolation", "nearest")
-        if aspect is None:
+        # Only fall back to the style default when the caller did NOT pass an
+        # aspect. An explicitly-passed aspect (including "auto") wins.
+        if aspect is _ASPECT_UNSET:
             aspect = self.get_param("aspect", "equal")
 
         # Apply interpolation
@@ -85,7 +97,7 @@ def style_imshow(
     image: Any,
     ax: Optional[Any] = None,
     interpolation: Optional[str] = None,
-    aspect: Optional[str] = None,
+    aspect: Any = _ASPECT_UNSET,
     cmap: Optional[str] = None,
     style: Any = None,
 ) -> Any:
@@ -102,7 +114,8 @@ def style_imshow(
     interpolation : str, optional
         Interpolation method. Default: "nearest".
     aspect : str, optional
-        Aspect ratio. Default: "equal".
+        Aspect ratio. If passed explicitly (e.g. "auto") it wins; only when
+        omitted does it default to the style's "equal".
     cmap : str, optional
         Colormap to apply.
     style : DotDict, optional

--- a/tests/figrecipe/_wrappers/test__figure.py
+++ b/tests/figrecipe/_wrappers/test__figure.py
@@ -67,3 +67,57 @@ def test_auto_panel_labels_match_body_font_family():
     # Assert
     assert same_family
     plt.close(mpl_fig)
+
+
+def _scitex_titled_panel_label_figure(tmp_path):
+    """Build+save a 1x2 SCITEX figure with auto labels AND axes titles.
+
+    Titles are set via ``set_xyt`` AFTER ``panel_labels=True`` (mirroring real
+    usage), then the figure is saved so the title-clearance finalizer runs.
+    Returns the real matplotlib figure.
+    """
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, axes = fr.subplots(
+        1, 2, axes_width_mm=90, axes_height_mm=70, panel_labels=True
+    )
+    for ax in axes:
+        ax.plot([0, 1], [0, 1])
+        ax.set_xyt("x", "y", "A Long Panel Title")
+    fr.save(fig, str(tmp_path / "fig.png"))
+    return fig._fig if hasattr(fig, "_fig") else fig
+
+
+def _max_label_title_band_intersection(mpl_fig):
+    """Largest vertical-band overlap (device px) of a panel label and its title.
+
+    The auto label is anchored at the left (x=-0.1) while the title is centred,
+    so a fixed-y label that sits ON the title shares the title's VERTICAL band
+    even when their x-ranges do not cross. Measuring the y-band intersection
+    therefore captures the "label rendered on the title" defect that the
+    title-clearance fix removes. Returns the worst (max) overlap; 0.0 means
+    every label sits cleanly above its title.
+    """
+    renderer = mpl_fig.canvas.get_renderer()
+    worst = 0.0
+    for a in mpl_fig.axes:
+        label = None
+        for t in a.texts:
+            if t.get_text() in set(string.ascii_uppercase):
+                label = t
+        if label is None or not a.get_title():
+            continue
+        lb = label.get_window_extent(renderer)
+        tb = a.title.get_window_extent(renderer)
+        worst = max(worst, max(0.0, min(lb.y1, tb.y1) - max(lb.y0, tb.y0)))
+    return worst
+
+
+def test_auto_panel_labels_do_not_overlap_axes_title(tmp_path):
+    # Arrange
+    mpl_fig = _scitex_titled_panel_label_figure(tmp_path)
+    # Act
+    band_overlap = _max_label_title_band_intersection(mpl_fig)
+    # Assert
+    assert band_overlap == 0.0

--- a/tests/figrecipe/styles/plot_stylers/test__imshow.py
+++ b/tests/figrecipe/styles/plot_stylers/test__imshow.py
@@ -1,20 +1,72 @@
-"""Smoke import mirror for figrecipe.styles.plot_stylers._imshow.
+"""Tests for figrecipe.styles.plot_stylers._imshow (incl. aspect honoring)."""
 
-Auto-generated subpackage mirror placeholder; replace with real tests
-as the module matures. Satisfies the src<->tests mirror audit rule.
-"""
+import glob
 
+import matplotlib
 
+matplotlib.use("Agg")
+
+import numpy as np
 import pytest
 
 
 def test_import_styles_plot_stylers__imshow_module():
     # Arrange
-    # Arrange
-    # Act
-    # Assert
-    module_path = 'figrecipe.styles.plot_stylers._imshow'
+    module_path = "figrecipe.styles.plot_stylers._imshow"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+def _reproduced_imshow_aspect(tmp_path, aspect_kwarg):
+    """Save a SCITEX imshow then reproduce it; return the reproduced aspect.
+
+    ``aspect_kwarg`` is a dict of kwargs forwarded to ``ax.imshow`` so callers
+    can include or omit ``aspect``. The aspect is read off the REPRODUCED axes
+    so the save->reproduce cycle is exercised (the bug was save-time).
+    """
+    import figrecipe as fr
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots(axes_width_mm=40, axes_height_mm=40)
+    ax.imshow(np.random.rand(28, 120), **aspect_kwarg)
+    fr.save(fig, str(tmp_path / "fig.png"))
+    yaml_path = glob.glob(str(tmp_path / "*.yaml"))[0]
+    reproduced = fr.reproduce(yaml_path)
+    rfig = reproduced[0] if isinstance(reproduced, tuple) else reproduced
+    mpl_fig = rfig.fig if hasattr(rfig, "fig") else rfig
+    return mpl_fig.get_axes()[0].get_aspect()
+
+
+def test_explicit_imshow_aspect_auto_survives_save_reproduce(tmp_path):
+    # Arrange
+    aspect_kwarg = {"aspect": "auto"}
+    # Act
+    reproduced_aspect = _reproduced_imshow_aspect(tmp_path, aspect_kwarg)
+    # Assert
+    assert reproduced_aspect == "auto"
+
+
+def test_default_imshow_aspect_stays_equal_when_unspecified(tmp_path):
+    # Arrange
+    aspect_kwarg = {}
+    # Act
+    reproduced_aspect = _reproduced_imshow_aspect(tmp_path, aspect_kwarg)
+    # Assert
+    assert reproduced_aspect == 1.0
+
+
+def test_styler_honors_explicit_aspect_auto():
+    # Arrange
+    import figrecipe as fr
+    from figrecipe.styles.plot_stylers._imshow import ImshowStyler
+
+    fr.load_style("SCITEX", background="white")
+    fig, ax = fr.subplots()
+    image = ax.imshow(np.random.rand(10, 10))
+    styler = ImshowStyler()
+    # Act
+    styler.apply(image, ax=ax.ax, aspect="auto")
+    # Assert
+    assert ax.ax.get_aspect() == "auto"

--- a/tests/integration/test_numpy_scalar_serialization.py
+++ b/tests/integration/test_numpy_scalar_serialization.py
@@ -69,3 +69,23 @@ def test_numpy_int_text_x_replays_as_number(np_int_text_recipe):
     plt.close("all")
     # Assert
     assert not isinstance(replayed_x, str)
+
+
+def test_numpy_str_label_saves_without_representer_crash(tmp_path):
+    # Arrange — np.str_ (e.g. a label from a DataFrame column) used to crash
+    # recipe->YAML save with ruamel RepresenterError (no representer for np.str_).
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.plot([0, 1, 2], [0, 1, 4], label=np.str_("P01"))
+    ax.legend()
+    out = tmp_path / "npstr.png"
+
+    # Act
+    saved = True
+    try:
+        fr.save(fig, str(out), validate=False, verbose=False)
+    except Exception:
+        saved = False
+    plt.close("all")
+
+    # Assert
+    assert saved


### PR DESCRIPTION
## Summary
Three grant-relevant figure/serialization fixes (all reported by the neurovista operator):
- **Title-aware auto panel labels** — `fr.subplots(..., panel_labels=True)` adds (A)/(B) labels before `set_xyt` titles exist, so a fixed `y=1.05` landed on the title. Labels now lift clear of the title at save time; no-title axes + explicit offsets keep their placement.
- **`imshow` honors an explicit `aspect`** — sentinel-guarded so `ax.imshow(..., aspect="auto")` is never coerced back to `"equal"` by the styler.
- **Recipe save no longer crashes on numpy-scalar labels** — `_convert_numpy_types` gains an `np.generic` catch-all (`.item()`), covering `np.str_` (DataFrame columns), `np.complex*`, `np.datetime64`, etc. (was only ndarray/integer/floating/bool_).

## Test plan
- [x] `tests/figrecipe/_wrappers/test__figure.py` — panel label vs title no-overlap (+ existing 0.29.8 size/family)
- [x] `tests/figrecipe/styles/plot_stylers/test__imshow.py` — explicit aspect survives save/reproduce; default stays equal
- [x] `tests/integration/test_numpy_scalar_serialization.py` — np.str_ label saves without RepresenterError
- [x] Full local testmon suite green