### PR TITLE
fix(frontend): export ./bridge/* from figrecipe-editor package

### DIFF
--- a/src/figrecipe/_django/frontend/package.json
+++ b/src/figrecipe/_django/frontend/package.json
@@ -10,6 +10,10 @@
       "import": "./src/index.ts",
       "types": "./src/index.ts"
     },
+    "./bridge/*": {
+      "import": "./src/bridge/*.ts",
+      "types": "./src/bridge/*.ts"
+    },
     "./dist": {
       "import": "./dist/figrecipe-editor.js"
     },


### PR DESCRIPTION
hub imports `figrecipe-editor/bridge/bridge-init` but the package's exports map omitted the bridge subpath, so Vite/Node exports resolution failed and `npm run build` was red on every consumer since 2026-07-08 — blocking all scitex-hub frontend prod deploys. The source src/bridge/bridge-init.ts exists; this adds a `./bridge/*` exports entry (raw TS, matching `.`). Unblocks the hub production frontend build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)