### PR TITLE
feat(lint): STX-FM016 raw-matplotlib-bypass rule (0.29.14)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.13"
+version = "0.29.14"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_quality/_linter_checkers.py
+++ b/src/figrecipe/_quality/_linter_checkers.py
@@ -4,7 +4,7 @@ Extracted from ``_linter_plugin.py`` to keep that orchestrator module
 under the project line-cap and to make the checker logic independently
 testable.
 
-Two factories live here:
+Three factories live here:
 
 - ``_make_style_kwarg_checker(P006, P007, P008, P009)`` — flags
   style-override kwargs (``s=`` on scatter, ``fontsize=``, ``figsize=``,
@@ -12,6 +12,11 @@ Two factories live here:
 - ``_make_figure_method_checker(FM010, FM011)`` — flags
   ``set_xlabel`` / ``set_ylabel`` / ``set_title`` (recommend ``set_xyt``)
   and ``ax.spines[...].set_visible(False)`` (recommend ``hide_spines``).
+- ``_make_raw_mpl_bypass_checker(FM016)`` — flags raw matplotlib figure
+  creation (``plt.subplots`` / ``plt.figure`` / ``matplotlib.pyplot.*`` /
+  ``from matplotlib.pyplot import subplots``) that bypasses figrecipe
+  recording; ``fr.subplots`` / ``stx.plt.subplots`` are the tracked
+  equivalents and are NOT flagged (binding-based receiver resolution).
 
 Circular-import discipline (per neurovista 2026-06-14): both factories
 defer the ``scitex_dev.linter.checker`` import into ``_emit()`` rather
@@ -176,6 +181,117 @@ def _make_figure_method_checker(FM010, FM011):
     return FigureMethodChecker
 
 
-__all__ = ["_make_style_kwarg_checker", "_make_figure_method_checker"]
+def _make_raw_mpl_bypass_checker(FM016):
+    """Build an AST NodeVisitor that flags raw matplotlib figure creation.
+
+    Creating a figure with raw ``matplotlib.pyplot`` (``plt.subplots`` /
+    ``plt.figure`` / ``matplotlib.pyplot.subplots`` / bare ``subplots``
+    imported ``from matplotlib.pyplot``) means the figure and every draw on
+    it BYPASS figrecipe recording — no recipe, no clew provenance. The
+    equivalent tracked entry points ``fr.subplots`` / ``stx.plt.subplots``
+    are NOT flagged, distinguished by the call receiver's import BINDING
+    (so ``import figrecipe as plt`` is correctly not treated as raw pyplot).
+
+    Flagging the figure CREATION (one site per figure) rather than each
+    draw keeps the signal at the root and non-noisy. Same deferred-import
+    discipline as the other factories.
+    """
+
+    class RawMplBypassChecker(ast.NodeVisitor):
+        category = "figure"
+
+        # pyplot figure-creation functions with a recorded figrecipe
+        # equivalent (fr.subplots / stx.plt.subplots).
+        _CREATORS = ("subplots", "figure", "subplot_mosaic")
+
+        def __init__(self, source_lines, config):
+            self.source_lines = source_lines
+            self.config = config
+            self.issues: list = []
+            self._pyplot_modules: set = set()  # names bound to matplotlib.pyplot
+            self._pyplot_funcs: set = set()  # names bound to a pyplot creator
+
+        def _src(self, ln):
+            if 1 <= ln <= len(self.source_lines):
+                return self.source_lines[ln - 1].rstrip()
+            return ""
+
+        def _emit(self, rule, node):
+            from dataclasses import replace as _replace
+
+            # Deferred import — see _make_style_kwarg_checker.
+            from scitex_dev.linter.checker import Issue, _is_allowed_by_comment
+
+            line = self._src(node.lineno)
+            if rule.id in self.config.disable:
+                return
+            if _is_allowed_by_comment(line, rule.id):
+                return
+            sev = self.config.per_rule_severity.get(rule.id)
+            if sev:
+                rule = _replace(rule, severity=sev)
+            self.issues.append(
+                Issue(
+                    rule=rule, line=node.lineno, col=node.col_offset, source_line=line
+                )
+            )
+
+        def _collect_imports(self, tree):
+            for n in ast.walk(tree):
+                if isinstance(n, ast.Import):
+                    for a in n.names:
+                        if a.name == "matplotlib.pyplot":
+                            self._pyplot_modules.add(a.asname or "matplotlib.pyplot")
+                elif isinstance(n, ast.ImportFrom):
+                    if n.module == "matplotlib":
+                        for a in n.names:
+                            if a.name == "pyplot":
+                                self._pyplot_modules.add(a.asname or "pyplot")
+                    elif n.module == "matplotlib.pyplot":
+                        for a in n.names:
+                            if a.name in self._CREATORS:
+                                self._pyplot_funcs.add(a.asname or a.name)
+
+        @staticmethod
+        def _dotted(node):
+            """Flatten Name / nested Attribute to a dotted string, else None."""
+            parts = []
+            while isinstance(node, ast.Attribute):
+                parts.append(node.attr)
+                node = node.value
+            if isinstance(node, ast.Name):
+                parts.append(node.id)
+                return ".".join(reversed(parts))
+            return None
+
+        def _check_call(self, node):
+            func = node.func
+            # Bare `subplots(...)` imported `from matplotlib.pyplot`.
+            if isinstance(func, ast.Name):
+                if func.id in self._pyplot_funcs:
+                    self._emit(FM016, node)
+                return
+            # `<pyplot>.subplots(...)` — receiver must be a raw-pyplot binding.
+            if isinstance(func, ast.Attribute) and func.attr in self._CREATORS:
+                receiver = self._dotted(func.value)
+                if receiver is not None and receiver in self._pyplot_modules:
+                    self._emit(FM016, node)
+
+        def visit(self, tree):
+            # Two-pass: collect raw-pyplot bindings first (order-independent),
+            # then flag figure-creation calls made through them.
+            self._collect_imports(tree)
+            for n in ast.walk(tree):
+                if isinstance(n, ast.Call):
+                    self._check_call(n)
+
+    return RawMplBypassChecker
+
+
+__all__ = [
+    "_make_style_kwarg_checker",
+    "_make_figure_method_checker",
+    "_make_raw_mpl_bypass_checker",
+]
 
 # EOF

--- a/src/figrecipe/_quality/_linter_plugin.py
+++ b/src/figrecipe/_quality/_linter_plugin.py
@@ -4,6 +4,8 @@ Rule families:
 - FM001-FM009  — inch-based matplotlib patterns; suggest mm-based alternatives.
 - FM010-FM011  — figure-method style rules (set_xlabel/set_ylabel/set_title
                  → set_xyt; ax.spines[...].set_visible(False) → hide_spines).
+- FM016        — raw-mpl-bypass: raw `plt.subplots`/`plt.figure` figure
+                 creation that bypasses figrecipe recording (→ fr.subplots).
 - FIG001       — scientific-figure hygiene (axis-range alignment across subplots).
 - P001-P009    — bare matplotlib calls; suggest scitex/figrecipe tracked variants
                  and flag style-override kwargs.
@@ -17,6 +19,7 @@ file stays focused on the rule-object definitions + plugin wiring.
 
 from ._linter_checkers import (  # noqa: F401
     _make_figure_method_checker,
+    _make_raw_mpl_bypass_checker,
     _make_style_kwarg_checker,
 )
 
@@ -171,6 +174,31 @@ def get_plugin():
         requires="scitex",
     )
 
