### PR TITLE
fix(overlap): detect ax.annotate overlaps (Annotation is a Text subclass) — 0.29.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.10"
+version = "0.29.11"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_quality/_overlap.py
+++ b/src/figrecipe/_quality/_overlap.py
@@ -233,7 +233,7 @@ def _enumerate_text(fig: "Figure", renderer, overlays: set) -> List[_Component]:
     comps: List[_Component] = []
     seen = set()
     for artist in fig.findobj():
-        if artist.__class__.__name__ != "Text":
+        if not any(k.__name__ == "Text" for k in type(artist).__mro__):
             continue
         if id(artist) in seen:
             continue

--- a/tests/figrecipe/_quality/test__overlap.py
+++ b/tests/figrecipe/_quality/test__overlap.py
@@ -89,6 +89,20 @@ def test_two_overlapping_texts_warn():
     assert _has_pair(conflicts, "text", "text")
 
 
+def test_two_overlapping_annotations_warn():
+    # Arrange: ax.annotate makes an Annotation (a Text SUBCLASS); it must not
+    # slip past the text enumeration the way an exact class-name check let it.
+    fig, ax = plt.subplots(figsize=(4, 3), dpi=100)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.annotate("P01", xy=(0.5, 0.5), ha="center", va="center", fontsize=20)
+    ax.annotate("P02", xy=(0.5, 0.5), ha="center", va="center", fontsize=20)
+    # Act
+    conflicts = detect_layout_conflicts(fig)
+    # Assert
+    assert _has_pair(conflicts, "text", "text")
+
+
 # ---------------------------------------------------------------------------
 # (colorbar, axes) -> forbidden
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Save-time `overlap_check` enumerated text artists by **exact class name** (`artist.__class__.__name__ != "Text"`), so `Annotation` artists from `ax.annotate()` — a `Text` **subclass** named `"Annotation"` — were silently skipped. Overlapping point labels shipped unflagged (neurovista Fig4B).
- Fix: `_enumerate_text` now matches `Text` **and its subclasses** via an MRO name check (`any(k.__name__ == "Text" for k in type(artist).__mro__)`). Import-free because `_overlap.py` is exactly at the 512-line budget. This makes the code honor the module's own docstring, which already states text detection includes annotations.

## Test plan
- [x] New regression test `test_two_overlapping_annotations_warn` (mirrors `test_two_overlapping_texts_warn`) — asserts a `(text, text)` conflict for two overlapping `ax.annotate` labels.
- [x] `tests/figrecipe/_quality/test__overlap.py` — 10/10 pass, no regressions.

## Deferred (carded)
The ink-mask hide pass (`_render_ink_mask`) still uses the exact-name check, so annotation pixels leak into the data-ink mask. Marginal (legend-vs-annotation already caught by the bbox path) and needs an `_overlap.py` extraction to fit — tracked on `figrecipe-overlap-annotation-isinstance`.