### PR TITLE
feat(composition): auto-tiler shelf-packing over panel aspect ratios

### DIFF
--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -167,6 +167,8 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     # ._composition._layout_report (machine-readable layout introspection)
     "empty_cells": ("._composition._layout_report", "empty_cells"),
     "layout_report": ("._composition._layout_report", "layout_report"),
+    # ._composition._auto_tile (aspect-ratio bin-packing for tight tiling)
+    "auto_tile_layout": ("._composition._auto_tile", "auto_tile_layout"),
     # ._configure_mpl
     "configure_mpl": ("._configure_mpl", "configure_mpl"),
     # ._diagram
@@ -285,6 +287,7 @@ __all__ = [
     "align_smart",
     "empty_cells",
     "layout_report",
+    "auto_tile_layout",
     "gui",
     "crop",
     "info",

--- a/src/figrecipe/_composition/_auto_tile.py
+++ b/src/figrecipe/_composition/_auto_tile.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Auto-tiler: bin-pack panel ASPECT RATIOS into a tight, whitespace-free grid.
+
+Where :func:`figrecipe._composition._tile.build_tiled_sources` places panels
+whose row assignment (``layout``) is already known, :func:`auto_tile_layout`
+answers the prior question -- GIVEN only each panel's true aspect ratio (no
+source, no render), how many rows should there be and which labels go in
+which row so the resulting canvas is as tight as possible (a target height)
+or wastes as little area as possible (no target height)? Its output is a
+``layout`` row-list in the EXACT format :func:`build_tiled_sources` consumes,
+so the two functions compose directly:
+
+    layout, sizes_mm, canvas_mm = auto_tile_layout(aspects, width_mm=180)
+    # ... re-author/re-plot each panel at sizes_mm[label] ...
+    sources_mm, canvas_mm = build_tiled_sources(layout, sources, width_mm=180)
+
+This module never renders or resizes a panel itself -- it only proposes
+geometry. Panels keep their true aspect ratio by construction (a row's
+common height ``h_r`` derived once, each panel's width ``aspect_i * h_r`` --
+see :func:`figrecipe._composition._tile._row_height_mm`), so "auto-tiling"
+never means "stretch to fit": that is a hard invariant, not a best-effort one.
+"""
+
+from typing import Dict, List, Tuple
+
+from ._tile import _row_height_mm, _row_panel_widths_mm
+
+__all__ = ["auto_tile_layout"]
+
+
+def _greedy_partition(
+    labels_by_aspect_desc: List[str],
+    aspects: Dict[str, float],
+    n_rows: int,
+) -> List[List[str]]:
+    """Multi-way partition of labels into ``n_rows`` rows (LPT-greedy).
+
+    Visits labels largest-aspect-first (Longest-Processing-Time-first, the
+    standard greedy for multiway partition / multiprocessor scheduling) and
+    drops each one into whichever row currently has the SMALLEST running
+    aspect-sum. Balancing the aspect-sum (not the panel COUNT) keeps row
+    heights close to parity -- see :func:`_row_height_mm`, where a row's
+    height is inversely proportional to its aspect-sum -- so this avoids one
+    very tall/skinny row sitting next to a very short/wide one.
+
+    Ties (equal running sums) break by lowest row index, which also
+    guarantees every one of the ``n_rows <= len(labels)`` rows receives at
+    least one label (the first ``n_rows`` labels each land in a still-empty
+    row before any row's sum grows past zero).
+    """
+    rows: List[List[str]] = [[] for _ in range(n_rows)]
+    row_sums = [0.0] * n_rows
+    for label in labels_by_aspect_desc:
+        idx = min(range(n_rows), key=lambda i: (row_sums[i], i))
+        rows[idx].append(label)
+        row_sums[idx] += aspects[label]
+    return rows
+
+
+def _row_geometry(
+    rows: List[List[str]],
+    aspects: Dict[str, float],
+    width_mm: float,
+    gap_mm: float,
+) -> Tuple[Dict[str, Tuple[float, float]], float]:
+    """Apply the shared row-height formula to every row of a candidate layout.
+
+    Returns ``(sizes_mm, total_height_mm)`` using the IDENTICAL
+    ``_row_height_mm`` / ``_row_panel_widths_mm`` helpers that
+    :func:`figrecipe._composition._tile.build_tiled_sources` uses, so a
+    proposed layout's sizes never drift from what actually placing it would
+    produce.
+    """
+    sizes_mm: Dict[str, Tuple[float, float]] = {}
+    row_heights: List[float] = []
+    for row in rows:
+        row_aspects = [aspects[lab] for lab in row]
+        h_r = _row_height_mm(row_aspects, width_mm, gap_mm)
+        row_widths = _row_panel_widths_mm(row_aspects, h_r)
+        for lab, w_i in zip(row, row_widths):
+            sizes_mm[lab] = (w_i, h_r)
+        row_heights.append(h_r)
+    total_height = sum(row_heights) + (len(rows) - 1) * gap_mm
+    return sizes_mm, total_height
+
+
+def auto_tile_layout(
+    aspects: Dict[str, float],
+    width_mm: float,
+    height_mm: float = None,
+    gap_mm: float = 1.0,
+) -> Tuple[List[List[str]], Dict[str, Tuple[float, float]], Tuple[float, float]]:
+    """Bin-pack panel aspect ratios into a tight ``layout`` for ``build_tiled_sources``.
+
+    Parameters
+    ----------
+    aspects : dict
+        ``{label: w/h}`` -- each panel's TRUE aspect ratio. Never a size to
+        target; only a ratio the packer must preserve exactly.
+    width_mm : float
+        Overall content width ``W`` of the figure in mm (same role as
+        ``build_tiled_sources``'s ``width_mm``).
+    height_mm : float, optional
+        Target overall canvas height in mm. When given, the packer searches
+        row-counts and picks the one whose resulting total height is closest
+        to ``height_mm`` without exceeding it (falling back to the closest
+        overall if every candidate exceeds it). When omitted, the packer
+        instead MINIMISES wasted canvas area (the ``width_mm x total_height``
+        bounding box minus the summed true panel areas) -- the canonical
+        packing-efficiency objective.
+    gap_mm : float
+        Gutter between adjacent panels (both within a row and between rows),
+        same convention as ``build_tiled_sources``.
+
+    Returns
+    -------
+    layout : list of list of str
+        Row-list of labels, ready to hand to ``build_tiled_sources`` (or
+        ``fr.compose``) verbatim.
+    sizes_mm : dict
+        ``{label: (width_mm, height_mm)}`` -- the target size each panel
+        should be RE-AUTHORED/re-plotted at. Every panel's ``w/h`` here
+        equals ``aspects[label]`` exactly (to floating-point precision):
+        this function only ever proposes geometry, it never stretches or
+        upscales a panel.
+    canvas_size_mm : tuple
+        ``(width_mm, total_height_mm)`` of the resulting canvas.
+
+    Notes
+    -----
+    For each candidate row-count ``n_rows`` (searched over ``1..len(aspects)``)
+    labels are greedily partitioned by :func:`_greedy_partition` (largest
+    aspect first, into whichever row has the smallest running aspect-sum --
+    this keeps row heights close to parity). Each row is then sized by the
+    SAME formula ``build_tiled_sources`` uses (see
+    ``figrecipe._composition._tile._row_height_mm``): row height ``h_r =
+    (width_mm - (k-1) * gap_mm) / sum(row aspects)``, panel width ``w_i =
+    aspect_i * h_r``. Row order (top-to-bottom) and each row's internal label
+    order follow assignment order and are never reshuffled afterwards.
+    """
+    if not aspects:
+        raise ValueError("auto_tile_layout requires at least one panel in `aspects`.")
+
+    labels = list(aspects.keys())
+    n = len(labels)
+    labels_by_aspect_desc = sorted(labels, key=lambda lab: aspects[lab], reverse=True)
+
+    candidates: List[Tuple[List[List[str]], Dict[str, Tuple[float, float]], float]] = []
+    for n_rows in range(1, n + 1):
+        rows = _greedy_partition(labels_by_aspect_desc, aspects, n_rows)
+        sizes_mm, total_height = _row_geometry(rows, aspects, width_mm, gap_mm)
+        candidates.append((rows, sizes_mm, total_height))
+
+    if height_mm is not None:
+        # Closest-without-exceeding when possible, else closest overall.
+        fitting = [c for c in candidates if c[2] <= height_mm + 1e-9]
+        best = (
+            max(fitting, key=lambda c: c[2])
+            if fitting
+            else min(candidates, key=lambda c: abs(c[2] - height_mm))
+        )
+    else:
+
+        def _wasted_area(
+            candidate: Tuple[List[List[str]], Dict[str, Tuple[float, float]], float],
+        ) -> float:
+            _rows, sizes_mm, total_height = candidate
+            occupied = sum(w * h for w, h in sizes_mm.values())
+            return width_mm * total_height - occupied
+
+        best = min(candidates, key=_wasted_area)
+
+    rows, sizes_mm, total_height = best
+    return rows, sizes_mm, (float(width_mm), float(total_height))
+
+
+# EOF

--- a/src/figrecipe/_composition/_tile.py
+++ b/src/figrecipe/_composition/_tile.py
@@ -222,6 +222,33 @@ def _png_aspect(path):
     return size[0] / size[1]
 
 
+def _row_height_mm(aspects: List[float], width_mm: float, gap_mm: float) -> float:
+    """Return the ONE common row height (mm) for panels of ``aspects`` in a row.
+
+    This is the single formula shared by :func:`build_tiled_sources` (which
+    resolves aspects from real ``sources``) and the auto-tiler (which packs
+    raw aspect ratios before any source exists) -- factored out here so both
+    callers compute row geometry identically (no drift between the two).
+
+    ``h_r = (width_mm - (k-1) * gap_mm) / sum(aspects)`` where ``k =
+    len(aspects)``; each panel's width is then ``aspect_i * h_r`` (never
+    stretched -- see :func:`_row_panel_widths_mm`).
+    """
+    k = len(aspects)
+    avail = width_mm - (k - 1) * gap_mm
+    sum_aspect = sum(aspects)
+    return avail / sum_aspect if sum_aspect else avail
+
+
+def _row_panel_widths_mm(aspects: List[float], row_height_mm: float) -> List[float]:
+    """Return each panel's true width (mm) at the row's common height.
+
+    ``width_i = aspect_i * row_height_mm`` -- the panel is drawn at its own
+    aspect ratio, never stretched to fill leftover space.
+    """
+    return [a * row_height_mm for a in aspects]
+
+
 def build_tiled_sources(
     layout: Union[str, List[List[str]]],
     sources: Dict[str, Any],
@@ -305,16 +332,13 @@ def build_tiled_sources(
     y = 0.0
     row_heights: List[float] = []
     for r, row in enumerate(rows):
-        k = len(row)
-        sum_aspect = sum(aspect_of[lab] for lab in row)
-        # Width available for actual panel ink (gaps removed).
-        avail = W - (k - 1) * gap_mm
-        h_r = avail / sum_aspect if sum_aspect else avail
+        row_aspects = [aspect_of[lab] for lab in row]
+        h_r = _row_height_mm(row_aspects, W, gap_mm)
+        row_widths = _row_panel_widths_mm(row_aspects, h_r)
         row_heights.append(h_r)
 
         x = 0.0
-        for lab in row:
-            w_i = aspect_of[lab] * h_r
+        for lab, w_i in zip(row, row_widths):
             sources_mm[sources[lab]] = {
                 "xy_mm": (x, y),
                 "size_mm": (w_i, h_r),
@@ -326,6 +350,11 @@ def build_tiled_sources(
     return sources_mm, (W, total_height)
 
 
-__all__ = ["build_tiled_sources", "_is_tiled_layout"]
+__all__ = [
+    "build_tiled_sources",
+    "_is_tiled_layout",
+    "_row_height_mm",
+    "_row_panel_widths_mm",
+]
 
 # EOF

--- a/tests/figrecipe/_composition/test__auto_tile.py
+++ b/tests/figrecipe/_composition/test__auto_tile.py
@@ -34,17 +34,31 @@ def _make_panel(tmp_path, name, figsize):
 class TestAutoTileWidthOnly:
     """width_mm only (no height_mm): a valid row-list covering every label once."""
 
+    def test_layout_is_a_list_of_lists(self):
+        # Arrange: four panels with mixed aspect ratios.
+        aspects = {"A": 3.0 / 2.0, "B": 1.0, "C": 2.0 / 3.0, "D": 5.0 / 2.0}
+        # Act
+        layout, _sizes_mm, _canvas = auto_tile_layout(aspects, width_mm=180)
+        # Assert: row-list format.
+        assert isinstance(layout, list) and all(isinstance(row, list) for row in layout)
+
     def test_layout_covers_every_label_exactly_once(self):
         # Arrange: four panels with mixed aspect ratios.
         aspects = {"A": 3.0 / 2.0, "B": 1.0, "C": 2.0 / 3.0, "D": 5.0 / 2.0}
         # Act
-        layout, sizes_mm, _canvas = auto_tile_layout(aspects, width_mm=180)
-        # Assert: row-list format, every label placed exactly once.
-        assert isinstance(layout, list)
-        assert all(isinstance(row, list) for row in layout)
+        layout, _sizes_mm, _canvas = auto_tile_layout(aspects, width_mm=180)
         placed = [lab for row in layout for lab in row]
-        assert sorted(placed) == sorted(aspects.keys())
-        assert len(placed) == len(set(placed))
+        # Assert: every label placed exactly once, no duplicates.
+        assert sorted(placed) == sorted(aspects.keys()) and len(placed) == len(
+            set(placed)
+        )
+
+    def test_sizes_mm_covers_every_label(self):
+        # Arrange: four panels with mixed aspect ratios.
+        aspects = {"A": 3.0 / 2.0, "B": 1.0, "C": 2.0 / 3.0, "D": 5.0 / 2.0}
+        # Act
+        _layout, sizes_mm, _canvas = auto_tile_layout(aspects, width_mm=180)
+        # Assert
         assert set(sizes_mm.keys()) == set(aspects.keys())
 
     def test_panel_aspect_ratio_is_preserved_not_stretched(self):
@@ -85,15 +99,37 @@ class TestAutoTileWithHeightTarget:
 class TestAutoTileSinglePanel:
     """N=1 degenerate case: one row, full width, height derived from aspect."""
 
-    def test_single_panel_fills_width(self):
+    def test_single_panel_is_one_row(self):
         # Arrange
         aspect = 4.0 / 3.0
         width_mm = 100.0
         # Act
-        layout, sizes_mm, canvas_mm = auto_tile_layout({"A": aspect}, width_mm=width_mm)
+        layout, _sizes_mm, _canvas_mm = auto_tile_layout(
+            {"A": aspect}, width_mm=width_mm
+        )
         # Assert
         assert layout == [["A"]]
+
+    def test_single_panel_size_fills_width_at_true_aspect(self):
+        # Arrange
+        aspect = 4.0 / 3.0
+        width_mm = 100.0
+        # Act
+        _layout, sizes_mm, _canvas_mm = auto_tile_layout(
+            {"A": aspect}, width_mm=width_mm
+        )
+        # Assert
         assert sizes_mm["A"] == pytest.approx((width_mm, width_mm / aspect))
+
+    def test_single_panel_canvas_matches_panel_size(self):
+        # Arrange
+        aspect = 4.0 / 3.0
+        width_mm = 100.0
+        # Act
+        _layout, _sizes_mm, canvas_mm = auto_tile_layout(
+            {"A": aspect}, width_mm=width_mm
+        )
+        # Assert
         assert canvas_mm == pytest.approx((width_mm, width_mm / aspect))
 
 
@@ -106,13 +142,17 @@ class TestAutoTileMatchesBuildTiledSources:
     row-height formula rather than two independently drifting ones.
     """
 
-    def test_sizes_match_real_build_tiled_sources(self, tmp_path):
-        # Arrange: real saved panels. `_source_aspect` (the same resolver
-        # `build_tiled_sources` uses) prefers the tight cropped
-        # `content_size_mm` over raw `figsize`, so its aspect is not exactly
-        # the figsize ratio passed to `_make_panel` -- resolve it from the
-        # real saved source (no mocks) so `aspects` is apples-to-apples with
-        # what `build_tiled_sources` will actually use internally.
+    @pytest.fixture
+    def _dry_check_fixtures(self, tmp_path):
+        """Real saved panels + the auto-tiler's proposal + the real placement.
+
+        `_source_aspect` (the same resolver `build_tiled_sources` uses)
+        prefers the tight cropped `content_size_mm` over raw `figsize`, so
+        its aspect is not exactly the figsize ratio passed to `_make_panel`
+        -- resolve it from the real saved source (no mocks) so `aspects` is
+        apples-to-apples with what `build_tiled_sources` will actually use
+        internally.
+        """
         panels = {
             "A": _make_panel(tmp_path, "A", (3, 2)),
             "B": _make_panel(tmp_path, "B", (2, 2)),
@@ -122,19 +162,30 @@ class TestAutoTileMatchesBuildTiledSources:
         aspects = {label: _source_aspect(spec) for label, spec in panels.items()}
         width_mm = 180.0
         gap_mm = 1.0
-        # Act
         layout, sizes_mm, canvas_mm = auto_tile_layout(
             aspects, width_mm=width_mm, gap_mm=gap_mm
         )
         sources_mm, real_canvas_mm = build_tiled_sources(
             layout, panels, width_mm=width_mm, gap_mm=gap_mm
         )
-        # Assert: same canvas size and same per-panel size_mm (same formula).
+        return panels, sizes_mm, canvas_mm, sources_mm, real_canvas_mm
+
+    def test_canvas_size_matches_real_build_tiled_sources(self, _dry_check_fixtures):
+        # Arrange
+        _panels, _sizes_mm, canvas_mm, _sources_mm, real_canvas_mm = _dry_check_fixtures
+        # Act
+        # (auto_tile_layout + build_tiled_sources already run in the fixture)
+        # Assert: same canvas size (same shared row-height formula).
         assert real_canvas_mm == pytest.approx(canvas_mm)
-        for label in aspects:
-            assert sources_mm[panels[label]]["size_mm"] == pytest.approx(
-                sizes_mm[label]
-            )
+
+    def test_per_panel_sizes_match_real_build_tiled_sources(self, _dry_check_fixtures):
+        # Arrange
+        panels, sizes_mm, _canvas_mm, sources_mm, _real_canvas_mm = _dry_check_fixtures
+        # Act
+        real_sizes = [sources_mm[panels[label]]["size_mm"] for label in sizes_mm]
+        proposed_sizes = [sizes_mm[label] for label in sizes_mm]
+        # Assert: same per-panel size_mm (same formula, no drift).
+        assert real_sizes == pytest.approx(proposed_sizes)
 
 
 class TestAutoTileValidation:

--- a/tests/figrecipe/_composition/test__auto_tile.py
+++ b/tests/figrecipe/_composition/test__auto_tile.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the auto-tiler (aspect-ratio bin-packing for tight tiling).
+
+``auto_tile_layout(aspects, width_mm, height_mm=None, gap_mm=1.0)`` decides
+how many rows to use and which labels go in which row, then sizes every
+panel with the SAME row-height formula ``build_tiled_sources`` uses -- it
+never stretches a panel, it only proposes a ``layout`` + ``sizes_mm`` that
+panels should be RE-AUTHORED at.
+"""
+
+import matplotlib
+import pytest
+
+matplotlib.use("Agg")
+
+import figrecipe as fr
+from figrecipe._composition._auto_tile import auto_tile_layout
+from figrecipe._composition._tile import _source_aspect, build_tiled_sources
+
+# Tolerance for floating-point aspect-ratio comparisons.
+TOL = 1e-6
+
+
+def _make_panel(tmp_path, name, figsize):
+    """Save a single-panel recipe with a distinct aspect ratio (no mocks)."""
+    fig, ax = fr.subplots(figsize=figsize)
+    ax.plot([1, 2, 3], [1, 4, 9], id=name)
+    path = tmp_path / f"{name}.yaml"
+    fr.save(fig, path, validate=False, verbose=False)
+    return path
+
+
+class TestAutoTileWidthOnly:
+    """width_mm only (no height_mm): a valid row-list covering every label once."""
+
+    def test_layout_covers_every_label_exactly_once(self):
+        # Arrange: four panels with mixed aspect ratios.
+        aspects = {"A": 3.0 / 2.0, "B": 1.0, "C": 2.0 / 3.0, "D": 5.0 / 2.0}
+        # Act
+        layout, sizes_mm, _canvas = auto_tile_layout(aspects, width_mm=180)
+        # Assert: row-list format, every label placed exactly once.
+        assert isinstance(layout, list)
+        assert all(isinstance(row, list) for row in layout)
+        placed = [lab for row in layout for lab in row]
+        assert sorted(placed) == sorted(aspects.keys())
+        assert len(placed) == len(set(placed))
+        assert set(sizes_mm.keys()) == set(aspects.keys())
+
+    def test_panel_aspect_ratio_is_preserved_not_stretched(self):
+        # Arrange
+        aspects = {"A": 3.0 / 2.0, "B": 1.0, "C": 2.0 / 3.0, "D": 5.0 / 2.0}
+        # Act
+        _layout, sizes_mm, _canvas = auto_tile_layout(aspects, width_mm=180)
+        # Assert: w/h in sizes_mm matches the input aspect exactly (no stretch).
+        for label, (w_mm, h_mm) in sizes_mm.items():
+            assert abs((w_mm / h_mm) - aspects[label]) < TOL
+
+
+class TestAutoTileWithHeightTarget:
+    """height_mm given: packer searches row-counts to approach the target height."""
+
+    def test_total_height_close_to_requested(self):
+        # Arrange: six panels, ask for a specific canvas height.
+        aspects = {
+            "A": 3.0 / 2.0,
+            "B": 1.0,
+            "C": 2.0 / 3.0,
+            "D": 5.0 / 2.0,
+            "E": 1.5,
+            "F": 0.8,
+        }
+        target_height_mm = 120.0
+        # Act
+        _layout, _sizes_mm, (_w, total_height_mm) = auto_tile_layout(
+            aspects, width_mm=180, height_mm=target_height_mm
+        )
+        # Assert: row-count is a DISCRETE search (1..N rows), so exact match is
+        # not expected -- 25% of the target is a generous but meaningful bound
+        # that still catches a badly-packed (e.g. all-one-row or all-N-rows)
+        # regression.
+        assert abs(total_height_mm - target_height_mm) < 0.25 * target_height_mm
+
+
+class TestAutoTileSinglePanel:
+    """N=1 degenerate case: one row, full width, height derived from aspect."""
+
+    def test_single_panel_fills_width(self):
+        # Arrange
+        aspect = 4.0 / 3.0
+        width_mm = 100.0
+        # Act
+        layout, sizes_mm, canvas_mm = auto_tile_layout({"A": aspect}, width_mm=width_mm)
+        # Assert
+        assert layout == [["A"]]
+        assert sizes_mm["A"] == pytest.approx((width_mm, width_mm / aspect))
+        assert canvas_mm == pytest.approx((width_mm, width_mm / aspect))
+
+
+class TestAutoTileMatchesBuildTiledSources:
+    """DRY-verification: auto_tile_layout's sizes match build_tiled_sources's.
+
+    Feeds the auto-tiler's proposed ``layout`` into the REAL
+    ``build_tiled_sources`` (real saved panels, no mocks) and checks the
+    resulting geometry is IDENTICAL -- proving both call the same shared
+    row-height formula rather than two independently drifting ones.
+    """
+
+    def test_sizes_match_real_build_tiled_sources(self, tmp_path):
+        # Arrange: real saved panels. `_source_aspect` (the same resolver
+        # `build_tiled_sources` uses) prefers the tight cropped
+        # `content_size_mm` over raw `figsize`, so its aspect is not exactly
+        # the figsize ratio passed to `_make_panel` -- resolve it from the
+        # real saved source (no mocks) so `aspects` is apples-to-apples with
+        # what `build_tiled_sources` will actually use internally.
+        panels = {
+            "A": _make_panel(tmp_path, "A", (3, 2)),
+            "B": _make_panel(tmp_path, "B", (2, 2)),
+            "C": _make_panel(tmp_path, "C", (2, 3)),
+            "D": _make_panel(tmp_path, "D", (5, 2)),
+        }
+        aspects = {label: _source_aspect(spec) for label, spec in panels.items()}
+        width_mm = 180.0
+        gap_mm = 1.0
+        # Act
+        layout, sizes_mm, canvas_mm = auto_tile_layout(
+            aspects, width_mm=width_mm, gap_mm=gap_mm
+        )
+        sources_mm, real_canvas_mm = build_tiled_sources(
+            layout, panels, width_mm=width_mm, gap_mm=gap_mm
+        )
+        # Assert: same canvas size and same per-panel size_mm (same formula).
+        assert real_canvas_mm == pytest.approx(canvas_mm)
+        for label in aspects:
+            assert sources_mm[panels[label]]["size_mm"] == pytest.approx(
+                sizes_mm[label]
+            )
+
+
+class TestAutoTileValidation:
+    """Empty input fails loud."""
+
+    def test_empty_aspects_raises(self):
+        # Arrange
+        # Act
+        # Assert
+        with pytest.raises(ValueError):
+            auto_tile_layout({}, width_mm=180)
+
+
+# EOF


### PR DESCRIPTION
## Summary

Adds `auto_tile_layout(aspects, width_mm, height_mm=None, gap_mm=1.0)`, which bin-packs panels — keyed only by their true aspect ratio, no source or render needed — into a row-list `layout` ready for `build_tiled_sources`/`fr.compose`.

- Rows are chosen via an LPT-greedy multiway partition over candidate row-counts (1..N), balancing each row's running aspect-sum (not panel count) to keep row heights close to parity.
- Scoring: closest-without-exceeding a target `height_mm` when given, else minimizing wasted canvas area (the canonical packing-efficiency objective) when not.
- **Hard invariant**: panels are never stretched or upscaled. `sizes_mm[label]`'s aspect ratio always equals the input `aspects[label]` exactly — this function only ever proposes geometry (a `layout` + target `sizes_mm` for panels to be re-authored/re-plotted at), it never renders.
- The row-height formula is factored out of `_tile.py` (`_row_height_mm` / `_row_panel_widths_mm`) so `build_tiled_sources` and `auto_tile_layout` compute row geometry identically — no drift between the two, verified by a cross-check test that feeds the auto-tiler's proposed layout into the real `build_tiled_sources`.

Closes scitex-todo card `figrecipe-auto-tiling-binpack`.

## Test plan
- [x] `test__auto_tile.py`: width-only packing (covers every label once), no-stretch aspect-preservation invariant, height-target case, N=1 degenerate case, DRY cross-check against real `build_tiled_sources` (real saved panels, no mocks), empty-input validation
- [x] `test__tile.py` / `test__layout_report.py` (regression check on the shared-math extraction) — pre-commit pytest-testmon hook passed