### PR TITLE
fix(tests): split combined AAA marker in panel-label-weight test (0.29.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.21] - 2026-07-09
+
+### Fixed
+- **Audit conformance for the 0.29.20 panel-label-weight regression test.** The new
+  `tests/integration/test_panel_label_weight_style.py` combined `# Arrange / Act`
+  on one line, tripping the STX-TQ002 AAA-marker audit rule (which runs only on the
+  3.13 CI SIF) and blocking the 0.29.20 release from publishing. Split into separate
+  `# Arrange` / `# Act` / `# Assert` markers. (0.29.20's panel-label-weight change is
+  included here — 0.29.20 never published.)
+
 ## [0.29.20] - 2026-07-09
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.20"
+version = "0.29.21"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/tests/integration/test_panel_label_weight_style.py
+++ b/tests/integration/test_panel_label_weight_style.py
@@ -17,9 +17,11 @@ from figrecipe.styles._style_loader import load_style  # noqa: E402
 
 
 def test_scitex_style_owns_panel_label_weight():
-    # Arrange / Act: load the SCITEX preset.
-    style = load_style("SCITEX")
-    # Assert: the weight is a real field on the style's fonts block.
+    # Arrange
+    name = "SCITEX"
+    # Act
+    style = load_style(name)
+    # Assert
     assert style.fonts.panel_label_weight == "bold"
 
 


### PR DESCRIPTION
Fixes the STX-TQ002 audit violation I introduced in the 0.29.20 panel-label-weight test (`test_panel_label_weight_style.py` combined `# Arrange / Act` on one line), which blocked 0.29.20 from publishing (audit runs only on the 3.13 CI SIF). Split into separate # Arrange / # Act / # Assert markers. Verified locally: audit now reports only the pre-existing local-checkout noise (logs/ + docs PATH.yaml), absent in CI. 0.29.20's panel-label-weight change ships here (0.29.20 never published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)