### PR TITLE
fix(tests): guard coverage import behind COVERAGE_PROCESS_START in subprocess .pth shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.25] - 2026-07-11
+
+### Fixed
+- **Subprocess-coverage `.pth` shim crashed every CLI invocation in venvs without
+  `coverage` installed.** `tests/conftest.py::_ensure_subprocess_coverage_shim()`
+  writes a `.pth` file that starts coverage tracing in child interpreters. Its
+  template had `import os, coverage` at the top level, executed unconditionally
+  by `site.py` on *every* interpreter start in that venv — not just test runs.
+  Any plain command (e.g. `figrecipe --help`) in a venv where `coverage` wasn't
+  installed raised `ModuleNotFoundError` on every invocation, once a prior
+  `pytest` run had dropped the shim into site-packages. `coverage` is now
+  imported only inside the `COVERAGE_PROCESS_START` conditional. Regression
+  test: `tests/integration/test_subprocess_coverage_shim_guard.py`.
+
 ## [0.29.24] - 2026-07-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.26] - 2026-07-11
+
+### Fixed
+- **Audit conformance for the 0.29.25 coverage-shim regression test.** The
+  new `tests/integration/test_subprocess_coverage_shim_guard.py` used the
+  `monkeypatch` fixture (forbidden as a mock by PA-306) and had a test
+  with no explicit assertion / AAA markers, tripping PA-306/STX-TQ001/
+  STX-TQ002 (3.11+ CI) and blocking the 0.29.25 release from publishing.
+  Rewritten to avoid mocking entirely: the "coverage not installed"
+  condition is now a REAL environment (a subprocess launched with `-S`,
+  which skips `site` initialization so no site-packages end up on
+  `sys.path`), not a monkeypatched import. (0.29.25's coverage-pth fix
+  is included here — 0.29.25 never published.)
+
 ## [0.29.25] - 2026-07-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.24"
+version = "0.29.25"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.29.25"
+version = "0.29.26"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,9 +43,15 @@ def _ensure_subprocess_coverage_shim() -> None:
     """
     purelib = Path(sysconfig.get_paths()["purelib"])
     pth = purelib / "_figrecipe_subprocess_coverage.pth"
+    # `coverage` is imported ONLY inside the conditional: this .pth line runs
+    # on every interpreter start in the venv (not just test runs), and an
+    # unconditional top-level `import coverage` breaks any invocation where
+    # coverage isn't installed (e.g. `figrecipe --help` in a plain user venv)
+    # with a ModuleNotFoundError printed by site.py on every single command.
     shim = (
-        "import os, coverage\n"
+        "import os\n"
         "if os.environ.get('COVERAGE_PROCESS_START'):\n"
+        "    import coverage\n"
         "    coverage.process_startup()\n"
     )
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,12 +36,18 @@ os.environ["COVERAGE_PROCESS_START"] = str(_PROJECT_ROOT / "pyproject.toml")
 os.environ["COVERAGE_FILE"] = str(_PROJECT_ROOT / ".coverage")
 
 
-def _ensure_subprocess_coverage_shim() -> None:
+def _ensure_subprocess_coverage_shim(purelib: Path | None = None) -> Path | None:
     """Drop an idempotent `.pth` file in site-packages that auto-starts
     coverage in every child Python interpreter via
     `coverage.process_startup()`.
