### PR TITLE
feat(quality): save-time color-collision detection (0.29.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.18] - 2026-07-09
+
+### Added
+- **Color-collision detection (save-time, always-on).** A new perceptual
+  color check flags two data series a reader must tell apart (both carrying a
+  real legend label) drawn in colors so close they are indistinguishable —
+  even when the shapes never geometrically overlap. Per data axes, every pair
+  of labelled series is compared in CIELAB space (`ΔE*76`); pairs below a
+  conservative just-noticeable threshold (default `ΔE 5.0`) surface through the
+  existing `run_overlap_check` save-time warning. Scope guards keep it quiet on
+  legitimate figures: only labelled series are compared, same-label series (one
+  logical series in parts) are exempt, colormapped scatters (intentional
+  gradients) are skipped, and colors are only compared within a single axes
+  (cross-panel color reuse is fine). Lives in `figrecipe._quality._color_collision`
+  (`detect_color_collisions`, `delta_e76`); `Conflict` gains a `kind` field
+  (`"overlap"` | `"color"`).
+
 ## [0.29.9] - 2026-06-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.17"
+version = "0.29.18"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_quality/_color_collision.py
+++ b/src/figrecipe/_quality/_color_collision.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Save-time COLOR-collision detector -- ambiguous, indistinguishable colors.
+
+Concept
+-------
+Two data series a reader is asked to tell apart (i.e. both carry a real
+legend label) but drawn in colors so close they are perceptually
+indistinguishable make a figure ambiguous even when the shapes never
+geometrically overlap. This detector, per data Axes, compares every pair
+of labelled series in perceptual CIELAB space (ΔE*76) and flags any pair
+whose colors sit below a just-noticeable threshold. It is the color
+sibling of the geometric overlap check in ``_overlap`` and is surfaced
+through the same save-time warning path.
+
+Scope guards (avoid false positives)
+------------------------------------
+- Only series carrying a REAL legend label (not ``""``/``_``-prefixed) are
+  compared -- decorative reference lines, grids, error bars without a
+  label never trip the rule.
+- Two artists sharing the SAME label are the same logical series drawn in
+  parts -- identical color is intentional, never a collision.
+- COLORMAPPED collections (a scatter with ``c=`` mapped to a colormap, so
+  its points carry many colors) are skipped -- their gradient is
+  deliberate, not an accidental duplicate.
+- The default threshold (``_COLOR_JND_DELTA_E``) is conservative: distinct
+  qualitative-palette entries sit well above it, so only genuine
+  near-duplicate colors are flagged.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
+
+__all__ = [
+    "detect_color_collisions",
+    "delta_e76",
+]
+
+# Minimum CIELAB ΔE*76 below which two labelled series are treated as
+# indistinguishable. The JND for large solid patches is ~2.3; across a plot
+# (thin lines, small markers) colors need more separation to read apart, but
+# distinct qualitative-palette colors are all >15 ΔE, so 5.0 flags only real
+# near-duplicates without touching legitimate palettes.
+_COLOR_JND_DELTA_E = 5.0
+
+_RGB = Tuple[float, float, float]
+_LAB = Tuple[float, float, float]
+
+
+# ---------------------------------------------------------------------------
+# Color science: sRGB -> CIELAB (D65) + ΔE*76
+# ---------------------------------------------------------------------------
+def _srgb_to_linear(c: float) -> float:
+    """Inverse sRGB companding for one channel in [0, 1]."""
+    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def _rgb_to_xyz(rgb: _RGB) -> Tuple[float, float, float]:
+    """Linearise sRGB and apply the sRGB->XYZ (D65) matrix."""
+    r, g, b = (_srgb_to_linear(c) for c in rgb)
+    x = r * 0.4124 + g * 0.3576 + b * 0.1805
+    y = r * 0.2126 + g * 0.7152 + b * 0.0722
+    z = r * 0.0193 + g * 0.1192 + b * 0.9505
+    return x, y, z
+
+
+def _f_lab(t: float) -> float:
+    """CIELAB nonlinearity."""
+    return t ** (1.0 / 3.0) if t > 0.008856 else (7.787 * t + 16.0 / 116.0)
+
+
+def _srgb_to_lab(rgb: _RGB) -> _LAB:
+    """Convert an sRGB triple in [0, 1] to CIELAB (D65 white point)."""
+    x, y, z = _rgb_to_xyz(rgb)
+    # D65 reference white.
+    fx, fy, fz = _f_lab(x / 0.95047), _f_lab(y / 1.0), _f_lab(z / 1.08883)
+    return (116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz))
+
+
+def delta_e76(rgb_a: _RGB, rgb_b: _RGB) -> float:
+    """CIELAB ΔE*76 (Euclidean Lab distance) between two sRGB triples.
+
+    Both inputs are sRGB in [0, 1]. Larger means more distinguishable;
+    ~0 means identical.
+    """
+    la, lb = _srgb_to_lab(rgb_a), _srgb_to_lab(rgb_b)
+    return math.sqrt(sum((p - q) ** 2 for p, q in zip(la, lb)))
+
+
+# ---------------------------------------------------------------------------
+# Per-artist representative color
+# ---------------------------------------------------------------------------
+def _single_rgb(color) -> Optional[_RGB]:
+    """One sRGB triple from any matplotlib color spec, else None."""
+    import matplotlib.colors as mcolors
+
+    try:
+        r, g, b, _a = mcolors.to_rgba(color)
+        return (r, g, b)
+    except Exception:
+        return None
+
+
+def _series_rgb(artist) -> Optional[_RGB]:
+    """Representative sRGB for a data artist, or None if it has no single one.
+
+    Line2D -> its line color. Patch -> its face color. Collection -> its
+    single shared face color; a collection whose points carry MORE than one
+    color (a colormapped scatter) returns None so its intentional gradient
+    is never flagged.
+    """
+    import matplotlib.collections as mcoll
+    import matplotlib.lines as mlines
+    import numpy as np
+    from matplotlib.patches import Patch
+
+    if isinstance(artist, mlines.Line2D):
+        return _single_rgb(artist.get_color())
+    if isinstance(artist, mcoll.Collection):
+        # Force colormap->facecolor mapping so a colormapped scatter exposes
+        # its full per-point colors (matplotlib maps these lazily at draw).
+        # A no-op for a single-color collection.
+        try:
+            artist.update_scalarmappable()
+        except Exception:
+            pass
+        fc = np.asarray(artist.get_facecolor(), dtype=float)
+        if fc.size == 0:
+            fc = np.asarray(artist.get_edgecolor(), dtype=float)
+        if fc.size == 0:
+            return None
+        rows = fc.reshape(-1, fc.shape[-1]) if fc.ndim > 1 else fc.reshape(1, -1)
+        if np.unique(np.round(rows, 4), axis=0).shape[0] != 1:
+            return None  # colormapped / multi-color -> intentional gradient
+        return (float(rows[0][0]), float(rows[0][1]), float(rows[0][2]))
+    if isinstance(artist, Patch):
+        return _single_rgb(artist.get_facecolor())
+    return None
+
+
+def _real_label(label) -> bool:
+    """True for a legend-worthy label (non-empty, not ``_``-prefixed)."""
+    return isinstance(label, str) and bool(label) and not label.startswith("_")
+
+
+def _collect_series(ax) -> List[Tuple[str, _RGB]]:
+    """(label, rgb) for every visible, labelled data series in one Axes.
+
+    Covers Line2D (``ax.lines``), Collections (scatter), labelled
+    containers (bar/errorbar, label lives on the container) and any
+    standalone labelled Patch. Bars are picked up once via their container;
+    their child Rectangles carry ``_``-labels and are skipped.
+    """
+    series: List[Tuple[str, _RGB]] = []
+
+    def _add(artist, label):
+        if not getattr(artist, "get_visible", lambda: True)():
+            return
+        if not _real_label(label):
+            return
+        rgb = _series_rgb(artist)
+        if rgb is not None:
+            series.append((label, rgb))
+
+    for ln in ax.get_lines():
+        _add(ln, ln.get_label())
+    for coll in ax.collections:
+        _add(coll, coll.get_label())
+    for cont in getattr(ax, "containers", []) or []:
+        if not _real_label(cont.get_label()):
+            continue
+        for child in cont:
+            rgb = _series_rgb(child)
+            if rgb is not None:
+                series.append((cont.get_label(), rgb))
+                break
+    for patch in ax.patches:
+        _add(patch, patch.get_label())
+    return series
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+def _resolve_axes(fig_or_axes):
+    """Accept a list of Axes, a matplotlib Figure, or a RecordingFigure."""
+    if isinstance(fig_or_axes, (list, tuple)):
+        return list(fig_or_axes)
+    mpl_fig = getattr(fig_or_axes, "fig", fig_or_axes)
+    if not hasattr(mpl_fig, "get_axes"):
+        return []
+    canvas = getattr(mpl_fig, "canvas", None)
+    if canvas is not None:
+        try:
+            canvas.draw()
+        except Exception:
+            pass
+    from ._overlap import _classify_axes
+
+    data_axes, _colorbars, _overlays = _classify_axes(mpl_fig)
+    return data_axes
+
+
+def detect_color_collisions(fig_or_axes, min_delta_e: float = _COLOR_JND_DELTA_E):
+    """Report pairs of labelled series with near-identical (ambiguous) colors.
+
+    ``fig_or_axes`` may be a list of data Axes (already drawn -- the
+    internal fast path used by ``detect_layout_conflicts``), a matplotlib
+    Figure, or a ``RecordingFigure`` (drawn + classified here). Returns a
+    list of ``Conflict`` objects with ``kind="color"``; ``fraction`` carries
+    the measured ΔE. Empty when every labelled series is distinguishable.
+    """
+    from ._overlap import Conflict
+
+    conflicts: List["Conflict"] = []
+    for ax in _resolve_axes(fig_or_axes):
+        series = _collect_series(ax)
+        n = len(series)
+        for i in range(n):
+            for j in range(i + 1, n):
+                label_a, rgb_a = series[i]
+                label_b, rgb_b = series[j]
+                if label_a == label_b:
+                    continue  # same logical series drawn in parts
+                de = delta_e76(rgb_a, rgb_b)
+                if de < min_delta_e:
+                    conflicts.append(
+                        Conflict(
+                            role_a="color",
+                            role_b="color",
+                            label_a=label_a,
+                            label_b=label_b,
+                            fraction=de,
+                            kind="color",
+                        )
+                    )
+    return conflicts
+
+
+# EOF

