### PR TITLE
chore: gitignore .worktrees/ (agent worktree churn)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -832,3 +832,4 @@ src/*/_docs/
 .scitex/dev/*
 !.scitex/dev/config.yaml
 !.scitex/dev/cli-audit-dict.yaml
+.worktrees/


### PR DESCRIPTION
Agent worktree-isolation creates <repo>/.worktrees/, which was NOT gitignored -> perpetual dirty tree -> pre-stop rescue-autosave commits pollute develop (fleet-wide, blocked deploy-freshness ff-pull). Adds .worktrees/ to .gitignore. Operator-approved 2026-07-08 (per-repo, option B).