+
+    `purelib` is overridable (tests pass a writable `tmp_path`) because the
+    real venv site-packages is read-only in some CI environments (e.g. a
+    layered/squashfs SIF image) — asserting against that path directly is
+    not hermetic. Returns the `.pth` path written, or None if the write was
+    skipped (read-only site-packages).
     """
-    purelib = Path(sysconfig.get_paths()["purelib"])
+    purelib = purelib if purelib is not None else Path(sysconfig.get_paths()["purelib"])
     pth = purelib / "_figrecipe_subprocess_coverage.pth"
     # `coverage` is imported ONLY inside the conditional: this .pth line runs
     # on every interpreter start in the venv (not just test runs), and an
@@ -58,9 +64,11 @@ def _ensure_subprocess_coverage_shim() -> None:
         if not pth.exists() or pth.read_text() != shim:
             pth.write_text(shim)
     except OSError:
-        # site-packages may be read-only (e.g. system Python); silently
-        # skip — local dev venvs are writable and that's where this matters.
-        pass
+        # site-packages may be read-only (e.g. system Python, or a
+        # layered/squashfs CI image); silently skip — local dev venvs are
+        # writable and that's where this matters.
+        return None
+    return pth
 
 
 _ensure_subprocess_coverage_shim()

--- a/tests/integration/test_subprocess_coverage_shim_guard.py
+++ b/tests/integration/test_subprocess_coverage_shim_guard.py
@@ -6,49 +6,50 @@ before the conditional, so a venv without ``coverage`` installed raised
 ``ModuleNotFoundError`` on every single interpreter start (not just test
 runs) -- surfaced by a user running plain CLI commands like
 ``figrecipe --help`` in a fresh dev venv.
+
+No mocks: the "coverage not installed" condition is a REAL environment
+(a subprocess launched with `-S`, which skips `site` initialization so no
+site-packages -- including wherever `coverage` lives -- end up on
+`sys.path`), not a monkeypatched import.
 """
 
 from __future__ import annotations
 
-import builtins
+import os
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
 
 from tests.conftest import _ensure_subprocess_coverage_shim
 
 
-def test_shim_pth_content_guards_coverage_import_behind_env_check(
-    tmp_path, monkeypatch
-):
+def test_shim_pth_content_guards_coverage_import_behind_env_check():
     # Arrange
-    monkeypatch.setattr(
-        "tests.conftest.sysconfig.get_paths", lambda: {"purelib": str(tmp_path)}
-    )
-    monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
-
-    # Act
     _ensure_subprocess_coverage_shim()
-    pth_text = (tmp_path / "_figrecipe_subprocess_coverage.pth").read_text()
-
+    purelib = Path(sysconfig.get_paths()["purelib"])
+    pth_path = purelib / "_figrecipe_subprocess_coverage.pth"
+    # Act
+    pth_text = pth_path.read_text()
     # Assert
     assert pth_text.index("import coverage") > pth_text.index("if os.environ.get(")
 
 
-def test_shim_does_not_import_coverage_when_env_var_unset(tmp_path, monkeypatch):
+def test_shim_does_not_import_coverage_when_env_var_unset():
     # Arrange
-    monkeypatch.setattr(
-        "tests.conftest.sysconfig.get_paths", lambda: {"purelib": str(tmp_path)}
-    )
-    monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
     _ensure_subprocess_coverage_shim()
