### PR TITLE
feat(wrappers): record bar_label + secondary_axis — completes wrapper-completeness (0.29.16)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.15"
+version = "0.29.16"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_wrappers/_axes.py
+++ b/src/figrecipe/_wrappers/_axes.py
@@ -17,29 +17,6 @@ if TYPE_CHECKING:
     from .._recorder import Recorder
 
 
-# Methods that draw but cannot round-trip because their arguments are not
-# recipe-serializable. They are wrapped to WARN on use (never silently drop).
-_UNRECORDED_WARN_METHODS = frozenset(
-    {"bar_label", "secondary_xaxis", "secondary_yaxis"}
-)
-_UNRECORDED_WARN_HINT = {
-    "bar_label": (
-        "It takes a live BarContainer. For a reproducible figure, add the "
-        "labels via recorded ax.text(...) at the bar tops instead."
-    ),
-    "secondary_xaxis": (
-        "It takes forward/inverse transform callables, which cannot be "
-        "serialized. Recreate the secondary axis in the reproduce script if "
-        "it is essential."
-    ),
-    "secondary_yaxis": (
-        "It takes forward/inverse transform callables, which cannot be "
-        "serialized. Recreate the secondary axis in the reproduce script if "
-        "it is essential."
-    ),
-}
-
-
 class RecordingAxes(
     RecordingAxesMethods,
     AxesStyleMixin,
@@ -131,12 +108,19 @@ class RecordingAxes(
 
             return build_inset_axes_wrapper(self)
 
-        # These draw but cannot round-trip: their args are not recipe-
-        # serializable (bar_label takes a live BarContainer; secondary_xaxis/
-        # secondary_yaxis take forward/inverse transform CALLABLES). Rather than
-        # let them silently vanish on reproduce(), warn the author on use.
-        if callable(attr) and name in _UNRECORDED_WARN_METHODS:
-            return self._create_unrecorded_warn_wrapper(name, attr)
+        # Route bar_label to a wrapper that freezes each label into a recorded
+        # annotate (its live BarContainer arg is otherwise un-serializable).
+        if callable(attr) and name == "bar_label":
+            from ._axes_barlabel import build_bar_label_wrapper
+
+            return build_bar_label_wrapper(self)
+
+        # Route secondary_xaxis/secondary_yaxis to a wrapper that records the
+        # plain-location case and warns when custom transform functions are given.
+        if callable(attr) and name in ("secondary_xaxis", "secondary_yaxis"):
+            from ._axes_barlabel import build_secondary_axis_wrapper
+
+            return build_secondary_axis_wrapper(self, name)
 
         # If it's a plotting or decoration method, wrap it
         if callable(attr) and name in (
@@ -213,25 +197,6 @@ class RecordingAxes(
                     self._result_refs,
                     self._RESULT_REFERENCING_METHODS,
                     self._RESULT_REFERENCEABLE_METHODS,
-                )
-            return result
-
-        return wrapper
-
-    def _create_unrecorded_warn_wrapper(self, method_name: str, method: callable):
-        """Wrap a draw-but-unrecordable method so it WARNS instead of silently
-        vanishing on reproduce() (its args are not recipe-serializable)."""
-        import warnings
-
-        def wrapper(*args, track: bool = True, **kwargs):
-            result = method(*args, **kwargs)
-            if self._track and track:
-                hint = _UNRECORDED_WARN_HINT.get(method_name, "")
-                warnings.warn(
-                    f"figrecipe: ax.{method_name}(...) is drawn but NOT recorded, "
-                    f"so it will be absent when the recipe is reproduced. {hint}",
-                    UserWarning,
-                    stacklevel=2,
                 )
             return result
 

--- a/src/figrecipe/_wrappers/_axes_barlabel.py
+++ b/src/figrecipe/_wrappers/_axes_barlabel.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Record ``bar_label`` + ``secondary_xaxis``/``secondary_yaxis`` so they
+round-trip through a recipe.
+
+``bar_label`` draws Annotations anchored at bar tops (``xy`` in data coords +
+a points offset), and figrecipe already records ``annotate``. So we FREEZE each
+label into a recorded ``annotate()`` call (solve-then-freeze, like
+scatter_labels) — no live BarContainer in the recipe, byte-identical replay.
+
+``secondary_xaxis``/``secondary_yaxis`` with a plain ``location`` (mirroring the
+primary axis) is recorded by location. With custom forward/inverse transform
+CALLABLES it cannot be serialized, so it is drawn but WARNS (never silently
+vanishes on reproduce()).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+def build_bar_label_wrapper(recording_axes):
+    """Wrapper for ``ax.bar_label`` that freezes each label into a recorded
+    ``annotate`` so the labels reproduce without the live BarContainer."""
+
+    def bar_label(*args, id=None, track=True, **kwargs):
+        anns = recording_axes._ax.bar_label(*args, **kwargs)
+        if not (recording_axes._track and track):
+            return anns
+        frozen = []
+        for ann in anns:
+            xy = (float(ann.xy[0]), float(ann.xy[1]))
+            xytext = (
+                tuple(float(v) for v in ann.xyann) if ann.xyann is not None else None
+            )
+            ann.remove()  # drop the raw annotation; re-add via the recorded path
+            frozen.append(
+                recording_axes.annotate(
+                    ann.get_text(),
+                    xy=xy,
+                    xytext=xytext,
+                    textcoords=ann.anncoords,
+                    ha=ann.get_ha(),
+                    va=ann.get_va(),
+                    rotation=float(ann.get_rotation()),
+                )
+            )
+        return frozen
+
+    return bar_label
+
+
+def build_secondary_axis_wrapper(recording_axes, method_name: str):
+    """Wrapper for ``ax.secondary_xaxis``/``ax.secondary_yaxis``: record the
+    plain-``location`` case; warn when custom transform functions are given."""
+    method = getattr(recording_axes._ax, method_name)
+
+    def secondary_axis(location, *args, functions=None, id=None, track=True, **kwargs):
+        recording = recording_axes._track and track
+        if functions is not None:
+            result = method(location, *args, functions=functions, **kwargs)
+            if recording:
+                warnings.warn(
+                    f"figrecipe: ax.{method_name}(..., functions=...) is drawn but "
+                    f"NOT recorded (transform callables are not recipe-serializable), "
+                    f"so it will be absent when the recipe is reproduced.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            return result
+        result = method(location, *args, **kwargs)
+        if recording:
+            recording_axes._recorder.record_call(
+                ax_position=recording_axes._position,
+                method_name=method_name,
+                args=(location,),
+                kwargs={},
+                call_id=id,
+            )
+        return result
+
+    return secondary_axis
+
+
+__all__ = ["build_bar_label_wrapper", "build_secondary_axis_wrapper"]
+
+# EOF

--- a/tests/integration/test_wrapper_completeness.py
+++ b/tests/integration/test_wrapper_completeness.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Wrapper-completeness: newly-recorded methods round-trip; un-serializable
-draw methods warn instead of silently vanishing on reproduce().
+"""Wrapper-completeness: element-producing methods that were forwarded to raw
+matplotlib (and vanished on replay) now round-trip.
 
-arrow / axline / broken_barh / table were forwarded to raw matplotlib and
-vanished on replay; they now record + reproduce. bar_label / secondary_xaxis
-/ secondary_yaxis cannot round-trip (live container / transform callables) so
-they must WARN on use.
+arrow / axline / broken_barh / table record + reproduce directly. bar_label is
+frozen into recorded annotate() calls. secondary_xaxis/secondary_yaxis record
+the plain-location case; only the custom-transform-functions case (not
+serializable) warns instead of silently vanishing.
 """
 
 import matplotlib
@@ -74,32 +74,54 @@ def test_table_round_trips(tmp_path):
     assert len(mpl_ax.tables) == 1
 
 
-def test_bar_label_warns_not_recorded():
-    # Arrange
+def test_bar_label_round_trips(tmp_path):
+    # Arrange -- bar_label draws Annotations; they are frozen into recorded
+    # annotate() calls so the labels reproduce without the live BarContainer.
     fig, ax = _axes()
-    bars = ax.bar([0, 1], [0.3, 0.6])
+    bars = ax.bar([0, 1, 2], [0.3, 0.6, 0.2])
+    ax.bar_label(bars, fmt="%.1f")
     # Act
-    # bar_label takes a live BarContainer -> not recordable -> must warn (Assert)
+    mpl_ax = _reproduce(fig, tmp_path, "bar_label")
+    reproduced = {t.get_text() for t in mpl_ax.texts if t.get_text()}
     # Assert
-    with pytest.warns(UserWarning, match="NOT recorded"):
-        ax.bar_label(bars)
+    assert {"0.3", "0.6", "0.2"}.issubset(reproduced)
 
 
-def test_secondary_xaxis_warns_not_recorded():
-    # Arrange
+def test_secondary_xaxis_plain_records_without_warning():
+    # Arrange -- a plain secondary_xaxis(location) mirrors the primary and is
+    # recorded by location, so it must NOT emit the not-recorded warning.
+    import warnings
+
     fig, ax = _axes()
+    ax.plot([0, 1], [0, 1])
     # Act
-    # secondary_xaxis takes transform callables -> not recordable -> warn (Assert)
-    # Assert
-    with pytest.warns(UserWarning, match="NOT recorded"):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         ax.secondary_xaxis("top")
+    # Assert
+    assert not any("NOT recorded" in str(w.message) for w in caught)
 
 
-def test_secondary_yaxis_warns_not_recorded():
-    # Arrange
+def test_secondary_xaxis_with_functions_warns():
+    # Arrange -- custom transform callables are not serializable.
     fig, ax = _axes()
+    ax.plot([0, 1], [0, 1])
     # Act
-    # secondary_yaxis takes transform callables -> not recordable -> warn (Assert)
+    # a functions= secondary axis cannot be recorded -> must warn (see Assert)
     # Assert
     with pytest.warns(UserWarning, match="NOT recorded"):
+        ax.secondary_xaxis("top", functions=(lambda x: x * 2, lambda x: x / 2))
+
+
+def test_secondary_yaxis_plain_records_without_warning():
+    # Arrange
+    import warnings
+
+    fig, ax = _axes()
+    ax.plot([0, 1], [0, 1])
+    # Act
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         ax.secondary_yaxis("right")
+    # Assert
+    assert not any("NOT recorded" in str(w.message) for w in caught)


### PR DESCRIPTION
Replaces the 0.29.15 warn-only stubs for the last two element-producing methods with proper recording (new `_wrappers/_axes_barlabel.py`):

- **bar_label**: draws Annotations anchored at bar tops (xy data-coords + points offset). figrecipe already records `annotate`, so each label is FROZEN into a recorded `annotate()` call (solve-then-freeze) — no live BarContainer in the recipe. Verified: save Reproducibility-Validation PASSED + labels reproduce.
- **secondary_xaxis / secondary_yaxis**: the plain `secondary_axis(location)` case (mirrors the primary) is recorded by location and round-trips (validation PASSED). Only the custom forward/inverse transform-CALLABLES case (not serializable) still warns instead of silently vanishing.

Removes the now-unused `_UNRECORDED_WARN_METHODS` + `_create_unrecorded_warn_wrapper`. **All 6 methods on the card now record** (arrow/axline/broken_barh/table from 0.29.15 + bar_label/secondary_axis here). Closes card figrecipe-wrapper-record-completeness.

Per operator 2026-07-08 (autonomous go-ahead).

Tests: bar_label round-trip; secondary_xaxis/yaxis plain records-without-warning; secondary_xaxis(functions=) warns. Regression guard: specialized_plots + params + reproducibility_matrix (incl. plotter-registry invariant) — 74 pass. Local pre-commit testmon skipped (`_axes.py` blast radius); CI matrix is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)