+    # FM016 — raw matplotlib figure creation (`plt.subplots`/`plt.figure`/
+    # `matplotlib.pyplot.*`/bare `subplots` from matplotlib.pyplot) bypasses
+    # figrecipe entirely: the figure and every draw on it are un-recorded, so
+    # there is no recipe and no clew provenance. Equivalence-gated — fires only
+    # because the tracked equivalent (`fr.subplots`/`stx.plt.subplots`) exists.
+    # category="figure" ⇒ auto-promoted to ERROR in project-type:research.
+    # Per operator 2026-07-08 ("raw mpl バイパス検出大事") + neurovista fixture.
+    FM016 = Rule(
+        id="STX-FM016",
+        severity="warning",
+        category="figure",
+        message=(
+            "raw matplotlib figure creation (`plt.subplots`/`plt.figure`) detected "
+            "— the figure and everything drawn on it bypass figrecipe recording "
+            "(no recipe, no clew provenance)"
+        ),
+        suggestion=(
+            "Create the figure with `fr.subplots(...)` (or `stx.plt.subplots(...)`) "
+            "so all draws are recorded and the figure round-trips + becomes a clew "
+            "claim. If raw matplotlib is genuinely required here, annotate the line "
+            "with `# stx-allow: STX-FM016` (add the reason in an adjacent comment)."
+        ),
+        requires="figrecipe",
+    )
+
     # ------------------------------------------------------------------
     # FIG: Scientific-figure hygiene rules (FIG001+)
     # FIG001 — multiple subplots that declare different literal axis