-    pth_text = (tmp_path / "_figrecipe_subprocess_coverage.pth").read_text()
-
-    real_import = builtins.__import__
-
-    def _blocking_import(name, *args, **kwargs):
-        if name == "coverage":
-            raise ModuleNotFoundError("simulated: coverage not installed")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", _blocking_import)
-
-    # Act / Assert (must not raise, since COVERAGE_PROCESS_START is unset)
-    exec(compile(pth_text, "_figrecipe_subprocess_coverage.pth", "exec"), {})
+    purelib = Path(sysconfig.get_paths()["purelib"])
+    pth_text = (purelib / "_figrecipe_subprocess_coverage.pth").read_text()
+    env = dict(os.environ)
+    env.pop("COVERAGE_PROCESS_START", None)
+    # Act: -S skips site-packages entirely, so `coverage` is genuinely
+    # unimportable here -- a real "not installed" condition.
+    result = subprocess.run(
+        [sys.executable, "-S", "-c", pth_text],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    # Assert
+    assert result.returncode == 0, result.stderr

--- a/tests/integration/test_subprocess_coverage_shim_guard.py
+++ b/tests/integration/test_subprocess_coverage_shim_guard.py
@@ -1,0 +1,54 @@
+"""Regression test for the subprocess-coverage `.pth` shim (tests/conftest.py).
+
+The shim's ``coverage`` import must be nested inside the
+``COVERAGE_PROCESS_START`` conditional. It previously sat at module level
+before the conditional, so a venv without ``coverage`` installed raised
+``ModuleNotFoundError`` on every single interpreter start (not just test
+runs) -- surfaced by a user running plain CLI commands like
+``figrecipe --help`` in a fresh dev venv.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+from tests.conftest import _ensure_subprocess_coverage_shim
+
+
+def test_shim_pth_content_guards_coverage_import_behind_env_check(
+    tmp_path, monkeypatch
+):
+    # Arrange
+    monkeypatch.setattr(
+        "tests.conftest.sysconfig.get_paths", lambda: {"purelib": str(tmp_path)}
+    )
+    monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
+
+    # Act
+    _ensure_subprocess_coverage_shim()
+    pth_text = (tmp_path / "_figrecipe_subprocess_coverage.pth").read_text()
+
+    # Assert
+    assert pth_text.index("import coverage") > pth_text.index("if os.environ.get(")
+
+
+def test_shim_does_not_import_coverage_when_env_var_unset(tmp_path, monkeypatch):
+    # Arrange
+    monkeypatch.setattr(
+        "tests.conftest.sysconfig.get_paths", lambda: {"purelib": str(tmp_path)}
+    )
+    monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
+    _ensure_subprocess_coverage_shim()
+    pth_text = (tmp_path / "_figrecipe_subprocess_coverage.pth").read_text()
+
+    real_import = builtins.__import__
+
+    def _blocking_import(name, *args, **kwargs):
+        if name == "coverage":
+            raise ModuleNotFoundError("simulated: coverage not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_import)
+
+    # Act / Assert (must not raise, since COVERAGE_PROCESS_START is unset)
+    exec(compile(pth_text, "_figrecipe_subprocess_coverage.pth", "exec"), {})

--- a/tests/integration/test_subprocess_coverage_shim_guard.py
+++ b/tests/integration/test_subprocess_coverage_shim_guard.py
@@ -18,28 +18,25 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import sysconfig
 from pathlib import Path
 
 from tests.conftest import _ensure_subprocess_coverage_shim
 
 
-def test_shim_pth_content_guards_coverage_import_behind_env_check():
-    # Arrange
-    _ensure_subprocess_coverage_shim()
-    purelib = Path(sysconfig.get_paths()["purelib"])
-    pth_path = purelib / "_figrecipe_subprocess_coverage.pth"
+def test_shim_pth_content_guards_coverage_import_behind_env_check(tmp_path: Path):
+    # Arrange: write to a writable tmp dir, not the real site-packages --
+    # that may be read-only in CI (e.g. a layered/squashfs SIF image).
+    pth_path = _ensure_subprocess_coverage_shim(purelib=tmp_path)
     # Act
     pth_text = pth_path.read_text()
     # Assert
     assert pth_text.index("import coverage") > pth_text.index("if os.environ.get(")
 
 
-def test_shim_does_not_import_coverage_when_env_var_unset():
+def test_shim_does_not_import_coverage_when_env_var_unset(tmp_path: Path):
     # Arrange
-    _ensure_subprocess_coverage_shim()
-    purelib = Path(sysconfig.get_paths()["purelib"])
-    pth_text = (purelib / "_figrecipe_subprocess_coverage.pth").read_text()
+    pth_path = _ensure_subprocess_coverage_shim(purelib=tmp_path)
+    pth_text = pth_path.read_text()
     env = dict(os.environ)
     env.pop("COVERAGE_PROCESS_START", None)
     # Act: -S skips site-packages entirely, so `coverage` is genuinely


### PR DESCRIPTION
## Summary
- The subprocess-coverage `.pth` shim written by `tests/conftest.py::_ensure_subprocess_coverage_shim()` had `import os, coverage` at the top level, executed unconditionally by `site.py` on every interpreter start in that venv — not just test runs.
- Any plain command (e.g. `figrecipe --help`) in a venv without `coverage` installed crashed with `ModuleNotFoundError` on every single invocation, once a prior test run had left the shim in site-packages.
- Reproduced live on the operator's own dev machine, not just a container artifact.
- `coverage` is now imported only inside the `COVERAGE_PROCESS_START` conditional.

## Test plan
- [x] New regression suite `tests/integration/test_subprocess_coverage_shim_guard.py` (2 tests) — pass
- [x] Verified via `ruff check` clean
- [x] Verified via full pre-commit test hook (testmon) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)