--- a/src/figrecipe/_quality/_overlap.py
+++ b/src/figrecipe/_quality/_overlap.py
@@ -101,13 +101,16 @@ class _Component:
 
 @dataclass
 class Conflict:
-    """A detected, forbidden overlap between two components.
+    """A detected figure-quality conflict between two components.
 
     ``role_a``/``role_b`` are the colliding roles; ``label_a``/``label_b``
     are short human labels (e.g. ``"colorbar"``, ``"axes r0c4"``,
-    ``"text 'PAC z-score'"``); ``fraction`` is the overlap measure that
-    tripped the rule (intersection/min-area for bbox pairs; non-background
-    pixel fraction for ``legend <-> ink``).
+    ``"text 'PAC z-score'"``). ``kind`` selects the conflict class:
+    ``"overlap"`` (default) for a geometric overlap -- ``fraction`` is then
+    the overlap measure that tripped the rule (intersection/min-area for
+    bbox pairs; non-background pixel fraction for ``legend <-> ink``) -- or
+    ``"color"`` for two labelled series with near-identical colors, where
+    ``fraction`` carries the measured CIELAB ΔE*76.
     """
 
     role_a: str
@@ -115,9 +118,15 @@ class Conflict:
     label_a: str
     label_b: str
     fraction: float
+    kind: str = "overlap"
 
     def describe(self) -> str:
         """One-line, actionable description of the conflict."""
+        if self.kind == "color":
+            return (
+                f"{self.label_a} and {self.label_b} share near-identical "
+                f"colors (ΔE={self.fraction:.1f})"
+            )
         return f"{self.label_a} overlaps {self.label_b} ({self.fraction:.0%} coverage)"
 
 
@@ -392,6 +401,13 @@ def detect_layout_conflicts(
                 _detect_legend_ink_conflicts(legends, ink_mask, height, tol)
             )
 
+    # Color-collision: labelled series drawn in indistinguishable colors.
+    # The figure is already drawn above, so pass the classified data axes to
+    # skip a redraw. Lazy import keeps _color_collision one-directional.
+    from ._color_collision import detect_color_collisions
+
+    conflicts.extend(detect_color_collisions(data_axes))
+
     return conflicts
 
 
@@ -409,10 +425,11 @@ def run_overlap_check(
     if conflicts:
         lines = "\n  ".join(c.describe() for c in conflicts)
         warnings.warn(
-            "Layout conflict detected: components overlap that should not.\n"
+            "Figure-quality conflict detected: components overlap or share "
+            "indistinguishable colors.\n"
             f"  {lines}\n"
-            "  (Move/resize the offending element, or pass a larger figure "
-            "/ tighter layout.)",
+            "  (Move/resize the offending element, pass a larger figure / "
+            "tighter layout, or use more distinct colors.)",
             UserWarning,
             stacklevel=2,
         )

--- a/tests/figrecipe/_quality/test__color_collision.py
+++ b/tests/figrecipe/_quality/test__color_collision.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the save-time COLOR-collision detector.
+
+AAA layout, ONE assertion each, no mocks, headless Agg backend. Each test
+drives ``detect_color_collisions`` (or the color-science helper
+``delta_e76``) directly on a real matplotlib figure and asserts whether a
+color-collision Conflict was produced.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+from figrecipe._quality._color_collision import (  # noqa: E402
+    delta_e76,
+    detect_color_collisions,
+)
+from figrecipe._quality._overlap import detect_layout_conflicts  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figs():
+    # Arrange / teardown: keep the pyplot state clean between tests.
+    yield
+    plt.close("all")
+
+
+def _has_color(conflicts):
+    """True if any conflict is a color collision."""
+    return any(c.kind == "color" for c in conflicts)
+
+
+# ---------------------------------------------------------------------------
+# Color science: sRGB -> CIELAB ΔE*76
+# ---------------------------------------------------------------------------
+def test_delta_e_zero_for_identical_colors():
+    # Arrange
+    color = (0.12, 0.47, 0.71)
+    # Act
+    de = delta_e76(color, color)
+    # Assert
+    assert de == pytest.approx(0.0, abs=1e-9)
+
+
+def test_delta_e_red_vs_blue_is_large():
+    # Arrange
+    red, blue = (1.0, 0.0, 0.0), (0.0, 0.0, 1.0)
+    # Act
+    de = delta_e76(red, blue)
+    # Assert
+    assert de > 100.0
+
+
+# ---------------------------------------------------------------------------
+# detect_color_collisions
+# ---------------------------------------------------------------------------
+def test_near_identical_line_colors_flagged():
+    # Arrange: two labelled lines whose colors differ imperceptibly.
+    fig, ax = plt.subplots(figsize=(4, 3), dpi=100)
+    ax.plot([0, 1], [0, 1], color="#1f77b4", label="A")
+    ax.plot([0, 1], [1, 0], color="#1f77b6", label="B")
+    # Act
+    conflicts = detect_color_collisions([ax])
+    # Assert
+    assert _has_color(conflicts)
+
+
+def test_distinct_line_colors_not_flagged():
+    # Arrange: two clearly distinguishable labelled lines.
+    fig, ax = plt.subplots(figsize=(4, 3), dpi=100)
+    ax.plot([0, 1], [0, 1], color="red", label="A")
+    ax.plot([0, 1], [1, 0], color="blue", label="B")
+    # Act
+    conflicts = detect_color_collisions([ax])
+    # Assert
+    assert not _has_color(conflicts)
+
+
+def test_unlabelled_near_identical_lines_not_flagged():
+    # Arrange: same near-duplicate colors but NO legend labels -> not a series
+    # a reader is asked to distinguish, so it must stay silent.
+    fig, ax = plt.subplots(figsize=(4, 3), dpi=100)
+    ax.plot([0, 1], [0, 1], color="#1f77b4")
+    ax.plot([0, 1], [1, 0], color="#1f77b6")
+    # Act
+    conflicts = detect_color_collisions([ax])
+    # Assert
+    assert not _has_color(conflicts)
+
+
+def test_same_label_same_color_not_flagged():
+    # Arrange: one logical series drawn in two segments (same label) -- the
+    # identical color is intentional, never a collision.
+    fig, ax = plt.subplots(figsize=(4, 3), dpi=100)
+    ax.plot([0, 1], [0, 1], color="#1f77b4", label="A")
+    ax.plot([1, 2], [1, 2], color="#1f77b4", label="A")
+    # Act
+    conflicts = detect_color_collisions([ax])
+    # Assert
+    assert not _has_color(conflicts)
+
+
+def test_colormapped_scatter_not_flagged():
+    # Arrange: a colormapped scatter carries many colors on purpose; its
+    # gradient must never be read as a near-duplicate collision.
+    fig, ax = plt.subplots(figsize=(4, 3), dpi=100)
+    ax.scatter([0, 1, 2], [0, 1, 2], c=[0, 1, 2], cmap="viridis", label="pts")
+    ax.plot([0, 2], [0, 2], color="#1f77b4", label="line")
+    # Act
+    conflicts = detect_color_collisions([ax])
+    # Assert
+    assert not _has_color(conflicts)
+
+
+def test_near_identical_colors_across_panels_not_flagged():
+    # Arrange: the SAME color reused in two separate panels is fine -- only
+    # within-axes ambiguity matters.
+    fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(6, 3), dpi=100)
+    ax0.plot([0, 1], [0, 1], color="#1f77b4", label="A")
+    ax1.plot([0, 1], [0, 1], color="#1f77b4", label="A")
+    # Act
+    conflicts = detect_color_collisions([ax0, ax1])
+    # Assert
+    assert not _has_color(conflicts)
+
+
+# ---------------------------------------------------------------------------
+# Conflict payload + save-time integration
+# ---------------------------------------------------------------------------
+def test_color_conflict_describe_mentions_delta_e():
+    # Arrange
+    fig, ax = plt.subplots(figsize=(4, 3), dpi=100)
+    ax.plot([0, 1], [0, 1], color="#1f77b4", label="A")
+    ax.plot([0, 1], [1, 0], color="#1f77b6", label="B")
+    # Act
+    text = detect_color_collisions([ax])[0].describe()
+    # Assert
+    assert "ΔE" in text
+
+
+def test_run_overlap_check_surfaces_color_collision():
+    # Arrange: the save-time entry point must fold color collisions in.
+    fig, ax = plt.subplots(figsize=(4, 3), dpi=100)
+    ax.plot([0, 1], [0, 1], color="#1f77b4", label="A")
+    ax.plot([0, 1], [1, 0], color="#1f77b6", label="B")
+    # Act
+    conflicts = detect_layout_conflicts(fig)
+    # Assert
+    assert _has_color(conflicts)
+
+
+# EOF


### PR DESCRIPTION
## Summary
Adds an always-on, save-time **color-collision** check: two data series a reader is asked to tell apart (both carrying a real legend label) drawn in colors so close they are perceptually **indistinguishable** are now flagged — even when their shapes never geometrically overlap. This is the color sibling of the existing geometric overlap check and is surfaced through the same `run_overlap_check` save-time warning path.

Closes card `figrecipe-color-overlap-detection-20260701` (P2).

## How
- New `figrecipe._quality._color_collision`:
  - `delta_e76(rgb_a, rgb_b)` — perceptual CIELAB ΔE*76 (sRGB→linear→XYZ(D65)→Lab).
  - `detect_color_collisions(fig_or_axes, min_delta_e=5.0)` — per data axes, compares every pair of labelled series; flags pairs below the just-noticeable threshold.
- `_quality/_overlap.py`: `Conflict` gains an additive `kind` field (`"overlap"` | `"color"`); `describe()` branches; `detect_layout_conflicts` folds color collisions in (figure already drawn → no redraw); `run_overlap_check` warning text generalized to cover both.

## Scope guards (no false positives on legitimate figures)
- Only **labelled** series are compared (decorative/reference artists ignored).
- **Same-label** series (one logical series in parts) are exempt.
- **Colormapped** scatters (intentional gradients) are skipped.
- Colors compared **within a single axes** only (cross-panel reuse is fine).
- Conservative default threshold (ΔE 5.0) — distinct qualitative-palette colors sit well above it.

## Tests
`tests/figrecipe/_quality/test__color_collision.py` — 10 tests (AAA, one assertion each, headless Agg, no mocks): ΔE identity/large-distance, near-identical flagged, distinct/unlabelled/same-label/colormapped/cross-panel not flagged, describe() payload, and `run_overlap_check` integration. All 10 pass; existing 11 `_overlap` tests still pass (backward-compatible `kind` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)