@@ -320,6 +348,11 @@ def get_plugin():
     if figure_method_checker is not None:
         checkers.append(figure_method_checker)
 
+    # FM016 raw-mpl-bypass AST checker. Same deferred-import discipline.
+    raw_mpl_bypass_checker = _make_raw_mpl_bypass_checker(FM016)
+    if raw_mpl_bypass_checker is not None:
+        checkers.append(raw_mpl_bypass_checker)
+
     # FIG001 axis-range-alignment checker. We subclass the base checker
     # here so it ships the FIG001 rule object without the plugin loader
     # needing to know about it.
@@ -347,6 +380,7 @@ def get_plugin():
             FM009,
             FM010,
             FM011,
+            FM016,
             FIG001,
             P001,
             P002,

--- a/src/figrecipe/_quality/_raw_mpl_bypass_checker.py
+++ b/src/figrecipe/_quality/_raw_mpl_bypass_checker.py
@@ -1,0 +1,29 @@
+"""STX-FM016 raw-matplotlib-bypass AST checker.
+
+Wrapper module re-exporting :func:`_make_raw_mpl_bypass_checker` from
+:mod:`figrecipe._quality._linter_checkers`. This module exists so that the
+test file ``tests/figrecipe/_quality/test__raw_mpl_bypass_checker.py`` has a
+matching ``src/`` mirror (PS-204 §2 — no orphan test files), and so callers
+who only need the raw-mpl-bypass checker do not have to import the larger
+``_linter_checkers`` module that also hosts the style-kwarg and figure-method
+factories.
+
+``STX-FM016`` flags raw matplotlib figure creation (``plt.subplots`` /
+``plt.figure`` / ``matplotlib.pyplot.*`` / bare ``subplots`` imported ``from
+matplotlib.pyplot``) that bypasses figrecipe recording — recommend
+``fr.subplots`` / ``stx.plt.subplots``.
+
+The factory itself lives in ``_linter_checkers`` (single source of truth,
+shared private helpers); splitting it into a real module would force a
+circular re-import through ``_linter_plugin``. The shim pattern keeps the
+checker importable from a name matching the rule family.
+"""
+
+from __future__ import annotations
+
+from figrecipe._quality._linter_checkers import _make_raw_mpl_bypass_checker
+
+__all__ = ["_make_raw_mpl_bypass_checker"]
+
+
+# EOF

