### PR TITLE
ci: pilot org-level reusable CI workflows (scitex-ai/.github)

### DIFF
--- a/.github/workflows/auto-merge-to-develop.yaml
+++ b/.github/workflows/auto-merge-to-develop.yaml
@@ -1,9 +1,11 @@
 name: auto-merge-to-develop
-# Merge green PRs that TARGET develop, the moment their checks complete.
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers/permissions preserved verbatim from the prior local file.
 # GitHub reads check_suite-triggered workflows from the DEFAULT branch (main),
-# so this file lives on main but acts ONLY on PRs whose base is develop.
-# codecov + readthedocs checks are ignored (advisory). Fail-safe: if a merge
-# is blocked by branch policy the PR simply stays open.
+# so this file must stay on main, acting only on PRs whose base is develop
+# (unchanged from before). Job body was byte-identical to the reusable
+# workflow at scitex-ai/.github/.github/workflows/auto-merge-to-develop.yml
+# (verified 2026-07-10) — a clean 1:1 extraction, no behavior change.
 on:
   check_suite:
     types: [completed]
@@ -14,36 +16,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  automerge:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.check_suite.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: merge green PRs targeting develop
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
-        run: |
-          set -uo pipefail
-          if [ -n "${HEAD_SHA:-}" ]; then
-            prs=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[] | select(.state=="open") | .number' 2>/dev/null || true)
-          else
-            prs=$(gh pr list --repo "$REPO" --base develop --state open --json number --jq '.[].number' 2>/dev/null || true)
-          fi
-          [ -z "${prs:-}" ] && { echo "no open PRs"; exit 0; }
-          for pr in $prs; do
-            base=$(gh pr view "$pr" --repo "$REPO" --json baseRefName --jq .baseRefName 2>/dev/null || echo "")
-            [ "$base" = "develop" ] || { echo "skip #$pr (base=$base, not develop)"; continue; }
-            draft=$(gh pr view "$pr" --repo "$REPO" --json isDraft --jq .isDraft 2>/dev/null || echo true)
-            [ "$draft" = "true" ] && continue
-            pending=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq '
-              [ .statusCheckRollup[]
-                | select(((.name // .context // "") | ascii_downcase | test("codecov|readthedocs")) | not)
-                | (.conclusion // .state // "")
-                | select(. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED" and . != "") ] | length' 2>/dev/null || echo 1)
-            if [ "$pending" = "0" ]; then
-              gh pr merge "$pr" --repo "$REPO" --merge --admin --delete-branch && echo "MERGED #$pr -> develop" || echo "blocked #$pr"
-            else
-              echo "PR #$pr not green ($pending) — skip"
-            fi
-          done
+  call:
+    uses: scitex-ai/.github/.github/workflows/auto-merge-to-develop.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What

Fleet-wide CI-workflow content-drift remediation (operator-approved 2026-07-10 incident). Follows the pattern piloted and merged on `scitex-ai/scitex-stats` PR #69: replace job bodies that are a clean 1:1 match for an `scitex-ai/.github` reusable workflow with a thin `uses:` caller stub.

## Converted (1 file)

- `auto-merge-to-develop.yaml`: job body was **byte-identical** to `scitex-ai/.github/.github/workflows/auto-merge-to-develop.yml@main`. Clean mechanical extraction — `on:`/`concurrency:`/`permissions:` preserved verbatim, `secrets: inherit` added. No behavior change.

## Left alone (with reasons)

figrecipe's CI is deeply customized around a **self-hosted Spartan SIF execution model**, documented in-repo as required because "the Spartan compute runners have NO Python on the bare node." This is fundamentally different from the `astral-sh/setup-uv` + `uv venv` approach the reusable workflows use, and figrecipe's self-hosted runner pool is labeled differently (`vars.CI_RUNS_ON` → `scitex-ci`, vs the reusable workflow's hardcoded `spartan-cpu`). Converting these would risk breaking CI (wrong runner label / missing SIF tooling), so none were converted:

- `pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml` — runs pytest **inside** a pre-built apptainer SIF via `.github/ci/exec-in-sif.sh`, not a uv-based install. Required-status-check names (`pytest-matrix-on-ubuntu-py3.1{1,2,3}`) are unchanged by leaving this alone, so branch protection needs no update.
- `import-smoke-on-ubuntu-py3-12.yml` — runs on `ubuntu-latest` with stdlib `venv`+`pip` (not self-hosted+uv); hardcodes package name and prints `__version__` instead of a generic import-OK message.
- `figrecipe-quality-audit-on-ubuntu-latest.yml` — uses a `--new-only` ratchet, `fetch-depth: 0` git-worktree diffing, a pinned `scitex-dev@develop` git ref, and an `fd` install step on `ubuntu-latest`. Substantially more than the reusable `quality-audit.yml`'s plain `audit-all` call on self-hosted `spartan-cpu`.
- `rtd-sphinx-build-on-ubuntu-latest.yml` (job "docs"/"sphinx") — builds real project docs and **auto-commits** refreshed HTML back to `develop`. Converting would silently drop that auto-commit-back behavior; the reusable `rtd-sphinx-build.yml` is a smoke check only.
- `cla.yml` — uses `secrets.CLA_PERSONAL_ACCESS_TOKEN`, but the reusable `cla.yml`'s `CLAssistant` step hardcodes `secrets.GH_PERSONAL_ACCESS_TOKEN` (not parameterized as an input). Converting would silently break CLA signing unless figrecipe also provisions a same-named `GH_PERSONAL_ACCESS_TOKEN` secret — left alone pending that decision.
- `newb-docs-quality-on-ubuntu-latest.yml` — no reusable-workflow equivalent exists yet (per the migration brief). Untouched.
- `pypi-publish-and-github-release-on-tag.yml` (job "release") — explicitly out of scope. PyPI OIDC trusted-publishing does not support `workflow_call` reusable workflows (`invalid-publisher`).

## Branch protection

Not updated — checked both `develop` and `main`; both require only `pytest-matrix-on-ubuntu-py3.1{1,2,3}`, which is untouched by this diff.

## Verification

- Edited YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`) — pass.
- `git status` after the edit showed exactly one changed file.

## Do not merge automatically

Left for review per task instructions — small, low-risk diff (one workflow, byte-identical body), but still real CI-affecting content.