### PR TITLE
fix(patches): record FancyArrowPatch add_patch path for round-trip (0.29.12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.11"
+version = "0.29.12"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_reproducer/_replay_patches.py
+++ b/src/figrecipe/_reproducer/_replay_patches.py
@@ -40,6 +40,14 @@ def reconstruct_patch(spec: Dict[str, Any]):
         )
     if ptype == "Polygon":
         return mpatches.Polygon(spec["xy"], closed=spec.get("closed", True))
+    if ptype == "FancyArrowPatch":
+        return mpatches.FancyArrowPatch(
+            tuple(spec["posA"]),
+            tuple(spec["posB"]),
+            arrowstyle=spec.get("arrowstyle", "-|>"),
+            connectionstyle=spec.get("connectionstyle", "arc3"),
+            mutation_scale=spec.get("mutation_scale", 1.0),
+        )
     raise ValueError(
         f"figrecipe cannot reproduce patch type {ptype!r} (recipe written by an "
         f"incompatible figrecipe version)."

--- a/src/figrecipe/_wrappers/_axes_patches.py
+++ b/src/figrecipe/_wrappers/_axes_patches.py
@@ -16,7 +16,13 @@ import matplotlib.patches as mpatches
 
 # Geometry-clean patch types supported for round-trip. Extend by adding a
 # branch in extract_patch_spec() + _replay_patches.reconstruct_patch().
-SUPPORTED_PATCH_TYPES = ("Rectangle", "Circle", "Ellipse", "Polygon")
+SUPPORTED_PATCH_TYPES = (
+    "Rectangle",
+    "Circle",
+    "Ellipse",
+    "Polygon",
+    "FancyArrowPatch",
+)
 
 # facecolor/edgecolor are captured as RGBA hex (alpha folded in), so the
 # patch-level alpha is intentionally NOT captured separately to avoid
@@ -63,6 +69,79 @@ def _style_of(patch) -> Dict[str, Any]:
     return style
 
 
+def _registered_style_name(style_obj, registry) -> str:
+    """Return the registered short name (e.g. ``'-|>'``, ``'arc3'``) for an
+    ArrowStyle/ConnectionStyle instance. FAIL LOUD on an unregistered style
+    rather than silently dropping it.
+    """
+    for name, cls in getattr(registry, "_style_list", {}).items():
+        if type(style_obj) is cls:
+            return name
+    raise ValueError(
+        f"figrecipe cannot record {registry.__name__} "
+        f"{type(style_obj).__name__!r} for reproduction. Use a standard named "
+        f"style, or draw the arrow via annotate(arrowprops=...) which is recorded."
+    )
+
+
+def _connectionstyle_string(style_obj) -> str:
+    """Serialize a ConnectionStyle to ``'name,param=value,...'``.
+
+    A ConnectionStyle's public numeric attrs map straight back to constructor
+    params (``Arc3.rad``, ``Arc.armA/armB/rad``, ``Angle.angleA/angleB``), so
+    ``rad`` and friends round-trip faithfully. The candidate string is
+    validated by re-parsing; a non-standard set falls back to the base named
+    style (which always reconstructs) rather than raising on a valid figure.
+    """
+    name = _registered_style_name(style_obj, mpatches.ConnectionStyle)
+    params = {
+        key: float(val)
+        for key, val in vars(style_obj).items()
+        if not key.startswith("_")
+        and isinstance(val, (int, float))
+        and not isinstance(val, bool)
+    }
+    if not params:
+        return name
+    candidate = name + "," + ",".join(f"{k}={v}" for k, v in sorted(params.items()))
+    try:
+        mpatches.ConnectionStyle(candidate)
+    except (ValueError, TypeError):
+        return name
+    return candidate
+
+
+def _fancyarrow_spec(patch, style: Dict[str, Any]) -> Dict[str, Any]:
+    """Decompose a FancyArrowPatch (posA/posB form) into a serializable spec.
+
+    The arrowstyle is stored by its registered name only: the class identity
+    already encodes the head shape + filled/open variant, and overall size is
+    carried by ``mutation_scale``. Non-default per-head geometry (custom
+    ``head_length``/``head_width``) is intentionally not captured -- it is rare
+    for leader arrows and would pollute the spec with base-class attrs that are
+    invalid params for the named style.
+    """
+    pos = getattr(patch, "_posA_posB", None)
+    if not pos or pos[0] is None or pos[1] is None:
+        raise ValueError(
+            "figrecipe cannot record a path-based FancyArrowPatch (no posA/posB) "
+            "for reproduction. Construct it with posA/posB, or draw the arrow via "
+            "annotate(arrowprops=...) which figrecipe records."
+        )
+    (ax0, ay0), (ax1, ay1) = pos
+    return {
+        "type": "FancyArrowPatch",
+        "posA": [float(ax0), float(ay0)],
+        "posB": [float(ax1), float(ay1)],
+        "arrowstyle": _registered_style_name(
+            patch.get_arrowstyle(), mpatches.ArrowStyle
+        ),
+        "connectionstyle": _connectionstyle_string(patch.get_connectionstyle()),
+        "mutation_scale": float(patch.get_mutation_scale()),
+        "style": style,
+    }
+
+
 def extract_patch_spec(patch) -> Dict[str, Any]:
     """Decompose a matplotlib patch into a serializable spec.
 
@@ -107,6 +186,11 @@ def extract_patch_spec(patch) -> Dict[str, Any]:
             "closed": bool(patch.get_closed()),
             "style": style,
         }
+    # FancyArrowPatch (add_patch path, e.g. adjustText leaders). The
+    # annotate() path already round-trips; this closes the add_patch gap so
+    # standalone arrows replay too. Path-based arrows (no posA/posB) FAIL LOUD.
+    if isinstance(patch, mpatches.FancyArrowPatch):
+        return _fancyarrow_spec(patch, style)
     raise ValueError(
         f"figrecipe cannot record patch type {type(patch).__name__!r} for "
         f"reproduction (it would be dropped on replay). Supported: "

--- a/tests/integration/test_add_patch_reproduction.py
+++ b/tests/integration/test_add_patch_reproduction.py
@@ -4,8 +4,8 @@
 
 Raw patches were forwarded to matplotlib but never recorded, so they vanished
 on replay and the figure failed save-time reproducibility. These tests guard
-that supported patches (Rectangle/Circle/Ellipse/Polygon) round-trip and that
-unsupported patch types fail loud at call time.
+that supported patches (Rectangle/Circle/Ellipse/Polygon/FancyArrowPatch)
+round-trip and that unsupported patch types fail loud at call time.
 """
 
 import matplotlib
@@ -137,9 +137,78 @@ def test_patch_only_figure_reproduces_clean(tmp_path):
 def test_unsupported_patch_fails_loud(tmp_path):
     # Arrange
     fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
-    arrow = mpatches.FancyArrowPatch((0.1, 0.1), (0.9, 0.9))
+    wedge = mpatches.Wedge((0.5, 0.5), 0.2, 0, 90)
     # Act
     # adding an unsupported patch type must raise at call time (see Assert)
     # Assert
     with pytest.raises(ValueError, match="cannot record patch type"):
-        ax.add_patch(arrow)
+        ax.add_patch(wedge)
+
+
+@pytest.fixture
+def arrow_round_trip(tmp_path):
+    fig, ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.add_patch(
+        mpatches.FancyArrowPatch(
+            (0.2, 0.3),
+            (0.7, 0.8),
+            arrowstyle="-|>",
+            connectionstyle="arc3,rad=0.2",
+            mutation_scale=12,
+            edgecolor="red",
+        )
+    )
+    spec, rax = _save_and_reproduce(fig, tmp_path / "arrow.png")
+    return {"spec": spec, "patches": _patches_of(rax, mpatches.FancyArrowPatch)}
+
+
+def test_arrow_recorded_in_recipe(arrow_round_trip):
+    # Arrange
+    spec = arrow_round_trip["spec"]
+    # Act
+    recorded_type = spec["type"] if spec else None
+    # Assert
+    assert recorded_type == "FancyArrowPatch"
+
+
+def test_arrow_reproduced_once(arrow_round_trip):
+    # Arrange
+    patches = arrow_round_trip["patches"]
+    # Act
+    count = len(patches)
+    # Assert
+    assert count == 1
+
+
+def test_arrow_endpoints_reproduced(arrow_round_trip):
+    # Arrange
+    arrow = arrow_round_trip["patches"][0]
+    # Act
+    posA, posB = arrow._posA_posB
+    endpoints = (*posA, *posB)
+    # Assert
+    assert endpoints == pytest.approx((0.2, 0.3, 0.7, 0.8))
+
+
+def test_arrow_connectionstyle_rad_reproduced(arrow_round_trip):
+    # Arrange
+    spec = arrow_round_trip["spec"]
+    # Act
+    connectionstyle = spec["connectionstyle"] if spec else ""
+    # Assert
+    assert "rad=0.2" in connectionstyle
+
+
+def test_path_based_arrow_fails_loud():
+    # Arrange
+    from figrecipe._wrappers._axes_patches import extract_patch_spec
+
+    arrow = mpatches.FancyArrowPatch((0.1, 0.1), (0.9, 0.9))
+    arrow._posA_posB = None  # a path-based arrow carries no endpoints
+    # Act
+    # no posA/posB means the arrow cannot round-trip and must fail loud (Assert)
+    # Assert
+    with pytest.raises(ValueError, match="path-based FancyArrowPatch"):
+        extract_patch_spec(arrow)


### PR DESCRIPTION
Closes the add_patch-path gap: `extract_patch_spec()` rejected `FancyArrowPatch`, so standalone arrows added via `ax.add_patch` (e.g. adjustText leaders) failed save-time reproducibility. The `annotate()` arrow path already round-tripped.

**Record side** (`_wrappers/_axes_patches.py`): capture posA/posB, mutation_scale, arrowstyle (registered name — class identity encodes head shape + fill), connectionstyle (name + validated numeric params, so arc3 `rad` survives). Path-based arrows (no posA/posB) FAIL LOUD.
**Replay side** (`_reproducer/_replay_patches.py`): rebuild FancyArrowPatch from the spec.

Reported by neurovista (add_patch-path adjustText leaders). Groundwork for native `scatter_labels(declutter=True)` leader lines.

Tests: FancyArrowPatch round-trip (recorded/reproduced/endpoints/rad) + path-based fail-loud; old unsupported-patch guard now uses Wedge. Verified locally green (13/13 add_patch tests + parallel full-suite 0 failures); local pre-commit testmon skipped due to the known ~2h cold-run bottleneck — CI matrix is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)