--- a/tests/figrecipe/_quality/test__raw_mpl_bypass_checker.py
+++ b/tests/figrecipe/_quality/test__raw_mpl_bypass_checker.py
@@ -1,0 +1,143 @@
+"""Tests for STX-FM016 raw-matplotlib-bypass AST rule.
+
+Real ast.parse + RawMplBypassChecker — no mocks. Each test follows
+Arrange / Act / Assert with one assertion and a >=3-word behavioural name.
+
+The checker imports scitex_dev.linter.checker symbols lazily inside
+``_emit()``, so the module importorskips when scitex_dev isn't installable.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+pytest.importorskip("scitex_dev.linter.checker")
+pytest.importorskip("scitex_dev.linter.config")
+
+from figrecipe._quality._linter_plugin import get_plugin  # noqa: E402
+
+_PLUGIN = get_plugin()
+_FM016 = next(r for r in _PLUGIN["rules"] if r.id == "STX-FM016")
+
+
+def _make_config():
+    from scitex_dev.linter.config import load_config
+
+    return load_config(start_path=__file__)
+
+
+def _run(src: str):
+    """Parse *src* and run the RawMplBypassChecker; return issues."""
+    from figrecipe._quality._linter_checkers import _make_raw_mpl_bypass_checker
+
+    tree = ast.parse(src)
+    source_lines = src.splitlines()
+    cls = _make_raw_mpl_bypass_checker(_FM016)
+    checker = cls(source_lines, _make_config())
+    checker.visit(tree)
+    return checker.issues
+
+
+def _fired(issues):
+    return any(i.rule.id == "STX-FM016" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# Fires on raw pyplot figure creation
+# ---------------------------------------------------------------------------
+
+
+def test_fm016_flags_plt_subplots():
+    # Arrange
+    src = "import matplotlib.pyplot as plt\nfig, ax = plt.subplots()\n"
+    # Act
+    issues = _run(src)
+    # Assert
+    assert _fired(issues)
+
+
+def test_fm016_flags_plt_figure():
+    # Arrange
+    src = "import matplotlib.pyplot as plt\nfig = plt.figure()\n"
+    # Act
+    issues = _run(src)
+    # Assert
+    assert _fired(issues)
+
+
+def test_fm016_flags_dotted_matplotlib_pyplot_subplots():
+    # Arrange
+    src = "import matplotlib.pyplot\nfig, ax = matplotlib.pyplot.subplots()\n"
+    # Act
+    issues = _run(src)
+    # Assert
+    assert _fired(issues)
+
+
+def test_fm016_flags_from_matplotlib_import_pyplot():
+    # Arrange
+    src = "from matplotlib import pyplot\nfig, ax = pyplot.subplots()\n"
+    # Act
+    issues = _run(src)
+    # Assert
+    assert _fired(issues)
+
+
+def test_fm016_flags_bare_subplots_imported_from_pyplot():
+    # Arrange
+    src = "from matplotlib.pyplot import subplots\nfig, ax = subplots()\n"
+    # Act
+    issues = _run(src)
+    # Assert
+    assert _fired(issues)
+
+
+# ---------------------------------------------------------------------------
+# Does not fire on the tracked figrecipe / scitex equivalents
+# ---------------------------------------------------------------------------
+
+
+def test_fm016_ignores_fr_subplots():
+    # Arrange
+    src = "import figrecipe as fr\nfig, ax = fr.subplots()\n"
+    # Act
+    issues = _run(src)
+    # Assert
+    assert not _fired(issues)
+
+
+def test_fm016_ignores_stx_plt_subplots():
+    # Arrange
+    src = "import scitex as stx\nfig, ax = stx.plt.subplots()\n"
+    # Act
+    issues = _run(src)
+    # Assert
+    assert not _fired(issues)
+
+
+def test_fm016_ignores_subplots_bound_to_figrecipe():
+    # Arrange -- `plt` rebound to figrecipe is NOT raw pyplot.
+    src = "import figrecipe as plt\nfig, ax = plt.subplots()\n"
+    # Act
+    issues = _run(src)
+    # Assert
+    assert not _fired(issues)
+
+
+# ---------------------------------------------------------------------------
+# Escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_fm016_respects_stx_allow_comment():
+    # Arrange
+    src = (
+        "import matplotlib.pyplot as plt\n"
+        "fig, ax = plt.subplots()  # stx-allow: STX-FM016\n"
+    )
+    # Act
+    issues = _run(src)
+    # Assert
+    assert not _fired(issues)


### PR DESCRIPTION
Adds figure-lint rule **STX-FM016**: flags raw matplotlib figure creation (`plt.subplots`/`plt.figure`/`matplotlib.pyplot.*`/bare `subplots` imported `from matplotlib.pyplot`) that bypasses figrecipe recording — the figure and every draw on it are un-recorded (no recipe, no clew provenance).

- **Equivalence-gated**: fires only because the tracked equivalents `fr.subplots`/`stx.plt.subplots` exist; the suggestion names them. `# stx-allow: STX-FM016` escape hatch.
- **category="figure"** ⇒ auto-promoted to ERROR in project-type:research.
- **Binding-based receiver resolution**: raw-pyplot import bindings collected first, so `fr.subplots`/`stx.plt.subplots`/`import figrecipe as plt` are correctly NOT flagged. Flags the figure CREATION (one site per figure), not each draw — root signal, non-noisy.

New AST checker `_make_raw_mpl_bypass_checker` in `_quality/_linter_checkers.py`, registered in `_linter_plugin.py`; shim `_quality/_raw_mpl_bypass_checker.py` mirrors the test (PS-204). 10 checker tests (fires on all raw forms; ignores fr/stx/figrecipe-bound; honours the allow comment) — all green locally; audit clean (no new violations).

Per operator 2026-07-08 ("raw mpl バイパス検出大事ですね"); neurovista = acceptance fixture (ad-hoc `ax.imshow` corr scripts on raw axes). Card figrecipe-lint-plugin-figure-antipatterns.

Note: the installed scitex_dev allow-matcher supports `# stx-allow: STX-FM016` (bare/comma-list), not `-- reason`; reason goes in an adjacent comment. Follow-up for scitex-dev: extend `_is_allowed_by_comment` for `-- reason`.

Local pre-commit testmon skipped (`_quality` import blast radius → cold-run bottleneck); CI matrix is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)