### PR TITLE
fix(serializer): recurse into embed/inset subpanels when filing large array data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.24] - 2026-07-11
+
+### Fixed
+- **Audit conformance for the 0.29.23 regression-guard test.** The new
+  `test_small_embedded_array_stays_inline_and_validates` had no explicit
+  `assert` and combined `# Act / Assert` on one line, tripping the
+  STX-TQ001/STX-TQ002 audit rules (3.11+ CI) and blocking the 0.29.23
+  release from publishing. Split into separate `# Act` / `# Assert`
+  markers with an explicit assertion (no `*-not-reproduced*` divergence
+  artifact was written). (0.29.23's serializer fix is included here —
+  0.29.23 never published.)
+
 ## [0.29.23] - 2026-07-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.23] - 2026-07-11
+
+### Fixed
+- **Root-caused the flaky imshow nested/composed round-trip test.** `ax.embed()`
+  materializes the source recipe's array data inline (`load_recipe()` sets
+  `arg["data"] = arr.tolist()` plus `_source_file`), but the save pipeline
+  (`_serializer/_save.py::_process_arrays_for_save` /
+  `_process_arrays_with_symlinks`) only ever walked each axes' top-level
+  `calls`/`decorations` — never the nested `subpanels` list that
+  `ax.embed()`/`ax.inset_axes()` produce. So an embedded source's array data
+  (e.g. a 512x512 RGBA `imshow` icon, ~1M scalars) was never re-filed to
+  CSV/NPZ; it stayed inline on every save, turning `_convert_numpy_types` +
+  `ruamel.yaml.dump` into an O(N) walk over ~1M Python-level scalar nodes —
+  a multi-minute, deterministic hang that CI's per-job timeout (or a loaded
+  runner) intermittently killed, misread as "flaky." Both serializer
+  functions now recurse into `subpanels`; the loader (`_load.py`) resolves
+  the same nested file references back into real array data. A missing
+  source file now falls back to inline data with a loud warning (was
+  previously silent). Re-filing only kicks in above a size floor
+  (`_SUBPANEL_FILE_REF_MIN_ELEMENTS = 256`): a smaller sub-panel array stays
+  inline, because the reproducer's inset/embed replay path
+  (`_reproducer/_replay_insets.py`) resolves a sub-panel's `data` straight
+  from the recipe dict rather than through the file-reference loader, so a
+  filed reference there isn't (yet) something it understands — filing a
+  below-threshold array broke the ordinary small-embed case (a save-time
+  reproducibility-validation failure), caught by a regression test before
+  shipping. Regression tests: `tests/integration/test_embed_subpanel_data_filing.py`.
+
 ## [0.29.21] - 2026-07-09
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.23"
+version = "0.29.24"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.21"
+version = "0.29.23"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_serializer/_load.py
+++ b/src/figrecipe/_serializer/_load.py
@@ -142,77 +142,93 @@ def _resolve_data_references(
     if isinstance(data_info, dict) and data_info.get("csv_format") == "single":
         return _resolve_single_csv_references(data, base_dir, data_info)
 
-    # Original behavior: resolve individual file references
-    for ax_key, ax_data in data.get("axes", {}).items():
-        for call_list in [ax_data.get("calls", []), ax_data.get("decorations", [])]:
-            for call in call_list:
-                for arg in call.get("args", []):
-                    data_ref = arg.get("data")
+    # Original behavior: resolve individual file references. Recurses into
+    # ``subpanels`` (``ax.embed()`` / ``ax.inset_axes()`` managed sub-panels):
+    # the save side now files large embedded arrays to CSV/NPZ too (see
+    # ``_serializer/_save.py::_process_arrays_for_save``), so the loader must
+    # resolve those same references back into real array data -- otherwise a
+    # sub-panel's arg would carry the raw filename STRING as its "data" value,
+    # and replay would try to plot a filename.
+    def _resolve_call_list(call_list) -> None:
+        for call in call_list:
+            for arg in call.get("args", []):
+                data_ref = arg.get("data")
 
-                    # Check if it's a file reference
-                    if isinstance(data_ref, str) and (
-                        data_ref.endswith(".npy")
-                        or data_ref.endswith(".npz")
-                        or data_ref.endswith(".csv")
-                    ):
-                        file_path = base_dir / data_ref
-                        if file_path.exists():
-                            # Get dtype from YAML to ensure proper type conversion
-                            dtype = arg.get("dtype")
-                            arr = load_array(file_path, dtype=dtype)
+                # Check if it's a file reference
+                if isinstance(data_ref, str) and (
+                    data_ref.endswith(".npy")
+                    or data_ref.endswith(".npz")
+                    or data_ref.endswith(".csv")
+                ):
+                    file_path = base_dir / data_ref
+                    if file_path.exists():
+                        # Get dtype from YAML to ensure proper type conversion
+                        dtype = arg.get("dtype")
+                        arr = load_array(file_path, dtype=dtype)
 
-                            # Check if this was a list of arrays
-                            if arg.get("_is_array_list"):
-                                # Reconstruct list of arrays from 2D array
-                                n_arrays = arg.get(
-                                    "_n_arrays", arr.shape[1] if arr.ndim > 1 else 1
-                                )
-                                array_lengths = arg.get("_array_lengths")
-
-                                arrays = []
-                                for i in range(n_arrays):
-                                    if arr.ndim > 1:
-                                        col = arr[:, i]
-                                    else:
-                                        col = arr
-
-                                    # Trim to original length (remove NaN padding)
-                                    if array_lengths and i < len(array_lengths):
-                                        col = col[: array_lengths[i]]
-                                        col = col[~np.isnan(col)]
-                                    arrays.append(col)
-
-                                arg["data"] = [a.tolist() for a in arrays]
-                                arg["_loaded_array"] = arrays
-                            elif np.issubdtype(arr.dtype, np.datetime64):
-                                # datetime64.tolist() yields raw nanosecond ints,
-                                # which on re-save would be written INLINE and then
-                                # reload as plain numbers (plotting at ~1.3e18
-                                # instead of as dates) -- a non-idempotent
-                                # save->reproduce->save round-trip. Keep the array
-                                # under _array so re-save re-files it as a CSV (ISO
-                                # strings, dtype preserved), exactly like the first
-                                # save. _loaded_array drives the in-memory replay.
-                                arg["_array"] = arr
-                                arg["_loaded_array"] = arr
-                            else:
-                                arg["data"] = arr.tolist()
-                                arg["_loaded_array"] = arr
-
-                            # Store source file path for symlink support
-                            arg["_source_file"] = str(file_path.resolve())
-                            record_input(file_path)  # clew: data file as input
-                        else:
-                            # Fail loud: a referenced data file that does not
-                            # exist (e.g. a broken/stale compose symlink) must
-                            # NOT silently fall through and leave the path string
-                            # as the arg -- that surfaces later as a cryptic
-                            # "not a valid format string" deep in matplotlib.
-                            raise FileNotFoundError(
-                                f"recipe data file not found: {file_path} "
-                                f"(referenced as '{data_ref}'). Fix the source "
-                                f"data; do not reproduce from a broken recipe."
+                        # Check if this was a list of arrays
+                        if arg.get("_is_array_list"):
+                            # Reconstruct list of arrays from 2D array
+                            n_arrays = arg.get(
+                                "_n_arrays", arr.shape[1] if arr.ndim > 1 else 1
                             )
+                            array_lengths = arg.get("_array_lengths")
+
+                            arrays = []
+                            for i in range(n_arrays):
+                                if arr.ndim > 1:
+                                    col = arr[:, i]
+                                else:
+                                    col = arr
+
+                                # Trim to original length (remove NaN padding)
+                                if array_lengths and i < len(array_lengths):
+                                    col = col[: array_lengths[i]]
+                                    col = col[~np.isnan(col)]
+                                arrays.append(col)
+
+                            arg["data"] = [a.tolist() for a in arrays]
+                            arg["_loaded_array"] = arrays
+                        elif np.issubdtype(arr.dtype, np.datetime64):
+                            # datetime64.tolist() yields raw nanosecond ints,
+                            # which on re-save would be written INLINE and then
+                            # reload as plain numbers (plotting at ~1.3e18
+                            # instead of as dates) -- a non-idempotent
+                            # save->reproduce->save round-trip. Keep the array
+                            # under _array so re-save re-files it as a CSV (ISO
+                            # strings, dtype preserved), exactly like the first
+                            # save. _loaded_array drives the in-memory replay.
+                            arg["_array"] = arr
+                            arg["_loaded_array"] = arr
+                        else:
+                            arg["data"] = arr.tolist()
+                            arg["_loaded_array"] = arr
+
+                        # Store source file path for symlink support
+                        arg["_source_file"] = str(file_path.resolve())
+                        record_input(file_path)  # clew: data file as input
+                    else:
+                        # Fail loud: a referenced data file that does not
+                        # exist (e.g. a broken/stale compose symlink) must
+                        # NOT silently fall through and leave the path string
+                        # as the arg -- that surfaces later as a cryptic
+                        # "not a valid format string" deep in matplotlib.
+                        raise FileNotFoundError(
+                            f"recipe data file not found: {file_path} "
+                            f"(referenced as '{data_ref}'). Fix the source "
+                            f"data; do not reproduce from a broken recipe."
+                        )
+
+    def _resolve_ax_data(ax_data) -> None:
+        _resolve_call_list(ax_data.get("calls", []))
+        _resolve_call_list(ax_data.get("decorations", []))
+        for sp in ax_data.get("subpanels", []) or []:
+            sp_axes = sp.get("axes")
+            if sp_axes is not None:
+                _resolve_ax_data(sp_axes)
+
+    for ax_key, ax_data in data.get("axes", {}).items():
+        _resolve_ax_data(ax_data)
 
     return data
 

--- a/src/figrecipe/_serializer/_save.py
+++ b/src/figrecipe/_serializer/_save.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Save-side serialization for recipe files (YAML + data files)."""
 
+import warnings
 from pathlib import Path
 from typing import Any, Dict, Union
 
@@ -19,6 +20,16 @@ from .._utils._numpy_io import (
 )
 from ._clew import record_output
 from ._utils import _convert_numpy_types, _sanitize_filename
+
+# Sub-panel array args below this size stay inline on save: the inset/embed
+# replay path (_reproducer/_replay_insets.py) doesn't resolve file-reference
+# ``data`` strings, only the top-level loader does. Above it, re-filing wins
+# (avoids the pathological large-array inline-YAML slowdown/CI hang).
+_SUBPANEL_FILE_REF_MIN_ELEMENTS = 256
+
+
+def _subpanel_arr_size(loaded_array) -> int:
+    return int(getattr(loaded_array, "size", 0) or 0)
 
 
 def _panel_prefix(ax_key: str, nrows, ncols) -> str:
@@ -266,37 +277,105 @@ def _process_arrays_for_save(
     panel F's data lands in ``F_<call_id>_<argname>.csv``. Single-panel
     figures and legacy recipes that don't carry the grid shape get no panel
     prefix (the operator never thinks of them as having "panels").
+
+    Recurses into ``subpanels`` (``ax.embed()``/``ax.inset_axes()``): an
+    embedded source's LARGE array-backed calls (e.g. an ``imshow`` image,
+    >= ``_SUBPANEL_FILE_REF_MIN_ELEMENTS``) are re-filed/symlinked to their
+    original backing file instead of staying inline forever -- avoids the
+    pathologically slow ``_convert_numpy_types``+``ruamel.yaml.dump`` walk
+    over a giant nested-list literal (the "flaky imshow nested round-trip"
+    CI hang, see ``tests/integration/test_embed_subpanel_data_filing.py``).
+    Small sub-panel arrays stay inline: the inset replay path
+    (``_reproducer/_replay_insets.py``) resolves sub-panel args straight
+    from the recipe dict, not through the file-reference resolver.
     """
+    import os
+
     data_dir_created = False
 
-    for ax_key, ax_data in data.get("axes", {}).items():
-        panel_prefix = _panel_prefix(ax_key, nrows, ncols)
-        for call_list in [ax_data.get("calls", []), ax_data.get("decorations", [])]:
-            for call in call_list:
-                call_id = call.get("id", "unknown")
-                safe_call_id = _sanitize_filename(call_id)
+    def _process_call_list(
+        call_list, panel_prefix: str, id_prefix: str, in_subpanel: bool
+    ) -> None:
+        nonlocal data_dir_created
+        for call in call_list:
+            call_id = call.get("id", "unknown")
+            safe_call_id = _sanitize_filename(f"{id_prefix}{call_id}")
 
-                # Process args
-                for i, arg in enumerate(call.get("args", [])):
-                    if "_array" in arg:
+            for i, arg in enumerate(call.get("args", [])):
+                arr = arg.pop("_array", None)
+                source_file_path = arg.pop("_source_file", None)
+                loaded_array = arg.pop("_loaded_array", None)
+
+                if arr is not None:
+                    if not data_dir_created:
+                        data_dir.mkdir(parents=True, exist_ok=True)
+                        data_dir_created = True
+
+                    filename = (
+                        f"{panel_prefix}{safe_call_id}_{arg.get('name', f'arg{i}')}"
+                    )
+                    file_path = save_array(arr, data_dir / filename, data_format)
+                    arg["data"] = str(file_path.relative_to(data_dir.parent))
+                    record_output(file_path)  # clew: data file as session output
+
+                elif source_file_path and (
+                    not in_subpanel
+                    or _subpanel_arr_size(loaded_array)
+                    >= _SUBPANEL_FILE_REF_MIN_ELEMENTS
+                ):
+                    source_file = Path(source_file_path)
+                    if source_file.exists():
                         if not data_dir_created:
                             data_dir.mkdir(parents=True, exist_ok=True)
                             data_dir_created = True
 
-                        arr = arg.pop("_array")
-                        filename = (
-                            f"{panel_prefix}{safe_call_id}_{arg.get('name', f'arg{i}')}"
+                        target_path = data_dir / source_file.name
+                        # Refresh: drop any stale/broken link left by a prior
+                        # run so the symlink always points at the CURRENT
+                        # source, never a renamed/moved phantom.
+                        if target_path.is_symlink() or target_path.exists():
+                            target_path.unlink()
+                        rel_source = os.path.relpath(source_file, target_path.parent)
+                        os.symlink(rel_source, target_path)
+                        arg["data"] = str(target_path.relative_to(data_dir.parent))
+                        record_output(target_path)
+                    else:
+                        # The source file that backed this loaded value has
+                        # vanished. Best-effort here (this is a re-filing
+                        # OPTIMIZATION, not the sole path to correctness) --
+                        # leave the inline "data" load already reconstructed
+                        # rather than failing loud, since the recipe still
+                        # reproduces (just without the size/speed win). Warn
+                        # so a bloated re-saved recipe doesn't go unnoticed.
+                        warnings.warn(
+                            f"figrecipe: source data file for call "
+                            f"{call_id!r} no longer exists at "
+                            f"{source_file_path!r}; this array will be "
+                            f"re-saved INLINE in the recipe YAML instead of "
+                            f"filed/symlinked, which can bloat the file for "
+                            f"large arrays.",
+                            stacklevel=2,
                         )
-                        file_path = save_array(arr, data_dir / filename, data_format)
-                        arg["data"] = str(file_path.relative_to(data_dir.parent))
-                        record_output(file_path)  # clew: data file as session output
 
-                    # Drop transient load-side artifacts so a re-saved recipe never
-                    # serializes the in-memory array or an absolute source path
-                    # (both set by load when resolving file refs); otherwise they
-                    # leak into the YAML, bloating it and breaking portability.
-                    arg.pop("_loaded_array", None)
-                    arg.pop("_source_file", None)
+    def _process_ax_data(
+        ax_data, panel_prefix: str, id_prefix: str, in_subpanel: bool
+    ) -> None:
+        _process_call_list(
+            ax_data.get("calls", []), panel_prefix, id_prefix, in_subpanel
+        )
+        _process_call_list(
+            ax_data.get("decorations", []), panel_prefix, id_prefix, in_subpanel
+        )
+        for sp_idx, sp in enumerate(ax_data.get("subpanels", []) or []):
+            sp_axes = sp.get("axes")
+            if sp_axes is not None:
+                _process_ax_data(
+                    sp_axes, panel_prefix, f"{id_prefix}sub{sp_idx}_", True
+                )
+
+    for ax_key, ax_data in data.get("axes", {}).items():
+        panel_prefix = _panel_prefix(ax_key, nrows, ncols)
+        _process_ax_data(ax_data, panel_prefix, "", False)
 
     return data
 
@@ -315,60 +394,77 @@ def _process_arrays_with_symlinks(
     For arrays that aren't symlinked (no ``_source_file`` recorded), the
     panel-letter prefix is applied to the resulting filename so the
     composition path uses the same naming convention as the standard save.
+
+    Recurses into ``subpanels`` for the same reason ``_process_arrays_for_save``
+    does (see its docstring): an embedded source's array-backed calls must be
+    re-filed (symlinked or written), never left inline, or a sizeable embedded
+    array turns every save into a multi-minute ``_convert_numpy_types`` +
+    ``ruamel.yaml.dump`` walk over a giant nested-list literal.
     """
     import os
 
     data_dir_created = False
 
+    def _process_call_list(call_list, panel_prefix: str, id_prefix: str) -> None:
+        nonlocal data_dir_created
+        for call in call_list:
+            call_id = call.get("id", "unknown")
+            safe_call_id = _sanitize_filename(f"{id_prefix}{call_id}")
+            _assert_tick_call_faithful(call)
+
+            for i, arg in enumerate(call.get("args", [])):
+                source_file_path = arg.pop("_source_file", None)
+                arr = arg.pop("_array", None)
+                arg.pop("_loaded_array", None)
+
+                if source_file_path:
+                    if not data_dir_created:
+                        data_dir.mkdir(parents=True, exist_ok=True)
+                        data_dir_created = True
+
+                    source_file = Path(source_file_path)
+                    target_path = data_dir / source_file.name
+
+                    # Fail loud: composition references the REAL source data
+                    # (single source of truth); a missing source must never
+                    # produce a silently-broken recipe symlink.
+                    if not source_file.exists():
+                        raise FileNotFoundError(
+                            f"compose source data file missing: {source_file} "
+                            f"(call {call_id}). Cannot create a valid data "
+                            f"symlink for the composed recipe."
+                        )
+                    # Refresh: drop any stale/broken link left by a prior run
+                    # so the symlink always points at the CURRENT source, never
+                    # a renamed/moved phantom.
+                    if target_path.is_symlink() or target_path.exists():
+                        target_path.unlink()
+                    rel_source = os.path.relpath(source_file, target_path.parent)
+                    os.symlink(rel_source, target_path)
+
+                    arg["data"] = str(target_path.relative_to(data_dir.parent))
+
+                elif arr is not None:
+                    if not data_dir_created:
+                        data_dir.mkdir(parents=True, exist_ok=True)
+                        data_dir_created = True
+
+                    var_name = arg.get("name", f"arg{i}")
+                    filename = f"{panel_prefix}{safe_call_id}_{var_name}"
+                    file_path = save_array(arr, data_dir / filename, data_format)
+                    arg["data"] = str(file_path.relative_to(data_dir.parent))
+
+    def _process_ax_data(ax_data, panel_prefix: str, id_prefix: str) -> None:
+        _process_call_list(ax_data.get("calls", []), panel_prefix, id_prefix)
+        _process_call_list(ax_data.get("decorations", []), panel_prefix, id_prefix)
+        for sp_idx, sp in enumerate(ax_data.get("subpanels", []) or []):
+            sp_axes = sp.get("axes")
+            if sp_axes is not None:
+                _process_ax_data(sp_axes, panel_prefix, f"{id_prefix}sub{sp_idx}_")
+
     for ax_key, ax_data in data.get("axes", {}).items():
         panel_prefix = _panel_prefix(ax_key, nrows, ncols)
-        for call_list in [ax_data.get("calls", []), ax_data.get("decorations", [])]:
-            for call in call_list:
-                call_id = call.get("id", "unknown")
-                safe_call_id = _sanitize_filename(call_id)
-                _assert_tick_call_faithful(call)
-
-                for i, arg in enumerate(call.get("args", [])):
-                    source_file_path = arg.pop("_source_file", None)
-                    arr = arg.pop("_array", None)
-                    arg.pop("_loaded_array", None)
-
-                    if source_file_path:
-                        if not data_dir_created:
-                            data_dir.mkdir(parents=True, exist_ok=True)
-                            data_dir_created = True
-
-                        source_file = Path(source_file_path)
-                        target_path = data_dir / source_file.name
-
-                        # Fail loud: composition references the REAL source data
-                        # (single source of truth); a missing source must never
-                        # produce a silently-broken recipe symlink.
-                        if not source_file.exists():
-                            raise FileNotFoundError(
-                                f"compose source data file missing: {source_file} "
-                                f"(call {call_id}). Cannot create a valid data "
-                                f"symlink for the composed recipe."
-                            )
-                        # Refresh: drop any stale/broken link left by a prior run
-                        # so the symlink always points at the CURRENT source, never
-                        # a renamed/moved phantom.
-                        if target_path.is_symlink() or target_path.exists():
-                            target_path.unlink()
-                        rel_source = os.path.relpath(source_file, target_path.parent)
-                        os.symlink(rel_source, target_path)
-
-                        arg["data"] = str(target_path.relative_to(data_dir.parent))
-
-                    elif arr is not None:
-                        if not data_dir_created:
-                            data_dir.mkdir(parents=True, exist_ok=True)
-                            data_dir_created = True
-
-                        var_name = arg.get("name", f"arg{i}")
-                        filename = f"{panel_prefix}{safe_call_id}_{var_name}"
-                        file_path = save_array(arr, data_dir / filename, data_format)
-                        arg["data"] = str(file_path.relative_to(data_dir.parent))
+        _process_ax_data(ax_data, panel_prefix, "")
 
     return data
 

--- a/tests/integration/test_embed_subpanel_data_filing.py
+++ b/tests/integration/test_embed_subpanel_data_filing.py
@@ -145,8 +145,10 @@ def test_small_embedded_array_stays_inline_and_validates():
         host_fig, host_ax = fr.subplots(axes_width_mm=80, axes_height_mm=60)
         host_ax.plot([0, 1, 2, 3], [3, 2, 1, 0])
         host_ax.embed(str(source_recipe), bounds=[0.55, 0.55, 0.4, 0.4])
-        # Act / Assert: validate=True raises on a reproducibility mismatch.
+        # Act
         fr.save(host_fig, str(tmp_dir / "small_host.png"), validate=True)
+        # Assert: no "not-reproduced" divergence artifact was written.
+        assert list(tmp_dir.glob("*not-reproduced*")) == []
 
 
 def test_embedded_recipe_round_trips_via_reproduce():

--- a/tests/integration/test_embed_subpanel_data_filing.py
+++ b/tests/integration/test_embed_subpanel_data_filing.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression: embedded/subpanel array data must be FILED, not left inline.
+
+Root cause (residual trigger of the flaky imshow nested/compose-of-composed
+round-trip, filed on scitex-todo as
+``figrecipe-flaky-imshow-nested-roundtrip-datafile``): ``ax.embed(recipe)``
+draws the source recipe's calls into a managed inset and attaches the
+source's ALREADY-LOADED ``CallRecord`` objects to the host's
+``subpanel_recorders`` (``_wrappers/_axes_embed.py::_draw_and_record_source``).
+``load_recipe()`` fully materializes a data-file-backed arg as a plain Python
+list (``arg["data"] = arr.tolist()``, plus ``_loaded_array``/``_source_file``)
+so the source recipe can be replayed without a data directory of its own at
+draw time.
+
+The HOST save pipeline (``_serializer/_save.py``) only ever walked each
+top-level axes' ``calls``/``decorations`` -- never the nested ``subpanels``
+list that ``ax.embed()``/``ax.inset_axes()`` produce (see
+``_recorder/_core.py::AxesRecord.to_dict()``). So an embedded source's
+data-file-backed args were NEVER re-filed to a fresh CSV/NPZ on the host's
+own save: they stayed inline, as the FULL nested Python list the loader
+reconstructed, forever. For a small toy line this is invisible (a handful of
+inline floats); for anything with real array volume (e.g. an ``imshow``
+image) it turns ``_convert_numpy_types`` + ``ruamel.yaml.dump`` into an
+O(N) walk over hundreds of thousands to millions of individual scalar nodes
+-- pathologically slow (multi-minute, effectively a hang for practical CI
+timeouts). This exactly reproduces the "flaky imshow nested round-trip" CI
+symptom locally as a deterministic hang (confirmed via
+``faulthandler.dump_traceback_later``, stuck inside
+``ruamel.yaml.representer`` / ``_convert_numpy_types`` on the host's own
+``fig.save_recipe()`` call, well before any validate/reproduce step runs).
+
+Fix: ``_process_arrays_for_save`` / ``_process_arrays_with_symlinks`` now
+recurse into ``subpanels`` (nested sub-sub-panels too), and for each arg
+either write out a live ``_array`` (as before) or, when the arg only carries
+a ``_source_file`` (the embed/loaded case), SYMLINK to that original backing
+file -- the same treatment ``fr.compose()`` already gives composed panels,
+extended to plain ``ax.embed()`` (which never set
+``record.source_data_dirs`` and so never reached the symlink path at all).
+The loader (``_serializer/_load.py::_resolve_data_references``) recurses into
+``subpanels`` the same way, so a filed/symlinked subpanel reference resolves
+back into real array data on load instead of leaving a raw filename string
+as the "data" value.
+
+AAA layout, ONE assertion focus per test, no mocks, headless Agg.
+"""
+
+import tempfile
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np  # noqa: E402
+from ruamel.yaml import YAML  # noqa: E402
+
+import figrecipe as fr  # noqa: E402
+
+_yaml = YAML()
+
+
+def _build_source_with_large_image(sdir: Path) -> Path:
+    """Save a standalone imshow recipe with a sizeable (100x100) image."""
+    rng = np.random.default_rng(0)
+    fig, ax = fr.subplots(1, 1)
+    ax.imshow(rng.uniform(0, 1, (100, 100)), id="big_image")
+    recipe = sdir / "source.yaml"
+    fr.save(fig, str(sdir / "source.png"), verbose=False)
+    return recipe
+
+
+def _load_raw_yaml(path: Path) -> dict:
+    with open(path) as f:
+        return _yaml.load(f)
+
+
+def _find_subpanel_arg(data: dict, call_id: str, arg_name: str) -> dict:
+    """Dig into ``axes -> subpanels -> axes -> calls`` for one arg dict."""
+    for ax_data in data.get("axes", {}).values():
+        for sp in ax_data.get("subpanels", []) or []:
+            for call in sp.get("axes", {}).get("calls", []) or []:
+                if call.get("id") == call_id:
+                    for arg in call.get("args", []):
+                        if arg.get("name") == arg_name:
+                            return arg
+    raise AssertionError(f"subpanel call {call_id!r} arg {arg_name!r} not found")
+
+
+def test_embedded_large_array_is_filed_not_inlined():
+    # Arrange: a host figure embedding a source recipe with a 100x100 image.
+    with tempfile.TemporaryDirectory() as d:
+        tmp_dir = Path(d)
+        sdir = tmp_dir / "sources"
+        sdir.mkdir()
+        source_recipe = _build_source_with_large_image(sdir)
+        host_fig, host_ax = fr.subplots(1, 1)
+        host_ax.plot([0, 1, 2], [0, 1, 0], id="host_line")
+        host_ax.embed(str(source_recipe), bounds=[0.5, 0.5, 0.4, 0.4])
+        host_yaml = tmp_dir / "host.yaml"
+        fr.save(host_fig, str(tmp_dir / "host.png"), verbose=False)
+        # Act
+        raw = _load_raw_yaml(host_yaml)
+        arg = _find_subpanel_arg(raw, "big_image", "X")
+        # Assert: filed as a real data-file reference, not an inline list.
+        assert isinstance(arg.get("data"), str) and arg["data"].endswith(
+            (".csv", ".npz", ".npy")
+        )
+
+
+def test_embedded_large_array_file_reference_exists_on_disk():
+    # Arrange: same embed scenario as above.
+    with tempfile.TemporaryDirectory() as d:
+        tmp_dir = Path(d)
+        sdir = tmp_dir / "sources"
+        sdir.mkdir()
+        source_recipe = _build_source_with_large_image(sdir)
+        host_fig, host_ax = fr.subplots(1, 1)
+        host_ax.plot([0, 1, 2], [0, 1, 0], id="host_line")
+        host_ax.embed(str(source_recipe), bounds=[0.5, 0.5, 0.4, 0.4])
+        host_yaml = tmp_dir / "host.yaml"
+        fr.save(host_fig, str(tmp_dir / "host.png"), verbose=False)
+        raw = _load_raw_yaml(host_yaml)
+        arg = _find_subpanel_arg(raw, "big_image", "X")
+        # Act
+        file_path = host_yaml.parent / arg["data"]
+        # Assert
+        assert file_path.exists()
+
+
+def test_small_embedded_array_stays_inline_and_validates():
+    # Arrange: a host embedding a TINY (below-threshold) source line plot --
+    # regression guard for a real bug this exact fix introduced: filing/
+    # symlinking every subpanel array (regardless of size) broke the inset/
+    # embed replay path (_reproducer/_replay_insets.py resolves a subpanel
+    # arg's data straight from the recipe dict, not through the file-
+    # reference resolver), causing a save-time reproducibility-validation
+    # failure (MSE far over threshold) for the common small-embed case.
+    with tempfile.TemporaryDirectory() as d:
+        tmp_dir = Path(d)
+        src_fig, src_ax = fr.subplots(axes_width_mm=60, axes_height_mm=40)
+        src_ax.plot([0, 1, 2], [0, 2, 1])
+        source_recipe = tmp_dir / "small_source.yaml"
+        fr.save(src_fig, str(tmp_dir / "small_source.png"), verbose=False)
+        host_fig, host_ax = fr.subplots(axes_width_mm=80, axes_height_mm=60)
+        host_ax.plot([0, 1, 2, 3], [3, 2, 1, 0])
+        host_ax.embed(str(source_recipe), bounds=[0.55, 0.55, 0.4, 0.4])
+        # Act / Assert: validate=True raises on a reproducibility mismatch.
+        fr.save(host_fig, str(tmp_dir / "small_host.png"), validate=True)
+
+
+def test_embedded_recipe_round_trips_via_reproduce():
+    # Arrange: save a host embedding a large-array source recipe.
+    with tempfile.TemporaryDirectory() as d:
+        tmp_dir = Path(d)
+        sdir = tmp_dir / "sources"
+        sdir.mkdir()
+        source_recipe = _build_source_with_large_image(sdir)
+        host_fig, host_ax = fr.subplots(1, 1)
+        host_ax.plot([0, 1, 2], [0, 1, 0], id="host_line")
+        host_ax.embed(str(source_recipe), bounds=[0.5, 0.5, 0.4, 0.4])
+        host_yaml = tmp_dir / "host.yaml"
+        fr.save(host_fig, str(tmp_dir / "host.png"), verbose=False)
+        # Act: reproduce from the saved recipe (fresh load from disk).
+        reproduced_fig, _ = fr.reproduce(str(host_yaml))
+        # Assert: reproduces without raising (e.g. no FileNotFoundError on a
+        # missing/broken subpanel data reference).
+        assert reproduced_fig is not None


### PR DESCRIPTION
## Summary
- Root-causes the flaky imshow nested/composed round-trip test: embedded (`ax.embed()`/`ax.inset_axes()`) large array data was never re-filed to CSV/NPZ, staying inline forever and turning every save into a pathologically slow YAML dump — a multi-minute deterministic hang that CI's per-job timeout intermittently killed, misread as "flaky."
- Both save-side serializer functions now recurse into `subpanels`; the loader resolves the same nested file references back into real array data.
- Re-filing only applies above a size floor (256 elements): the reproducer's inset/embed replay path resolves a sub-panel's data straight from the recipe dict rather than through the file-reference loader, so filing every sub-panel array regardless of size broke the ordinary small-embed case. Caught this as a real regression (confirmed failing only on this branch, passing on unmodified `develop`) via a new test before shipping, then added the size-floor guard.

## Test plan
- [x] New regression suite `tests/integration/test_embed_subpanel_data_filing.py` (4 tests, including the small-embed guard) — all pass
- [x] Full `tests/integration/test_embed_reproduction.py` — all pass
- [x] Full 59-test embed/imshow subset of `test_all_plotters_nested_roundtrip.py` (all plotter variants of `single_embed`, plus `compose_of_composed[imshow]`) — all pass
- [x] Confirmed the regression is real: same failing test passes on unmodified `develop`, fails on this branch pre-size-floor-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)