### PR TITLE
fix(serializer): to_dict snapshot so save no longer destroys record data (0.29.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.19] - 2026-07-09
+
+### Fixed
+- **Serializing a figure record no longer destroys its in-memory data** (root
+  cause of the flaky imshow nested / compose-of-composed round-trip failure).
+  `CallRecord.to_dict()` returned its `args`/`kwargs` **by reference**, and the
+  save pipeline (`_process_arrays_for_save`) pops `_array` and rewrites `data`
+  on those dicts in place — so the first save mutated the *live* record,
+  stripping each arg's `_array`. A second save/compose of the same live record
+  then emitted a data reference with no CSV written behind it, and reproduce
+  raised `FileNotFoundError: <name>_data/<id>_x.csv` (intermittently on py3.11
+  in CI, deterministically for any double-serialize). `to_dict()` now returns a
+  shallow-copied snapshot of `args`/`kwargs`, so the save pipeline mutates only
+  the snapshot; the `_array` values are shared by reference (not deep-copied, so
+  file-based storage is unaffected). Regression tests: `to_dict` non-aliasing
+  (recorder) + save-same-figure-twice writes data files both times (serializer).
+
 ## [0.29.18] - 2026-07-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.18"
+version = "0.29.19"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_recorder/_core.py
+++ b/src/figrecipe/_recorder/_core.py
@@ -31,12 +31,24 @@ class CallRecord:
     stats: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary for serialization."""
+        """Convert to dictionary for serialization.
+
+        ``args``/``kwargs`` are SHALLOW-COPIED so the save pipeline
+        (``_process_arrays_for_save`` pops ``_array`` and rewrites ``data``
+        in place) mutates only this snapshot, never the live record. Without
+        the copy, serializing a record DESTROYS its in-memory ``_array``: a
+        second save/compose of the same live record then emits a data
+        reference with no CSV written behind it, so reproduce raises
+        ``FileNotFoundError: <name>_data/<id>_x.csv`` (the flaky imshow
+        nested/compose-of-composed round-trip failure). The ``_array`` values
+        are shared by reference (not deep-copied) -- the save path only reads
+        them, and deep-copying the arrays would defeat file-based storage.
+        """
         result = {
             "id": self.id,
             "function": self.function,
-            "args": self.args,
-            "kwargs": self.kwargs,
+            "args": [dict(a) if isinstance(a, dict) else a for a in self.args],
+            "kwargs": dict(self.kwargs),
             "timestamp": self.timestamp,
         }
         if self.stats is not None:

--- a/tests/integration/test_save_idempotency.py
+++ b/tests/integration/test_save_idempotency.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression: serialization must NOT destroy the live record's data.
+
+The save pipeline (``_process_arrays_for_save``) pops ``_array`` from a
+record's args and rewrites ``data`` in place. ``CallRecord.to_dict()`` used
+to return those args BY REFERENCE, so the FIRST save mutated the live
+record -- stripping every arg's ``_array``. A second save/compose of the
+same live record then emitted a data reference with no CSV written behind
+it, and reproduce raised ``FileNotFoundError: <name>_data/<id>_x.csv`` (the
+flaky imshow nested / compose-of-composed round-trip failure). ``to_dict()``
+now returns a shallow-copied snapshot. AAA layout, ONE assertion each, no
+mocks, headless Agg.
+"""
+
+import tempfile
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np  # noqa: E402
+
+import figrecipe as fr  # noqa: E402
+from figrecipe._recorder import CallRecord  # noqa: E402
+
+
+def test_to_dict_does_not_alias_live_args():
+    # Arrange: an arg carrying an in-memory _array (what the save pipeline pops).
+    record = CallRecord(
+        id="plot_001",
+        function="plot",
+        args=[{"name": "x", "_array": np.array([1, 2, 3])}],
+        kwargs={"color": "red"},
+    )
+    # Act: mutate the serialization snapshot the way the save pipeline does.
+    record.to_dict()["args"][0].pop("_array")
+    # Assert: the live record is untouched, so a later save still has its data.
+    assert "_array" in record.args[0]
+
+
+def test_second_save_of_same_figure_writes_data_files():
+    # Arrange: one live figure whose line data is filed to CSV on save.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fig, ax = fr.subplots(1, 1)
+        ax.plot([0, 1, 2, 3], [3, 2, 1, 0], id="host_line")
+        fr.save(fig, str(Path(tmpdir) / "figA.png"))
+        # Act: save the SAME live figure a second time to a fresh location.
+        fr.save(fig, str(Path(tmpdir) / "figB.png"))
+        # Assert: the second save wrote its own copy of the data file.
+        assert (Path(tmpdir) / "figB_data" / "host_line_x.csv").exists()


### PR DESCRIPTION
## Summary
Fixes the **root cause** of the flaky imshow nested / compose-of-composed round-trip failure (`FileNotFoundError: <name>_data/<id>_x.csv`) that has been forcing repeated release-matrix re-runs.

`CallRecord.to_dict()` returned its `args`/`kwargs` **by reference**, and the save pipeline (`_process_arrays_for_save`) pops `_array` and rewrites `data` on those dicts **in place**. So the **first** save mutated the *live* record, stripping every arg's `_array`. A **second** save/compose of the same live record then emitted a data reference with no CSV written behind it → reproduce raised `FileNotFoundError`. Intermittent on py3.11 in CI (whichever nested path re-serializes), but **deterministic** for any double-serialize.

Closes card `figrecipe-flaky-imshow-nested-roundtrip-datafile` (P2).

## Root-cause method
Read-trace of the data-file lifecycle → hypothesis → **local deterministic repro**: saving the same live figure twice drops the second data dir's CSV (`bug reproduced = True`). The card previously believed this was not locally reproducible (only the full nested flow was tried); the underlying double-serialize reproduces trivially.

## Fix
`CallRecord.to_dict()` now returns a **shallow-copied snapshot** of `args`/`kwargs`, so the save pipeline mutates only the snapshot, never the live record. `_array` values are shared by reference (not deep-copied — file-based storage and memory are unaffected). One-line-equivalent, no behavior change to recording/serialization output.

## Tests
`tests/integration/test_save_idempotency.py` (AAA, one assertion each, headless Agg, no mocks):
- `test_to_dict_does_not_alias_live_args` — mutating the snapshot leaves the record's `_array` intact.
- `test_second_save_of_same_figure_writes_data_files` — saving the same figure twice writes the data file both times.

Both pass; repro flips from `True` → `False` with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)