### PR TITLE
feat(cli): normalize gui command to open/serve/status/stop group

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fr.gui(fig)  # Launch visual editor at http://127.0.0.1:5050
 
 ## Architecture
 
-FigRecipe is the **first app built on the SciTeX platform** -- it proves the app pattern that other apps follow. It works standalone (`figrecipe gui`) AND embedded inside scitex-cloud.
+FigRecipe is the **first app built on the SciTeX platform** -- it proves the app pattern that other apps follow. It works standalone (`figrecipe gui open`) AND embedded inside scitex-cloud.
 
 ```
 scitex (orchestrator) — re-exports figrecipe as scitex.plt
@@ -300,7 +300,7 @@ ax.add_stat_annotation(x1=0, x2=1, p_value=0.01, style="stars")
 ```bash
 figrecipe --help-recursive            # Show all commands
 figrecipe reproduce fig.yaml          # Recreate figure from recipe
-figrecipe gui figure.png              # Launch visual editor
+figrecipe gui open figure.png          # Launch visual editor
 figrecipe validate fig.yaml           # Verify pixel-identical reproduction
 figrecipe extract fig.yaml            # Extract plotted data as CSV
 figrecipe compose a.yaml b.yaml       # Compose multi-panel figure

--- a/docs/sphinx/cli_reference.rst
+++ b/docs/sphinx/cli_reference.rst
@@ -62,17 +62,22 @@ Compose multiple figures into a single multi-panel figure.
 gui
 ^^^
 
-Launch the interactive GUI editor for figure styling.
+Launch the interactive GUI editor for figure styling. `gui` is a command
+group with four verbs: `open` (auto-serves + opens the browser), `serve`
+(foreground server), `status`, and `stop`.
 
 .. code-block:: bash
 
-   figrecipe gui recipe.yaml
+   figrecipe gui open recipe.yaml
 
-   # Options:
+   # Options (gui open / gui serve):
    #   --port INTEGER       Server port (default: 5050)
    #   --host TEXT          Host address
-   #   --no-browser         Don't open browser automatically
-   #   --desktop            Launch as native desktop window
+   #   --no-browser         Don't open browser automatically (gui open only)
+   #   --desktop            Launch as native desktop window (gui open only)
+
+   figrecipe gui status                  # Is a server running? where?
+   figrecipe gui stop -y                 # Stop the running server
 
 Image Processing
 ----------------

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -16,7 +16,7 @@ Role in SciTeX Ecosystem
 -------------------------
 
 FigRecipe is the **first app built on the SciTeX platform** -- it proves the app pattern
-that other apps follow. It works standalone (``figrecipe gui``) AND embedded in
+that other apps follow. It works standalone (``figrecipe gui open``) AND embedded in
 scitex-cloud. The orchestrator re-exports it as ``scitex.plt``.
 
 .. code-block:: text
@@ -98,7 +98,7 @@ CLI:
     figrecipe reproduce my_plot.yaml -o reproduced.png
 
     # Launch GUI editor
-    figrecipe gui my_plot.yaml
+    figrecipe gui open my_plot.yaml
 
     # Validate reproduction fidelity
     figrecipe validate my_plot.yaml

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -161,7 +161,7 @@ FigRecipe provides a comprehensive CLI:
     figrecipe diff original.png reproduced.png
 
     # Launch GUI editor
-    figrecipe gui trig_plot.yaml
+    figrecipe gui open trig_plot.yaml
 
 MCP Server for AI Agents
 ------------------------

--- a/src/figrecipe/_cli/_gui.py
+++ b/src/figrecipe/_cli/_gui.py
@@ -1,17 +1,53 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""gui command - Launch GUI editor."""
+# File: src/figrecipe/_cli/_gui.py
 
+"""`gui` command group (browser-based editor): open / serve / status / stop.
+
+Follows the scitex-dev fleet CLI canon (19_gui-commands.md §12): one `gui`
+group with exactly four verbs. `serve` runs in the FOREGROUND; `open`
+auto-serves a detached server when none is running, then opens the browser.
+Runtime state lives in `_gui_runtime` so status/stop work from a fresh
+shell. Ported from scitex-writer's `_cli/commands/gui.py`
+(card: figrecipe-gui-cli-noun-verb-normalize-20260712).
+
+figrecipe's own argument semantics are preserved from the previous flat
+`start-gui` command: the positional arg is `source` (a .yaml recipe path,
+bundle, or directory — not scitex-writer's `project`), and a directory
+without `recipe.yaml` resolves to a browse-root `working_dir` instead of a
+specific recipe.
+
+`start-gui` remains as a hidden warn-forward alias for one deprecation
+cycle, keeping its original `--force`/`--yes` options so existing scripts
+don't break mid-cycle; the new `gui open`/`gui serve` do NOT expose
+`--force` — `gui stop -y` is the direct, tracked replacement for killing a
+server this CLI started. `_kill_port` is kept as a private helper used only
+by the deprecated alias's `--force` path (untracked stray processes holding
+the port are out of scope for the new lifecycle; users can reach for
+`fuser`/`lsof` directly, matching this project's simplicity-first stance).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+import webbrowser
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import click
 
+from . import _gui_runtime
+
 
 def _kill_port(port: int) -> bool:
-    """Kill process occupying the given port. Returns True if killed."""
-    import subprocess
+    """Kill process occupying the given port. Returns True if killed.
 
+    Legacy helper retained ONLY for the deprecated `start-gui --force` alias
+    (see module docstring) — the new `gui` group's own lifecycle uses
+    `gui stop` instead.
+    """
     try:
         result = subprocess.run(
             ["lsof", "-ti", f":{port}"],
@@ -36,104 +72,329 @@ def _kill_port(port: int) -> bool:
             return False
 
 
-@click.command("start-gui")
-@click.argument("source", type=click.Path(exists=True), required=False)
-@click.option(
-    "--port",
-    type=int,
-    default=5050,
-    help="Server port (default: 5050).",
-)
-@click.option(
-    "--host",
-    type=str,
-    default="127.0.0.1",
-    help="Host to bind (default: 127.0.0.1).",
-)
-@click.option(
-    "--no-browser",
-    is_flag=True,
-    help="Don't auto-open browser.",
-)
-@click.option(
-    "--desktop",
-    is_flag=True,
-    help="Launch as native desktop window (requires pywebview).",
-)
-@click.option(
-    "--force",
-    is_flag=True,
-    help="Kill existing process on port before starting.",
-)
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    help="Print what would happen (port, source, mode) without launching the server.",
-)
-@click.option("-y", "--yes", is_flag=True, help="Skip interactive confirmations.")
-def gui(
+def _resolve_source(
     source: Optional[str],
-    port: int,
-    host: str,
-    no_browser: bool,
-    desktop: bool,
-    force: bool,
-    dry_run: bool,
-    yes: bool,
-) -> None:
-    """Launch interactive GUI editor.
+) -> Tuple[Optional[Path], Optional[Path]]:
+    """Resolve a `source` CLI arg into (source_path, working_dir).
 
-    SOURCE is the optional path to a .yaml recipe file or bundle.
-    If not provided, creates a new blank figure.
-
-    \b
-    Example:
-      $ figrecipe gui
-      $ figrecipe gui figure.yaml --port 8080
-      $ figrecipe gui --desktop
-      $ figrecipe gui figure.yaml --force --no-browser
+    A directory without `recipe.yaml` is treated as a working_dir browse
+    root rather than a specific recipe — ported verbatim from figrecipe's
+    original flat `start-gui` command.
     """
-    from .. import gui as fr_gui
-
-    if force:
-        if _kill_port(port):
-            import time
-
-            click.echo(f"Killed existing process on port {port}")
-            time.sleep(0.5)  # Brief wait for port release
-
-    source_path = Path(source) if source else None
+    if source is None:
+        return None, None
+    source_path = Path(source)
     working_dir = None
-
-    # If source is a directory without recipe.yaml, use it as working_dir
-    if source_path is not None and source_path.is_dir():
+    if source_path.is_dir():
         recipe_yaml = source_path / "recipe.yaml"
         if not recipe_yaml.exists():
             working_dir = source_path
             source_path = None
-            click.echo(f"Browsing directory: {working_dir}")
+    return source_path, working_dir
 
+
+def _emit_json(payload: dict) -> None:
+    import json as _json
+
+    click.echo(_json.dumps(payload, indent=2))
+
+
+@click.group("gui")
+def gui():
+    """Browser-based editor: open, serve, status, stop."""
+
+
+# =========================================================================
+# gui serve — run the server in the foreground
+# =========================================================================
+
+
+@gui.command("serve")
+@click.argument("source", type=click.Path(exists=True), required=False)
+@click.option("--port", type=int, default=5050, help="Server port (default: 5050).")
+@click.option("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1).")
+@click.option("--dry-run", is_flag=True, default=False, help="Print, don't launch.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
+def gui_serve(source, port, host, dry_run, as_json):
+    """Run the editor server in the foreground (Ctrl-C to stop).
+
+    SOURCE is the optional path to a .yaml recipe file or a directory.
+    If not provided, creates a new blank figure.
+
+    \b
+    Example:
+        $ figrecipe gui serve
+        $ figrecipe gui serve figure.yaml --port 5051
+    """
+    source_path, working_dir = _resolve_source(source)
+    if working_dir is not None:
+        click.echo(f"Browsing directory: {working_dir}")
     if dry_run:
-        click.echo(
-            f"[dry-run] would start editor: source={source_path} "
-            f"host={host} port={port} desktop={desktop} "
-            f"open_browser={not no_browser} working_dir={working_dir}"
-        )
-        return
+        payload = {
+            "would_serve": True,
+            "host": host,
+            "port": port,
+            "source": str(source_path) if source_path else None,
+            "working_dir": str(working_dir) if working_dir else None,
+        }
+        if as_json:
+            _emit_json(payload)
+        else:
+            click.echo(f"Would serve editor at http://{host}:{port}.")
+        return 0
 
-    if desktop:
-        click.echo("Starting editor in desktop mode...")
-    else:
-        click.echo(f"Starting editor on http://{host}:{port}")
+    import os
 
+    from .. import gui as fr_gui
+
+    _gui_runtime.write_state(
+        os.getpid(),
+        port,
+        host,
+        str(source_path)
+        if source_path
+        else (str(working_dir) if working_dir else None),
+    )
     try:
         fr_gui(
             source_path,
             port=port,
             host=host,
-            open_browser=not no_browser,
-            desktop=desktop,
+            open_browser=False,
+            desktop=False,
             working_dir=working_dir,
         )
     except Exception as e:
         raise click.ClickException(f"Editor failed: {e}") from e
+    finally:
+        _gui_runtime.clear_state()
+    return 0
+
+
+# =========================================================================
+# gui open — ensure a server is running, then open the browser
+# =========================================================================
+
+
+def _autoserve(source: Optional[str], port: int, host: str) -> dict:
+    """Spawn a detached `gui serve` and wait for its state file."""
+    log_path = _gui_runtime.state_path().with_name("gui.log")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [sys.executable, "-m", "figrecipe", "gui", "serve"]
+    if source:
+        cmd.append(str(source))
+    cmd += ["--port", str(port), "--host", host]
+    with open(log_path, "ab") as log:
+        subprocess.Popen(cmd, stdout=log, stderr=log, start_new_session=True)
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        current = _gui_runtime.status()
+        if current.get("running"):
+            return current
+        time.sleep(0.3)
+    return {"running": False, "log": str(log_path)}
+
+
+@gui.command("open")
+@click.argument("source", type=click.Path(exists=True), required=False)
+@click.option("--port", type=int, default=5050, help="Server port (default: 5050).")
+@click.option("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1).")
+@click.option("--no-browser", is_flag=True, default=False, help="Don't open browser.")
+@click.option(
+    "--desktop",
+    is_flag=True,
+    default=False,
+    help="Launch as desktop window (requires pywebview).",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Print, don't launch.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
+def gui_open(source, port, host, no_browser, desktop, dry_run, as_json):
+    """Open the editor, auto-starting a background server when needed.
+
+    SOURCE is the optional path to a .yaml recipe file or a directory.
+    If not provided, creates a new blank figure.
+
+    \b
+    Example:
+        $ figrecipe gui open
+        $ figrecipe gui open figure.yaml --port 5051
+        $ figrecipe gui open --desktop
+    """
+    source_path, working_dir = _resolve_source(source)
+    if working_dir is not None:
+        click.echo(f"Browsing directory: {working_dir}")
+    if dry_run:
+        payload = {
+            "would_open": True,
+            "host": host,
+            "port": port,
+            "desktop": desktop,
+            "source": str(source_path) if source_path else None,
+            "working_dir": str(working_dir) if working_dir else None,
+        }
+        if as_json:
+            _emit_json(payload)
+        else:
+            click.echo(f"Would open editor at http://{host}:{port}.")
+        return 0
+
+    if desktop:
+        # Desktop mode is synchronous/blocking by nature (its own window),
+        # not a backgroundable server — run it directly, no state file.
+        from .. import gui as fr_gui
+
+        try:
+            fr_gui(
+                source_path,
+                port=port,
+                host=host,
+                open_browser=False,
+                desktop=True,
+                working_dir=working_dir,
+            )
+        except Exception as e:
+            raise click.ClickException(f"Editor failed: {e}") from e
+        return 0
+
+    current = _gui_runtime.status()
+    if not current.get("running"):
+        current = _autoserve(source, port, host)
+        if not current.get("running"):
+            click.echo(
+                f"Error: server did not come up within 30s; see {current.get('log')}",
+                err=True,
+            )
+            # `return 1` would be silently discarded by Click's standalone
+            # mode (it only exits non-zero via ctx.exit(code)/SystemExit),
+            # so raise explicitly to make the failure observable to scripts.
+            raise SystemExit(1)
+    url = current["url"]
+    if not no_browser:
+        webbrowser.open(url)
+    if as_json:
+        _emit_json(current)
+    else:
+        click.echo(f"Editor running at {url}.")
+    return 0
+
+
+# =========================================================================
+# gui status / gui stop
+# =========================================================================
+
+
+@gui.command("status")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
+def gui_status(as_json):
+    """Report whether the editor server is running.
+
+    \b
+    Example:
+        $ figrecipe gui status
+        $ figrecipe gui status --json
+    """
+    current = _gui_runtime.status()
+    if as_json:
+        _emit_json(current)
+    elif current.get("running"):
+        click.echo(f"Running at {current['url']} (pid {current['pid']}).")
+    else:
+        click.echo("Not running.")
+    return 0
+
+
+@gui.command("stop")
+@click.option("--dry-run", is_flag=True, default=False, help="Print, don't stop.")
+@click.option(
+    "--yes", "-y", is_flag=True, default=False, help="Stop without confirmation."
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
+def gui_stop(dry_run, yes, as_json):
+    """Stop the editor server started by `gui serve` / `gui open`.
+
+    \b
+    Example:
+        $ figrecipe gui stop -y
+        $ figrecipe gui stop --dry-run
+    """
+    current = _gui_runtime.status()
+    if not current.get("running"):
+        if as_json:
+            _emit_json({"stopped": False, "running": False})
+        else:
+            click.echo("Not running.")
+        return 0
+    if dry_run:
+        would = {"would_stop": True, "pid": current["pid"], "url": current["url"]}
+        if as_json:
+            _emit_json(would)
+        else:
+            click.echo(f"Would stop {current['url']} (pid {current['pid']}).")
+        return 0
+    if not yes:
+        click.echo(
+            f"Refusing to stop {current['url']} (pid {current['pid']}) "
+            "without --yes/-y.",
+            err=True,
+        )
+        # `return 2` would be silently discarded by Click's standalone mode
+        # (see `gui_open`'s comment above) — raise explicitly so scripts
+        # checking `$?` actually observe the refusal.
+        raise SystemExit(2)
+    result = _gui_runtime.stop()
+    if as_json:
+        _emit_json(result)
+    elif result.get("stopped"):
+        click.echo(f"Stopped (pid {result['pid']}).")
+    else:
+        click.echo("Not running.")
+    return 0
+
+
+# =========================================================================
+# start-gui — hidden warn-forward alias (one deprecation cycle)
+# =========================================================================
+
+
+@click.command("start-gui", hidden=True)
+@click.argument("source", type=click.Path(exists=True), required=False)
+@click.option("--port", type=int, default=5050)
+@click.option("--host", default="127.0.0.1")
+@click.option("--no-browser", is_flag=True, default=False)
+@click.option("--desktop", is_flag=True, default=False)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="[deprecated] kill existing process on port; use `gui stop -y` instead.",
+)
+@click.option("--dry-run", is_flag=True, default=False)
+@click.option("-y", "--yes", is_flag=True, default=False)
+@click.option("--json", "as_json", is_flag=True, default=False)
+@click.pass_context
+def start_gui(
+    ctx, source, port, host, no_browser, desktop, force, dry_run, yes, as_json
+):
+    """Deprecated alias for `gui open`."""
+    del yes  # accepted for back-compat only; `gui open` has no confirmation gate
+    click.echo(
+        "Warning: `start-gui` is deprecated; use `figrecipe gui open` instead.",
+        err=True,
+    )
+    if force and not dry_run:
+        if _kill_port(port):
+            click.echo(f"Killed existing process on port {port}", err=True)
+            time.sleep(0.5)
+    return ctx.invoke(
+        gui_open,
+        source=source,
+        port=port,
+        host=host,
+        no_browser=no_browser,
+        desktop=desktop,
+        dry_run=dry_run,
+        as_json=as_json,
+    )
+
+
+# EOF

--- a/src/figrecipe/_cli/_gui_runtime.py
+++ b/src/figrecipe/_cli/_gui_runtime.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/figrecipe/_cli/_gui_runtime.py
+
+"""Runtime state for the figrecipe GUI server (`gui serve/open/status/stop`).
+
+State lives at the fleet runtime-state path resolved via
+``scitex_config._ecosystem.local_state.runtime_path("figrecipe", "gui.json")``
+so ``gui status`` / ``gui stop`` in a fresh shell can find a server launched
+earlier by ``gui serve`` / ``gui open``.
+
+Ported from scitex-writer's ``_core/_gui_runtime.py`` per the scitex-dev
+fleet CLI canon (``19_gui-commands.md`` — one canonical ``gui`` group with
+``open``/``serve``/``status``/``stop``). Card:
+figrecipe-gui-cli-noun-verb-normalize-20260712.
+
+Placed alongside ``_gui.py`` under ``_cli/`` (not a new top-level ``_core/``
+package like scitex-writer's) because figrecipe has no existing ``_core/``
+directory — this matches figrecipe's own flat ``_cli/_xxx.py`` module
+convention instead of introducing a new package for one file.
+
+Unlike scitex-writer's docstring (written before the shared helper existed),
+``scitex_config._ecosystem.local_state`` IS reliably importable here:
+figrecipe already declares ``scitex-config>=0.3.0`` in pyproject.toml and it
+resolves in this environment, so we reuse it directly rather than
+reimplementing path resolution.
+
+Pure state logic only — no Click, no Django. The CLI layer (`_cli/_gui.py`)
+owns argument parsing and process spawning.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import time
+from pathlib import Path
+from typing import Optional, Union
+
+PathLike = Union[str, Path]
+
+# "source" (not "project") to match figrecipe's own CLI argument semantics
+# (a .yaml recipe path, a bundle/directory, or None for a blank figure).
+_STATE_FIELDS = ("pid", "port", "host", "source", "started_at")
+
+
+def state_path() -> Path:
+    """Resolve the GUI state-file path.
+
+    ``FIGRECIPE_GUI_STATE`` overrides the resolved path (isolated CI runs,
+    tests) — mirrors figrecipe's existing ``FIGRECIPE_CONFIG`` /
+    ``FIGRECIPE_WORKING_DIR`` env-override convention. Otherwise resolves
+    via the shared fleet runtime-state helper.
+    """
+    override = os.environ.get("FIGRECIPE_GUI_STATE")
+    if override:
+        return Path(override)
+    from scitex_config._ecosystem import local_state
+
+    return Path(local_state.runtime_path("figrecipe", "gui.json"))
+
+
+def read_state(path: Optional[PathLike] = None) -> Optional[dict]:
+    """Return the persisted state dict, or None when absent/corrupt."""
+    p = Path(path) if path is not None else state_path()
+    try:
+        loaded = json.loads(p.read_text())
+    except (OSError, ValueError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def write_state(
+    pid: int,
+    port: int,
+    host: str,
+    source: Optional[str],
+    path: Optional[PathLike] = None,
+) -> Path:
+    """Persist the running server's coordinates; returns the state-file path.
+
+    ``source`` may be None (the editor was launched for a blank figure with
+    no recipe/working-dir on the command line).
+    """
+    p = Path(path) if path is not None else state_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    state = {
+        "pid": pid,
+        "port": port,
+        "host": host,
+        "source": source,
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    }
+    p.write_text(json.dumps(state, indent=2))
+    return p
+
+
+def clear_state(path: Optional[PathLike] = None) -> None:
+    """Remove the state file. Idempotent."""
+    p = Path(path) if path is not None else state_path()
+    try:
+        p.unlink()
+    except OSError:
+        pass
+
+
+def pid_alive(pid: int) -> bool:
+    """True when ``pid`` refers to a live process we could signal.
+
+    A zombie still answers signal 0 but is already dead — without this
+    check ``stop()`` would poll an exited-but-unreaped server for the
+    full timeout and report ``terminated=False``.
+    """
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        if stat.rpartition(")")[2].split()[0] == "Z":
+            return False
+    except (OSError, IndexError):
+        pass
+    return True
+
+
+def status(path: Optional[PathLike] = None) -> dict:
+    """Report the server's state, self-healing a stale file.
+
+    A state file whose pid is dead (crash, kill -9) is removed so the next
+    ``open`` auto-serves instead of pointing the browser at a dead port.
+    """
+    state = read_state(path)
+    if state is None:
+        return {"running": False}
+    if not pid_alive(state.get("pid", -1)):
+        clear_state(path)
+        return {"running": False, "stale_state_cleared": True}
+    url = f"http://{state.get('host')}:{state.get('port')}"
+    return {"running": True, "url": url, **{k: state.get(k) for k in _STATE_FIELDS}}
+
+
+def stop(path: Optional[PathLike] = None, timeout: float = 5.0) -> dict:
+    """SIGTERM the recorded server and clear the state file. Idempotent."""
+    current = status(path)
+    if not current.get("running"):
+        return {"stopped": False, "running": False}
+    pid = current["pid"]
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError as exc:
+        return {"stopped": False, "running": True, "pid": pid, "error": str(exc)}
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and pid_alive(pid):
+        time.sleep(0.1)
+    clear_state(path)
+    return {"stopped": True, "pid": pid, "terminated": not pid_alive(pid)}
+
+
+# EOF

--- a/src/figrecipe/_cli/_main.py
+++ b/src/figrecipe/_cli/_main.py
@@ -15,7 +15,7 @@ from ._diagram import diagram as _diagram_cmd
 from ._diff import diff
 from ._extract import extract
 from ._fonts import fonts
-from ._gui import gui
+from ._gui import gui, start_gui
 from ._hitmap import hitmap
 from ._info import info
 from ._mcp import mcp
@@ -32,7 +32,7 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 # Command categories for organized help display
 COMMAND_CATEGORIES = [
-    ("Figure Creation", ["plot", "reproduce", "compose", "start-gui"]),
+    ("Figure Creation", ["plot", "reproduce", "compose", "gui"]),
     ("Image Processing", ["convert", "crop", "diff", "show-hitmap"]),
     ("Data & Validation", ["extract", "validate", "info"]),
     ("Diagram", ["diagram"]),
@@ -124,7 +124,7 @@ def main(
 ) -> None:
     """FigRecipe - Reproducible, style-editable scientific figures via YAML recipes.
 
-    Use 'figrecipe start-gui' to launch the GUI editor.
+    Use 'figrecipe gui open' to launch the GUI editor.
 
     Config is loaded with the SciTeX precedence chain:
       config.yaml -> $FIGRECIPE_CONFIG -> ~/.scitex/figrecipe/config.yaml -> defaults
@@ -164,6 +164,7 @@ main.add_command(diff)
 main.add_command(extract)
 main.add_command(fonts)
 main.add_command(gui)
+main.add_command(start_gui)
 main.add_command(hitmap)
 main.add_command(info)
 main.add_command(list_python_apis)

--- a/src/figrecipe/_skills/figrecipe/01_installation.md
+++ b/src/figrecipe/_skills/figrecipe/01_installation.md
@@ -25,7 +25,7 @@ Pulls `matplotlib>=3.5`, `numpy>=1.20`, `pandas>=1.3`, `PyYAML`,
 | `imaging` | Pillow-based image processing helpers |
 | `graph` | Mermaid / Graphviz diagram backends |
 | `graph-interactive` | Web-rendered diagram preview |
-| `editor` | GUI editor (`figrecipe gui`) |
+| `editor` | GUI editor (`figrecipe gui open`) |
 | `app` | Workspace-app integration (scitex-cloud) |
 | `desktop` | Native desktop launcher |
 | `mcp` | MCP server (`figrecipe mcp serve`) |

--- a/src/figrecipe/_skills/figrecipe/04_cli-reference.md
+++ b/src/figrecipe/_skills/figrecipe/04_cli-reference.md
@@ -12,7 +12,7 @@ figrecipe [OPTIONS] COMMAND [ARGS]...
 ```
 
 Reproducible, style-editable scientific figures via YAML recipes.
-Use `figrecipe gui` to launch the GUI editor.
+Use `figrecipe gui open` to launch the GUI editor.
 
 ## Global options
 

--- a/src/figrecipe/_skills/figrecipe/11_cli-reference.md
+++ b/src/figrecipe/_skills/figrecipe/11_cli-reference.md
@@ -61,13 +61,17 @@ Options: `-o/--output` (required), `--layout [horizontal|vertical|grid]`, `--col
 
 ### figrecipe gui
 
-Launch the interactive GUI editor.
+Launch the interactive GUI editor. `gui` is a command group with four
+verbs: `open` (auto-serves a background server if needed, then opens the
+browser), `serve` (foreground server), `status`, and `stop`.
 
 ```bash
-figrecipe gui
-figrecipe gui recipe.yaml
-figrecipe gui recipe.yaml --port 8080
-figrecipe gui recipe.yaml --desktop          # native window (requires figrecipe[desktop])
+figrecipe gui open
+figrecipe gui open recipe.yaml
+figrecipe gui open recipe.yaml --port 8080
+figrecipe gui open recipe.yaml --desktop     # native window (requires figrecipe[desktop])
+figrecipe gui status                         # is a server running? where?
+figrecipe gui stop -y                        # stop the running server
 ```
 
 ## Image Processing

--- a/tests/figrecipe/_cli/test__gui.py
+++ b/tests/figrecipe/_cli/test__gui.py
@@ -1,20 +1,224 @@
-"""Smoke import mirror for figrecipe._cli._gui.
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/figrecipe/_cli/_gui.py
 
-Auto-generated subpackage mirror placeholder; replace with real tests
-as the module matures. Satisfies the src<->tests mirror audit rule.
+"""Tests for the `figrecipe gui` command group (real Click invocation).
+
+Ported from scitex-writer's tests/scitex_writer/_cli/commands/test_gui.py
+idiom (card figrecipe-gui-cli-noun-verb-normalize-20260712): CLI-level
+tests use `--dry-run` to avoid actually starting a Django server, and an
+isolated per-test state file via `FIGRECIPE_GUI_STATE` so `status`/`stop`
+tests never touch a real running server on the host.
 """
 
+import json
+import os
 
 import pytest
+from click.testing import CliRunner
+
+from figrecipe._cli import _gui_runtime, main
+from figrecipe._cli._gui import gui
 
 
-def test_import__cli__gui_module():
-    # Arrange
-    # Arrange
-    # Act
-    # Assert
-    module_path = 'figrecipe._cli._gui'
-    # Act
-    mod = pytest.importorskip(module_path)
-    # Assert
-    assert mod.__name__ == module_path
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_state(tmp_path):
+    state_file = tmp_path / "gui.json"
+    os.environ["FIGRECIPE_GUI_STATE"] = str(state_file)
+    yield state_file
+    os.environ.pop("FIGRECIPE_GUI_STATE", None)
+
+
+class TestGuiGroupRegistration:
+    """Test the `gui` group's wiring onto the top-level CLI."""
+
+    def test_gui_group_registered_on_main(self):
+        # Arrange
+        commands = main.commands
+        # Act
+        present = "gui" in commands
+        # Assert
+        assert present
+
+    def test_gui_group_has_canonical_verbs(self):
+        # Arrange
+        verbs = set(gui.commands)
+        # Act
+        canonical = {"open", "serve", "status", "stop"}
+        # Assert
+        assert canonical <= verbs
+
+    def test_start_gui_alias_registered_on_main(self):
+        # Arrange
+        commands = main.commands
+        # Act
+        present = "start-gui" in commands
+        # Assert
+        assert present
+
+    def test_start_gui_alias_is_hidden(self):
+        # Arrange
+        command = main.commands["start-gui"]
+        # Act
+        hidden = command.hidden
+        # Assert
+        assert hidden
+
+
+class TestStartGuiDeprecatedAlias:
+    """Test the deprecated `start-gui` -> `gui open` forwarding alias."""
+
+    def test_start_gui_warns_deprecated(self, runner):
+        # Arrange
+        args = ["start-gui", "--dry-run"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert "deprecated" in result.output
+
+    def test_start_gui_dry_run_exits_zero(self, runner):
+        # Arrange
+        args = ["start-gui", "--dry-run"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert result.exit_code == 0
+
+    def test_start_gui_dry_run_forwards_to_open(self, runner):
+        # Arrange
+        # `--json` payload and the deprecation warning may share the same
+        # output stream under CliRunner's default mixing, so assert the
+        # forwarded payload key by substring rather than a strict
+        # json.loads() of the whole (possibly-mixed) output.
+        args = ["start-gui", "--dry-run", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert '"would_open": true' in result.output
+
+
+class TestGuiOpenDryRun:
+    """Test `gui open --dry-run` (never actually starts a server)."""
+
+    def test_gui_open_dry_run_exits_zero(self, runner):
+        # Arrange
+        args = ["gui", "open", "--dry-run"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert result.exit_code == 0
+
+    def test_gui_open_dry_run_json_shape(self, runner):
+        # Arrange
+        args = ["gui", "open", "--dry-run", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload["would_open"]
+
+
+class TestGuiServeDryRun:
+    """Test `gui serve --dry-run` (never actually starts a server)."""
+
+    def test_gui_serve_dry_run_exits_zero(self, runner):
+        # Arrange
+        args = ["gui", "serve", "--dry-run"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert result.exit_code == 0
+
+    def test_gui_serve_dry_run_json_shape(self, runner):
+        # Arrange
+        args = ["gui", "serve", "--dry-run", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload["would_serve"]
+
+
+class TestGuiStatus:
+    """Test `gui status` against an isolated (never-running) state file."""
+
+    def test_gui_status_json_not_running(self, runner, isolated_state):
+        # Arrange
+        args = ["gui", "status", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload == {"running": False}
+
+    def test_gui_status_human_not_running(self, runner, isolated_state):
+        # Arrange
+        args = ["gui", "status"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert "Not running" in result.output
+
+
+class TestGuiStop:
+    """Test `gui stop` idempotency and the --yes confirmation gate."""
+
+    def test_gui_stop_json_idempotent(self, runner, isolated_state):
+        # Arrange
+        args = ["gui", "stop", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload == {"stopped": False, "running": False}
+
+    def test_gui_stop_dry_run_reports_would_stop(self, runner, isolated_state):
+        # Arrange
+        _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", None, isolated_state)
+        args = ["gui", "stop", "--dry-run", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload["would_stop"]
+
+    def test_gui_stop_dry_run_leaves_server_state(self, runner, isolated_state):
+        # Arrange
+        _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", None, isolated_state)
+        args = ["gui", "stop", "--dry-run"]
+        # Act
+        runner.invoke(main, args)
+        # Assert
+        assert isolated_state.exists()
+
+    def test_gui_stop_without_yes_refuses_exit_code(self, runner, isolated_state):
+        # Arrange
+        _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", None, isolated_state)
+        args = ["gui", "stop"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert result.exit_code == 2
+
+    def test_gui_stop_without_yes_refuses_message(self, runner, isolated_state):
+        # Arrange
+        _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", None, isolated_state)
+        args = ["gui", "stop"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert "without --yes" in result.output
+
+    def test_gui_stop_without_yes_leaves_state(self, runner, isolated_state):
+        # Arrange
+        _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", None, isolated_state)
+        args = ["gui", "stop"]
+        # Act
+        runner.invoke(main, args)
+        # Assert
+        assert isolated_state.exists()

--- a/tests/figrecipe/_cli/test__gui_runtime.py
+++ b/tests/figrecipe/_cli/test__gui_runtime.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/figrecipe/_cli/_gui_runtime.py
+
+"""Tests for the GUI runtime-state module (state file, pid checks, stop).
+
+Ported from scitex-writer's tests/scitex_writer/_core/test__gui_runtime.py
+idiom (card figrecipe-gui-cli-noun-verb-normalize-20260712) — real
+subprocess children for pid-liveness checks, no mocking.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from figrecipe._cli import _gui_runtime
+
+
+@pytest.fixture
+def state_file(tmp_path):
+    return tmp_path / "gui.json"
+
+
+def test_read_state_missing_returns_none(state_file):
+    # Arrange
+    # (state_file is never created)
+    # Act
+    result = _gui_runtime.read_state(state_file)
+    # Assert
+    assert result is None
+
+
+def test_read_state_corrupt_returns_none(state_file):
+    # Arrange
+    state_file.write_text("{not json")
+    # Act
+    result = _gui_runtime.read_state(state_file)
+    # Assert
+    assert result is None
+
+
+def test_write_state_roundtrips_fields(state_file):
+    # Arrange
+    _gui_runtime.write_state(123, 5050, "127.0.0.1", "/proj/figure.yaml", state_file)
+    # Act
+    state = _gui_runtime.read_state(state_file)
+    # Assert
+    assert (state["pid"], state["port"], state["host"], state["source"]) == (
+        123,
+        5050,
+        "127.0.0.1",
+        "/proj/figure.yaml",
+    )
+
+
+def test_write_state_source_may_be_none(state_file):
+    # Arrange
+    _gui_runtime.write_state(123, 5050, "127.0.0.1", None, state_file)
+    # Act
+    state = _gui_runtime.read_state(state_file)
+    # Assert
+    assert state["source"] is None
+
+
+def test_write_state_records_started_at(state_file):
+    # Arrange
+    _gui_runtime.write_state(123, 5050, "127.0.0.1", "/proj/figure.yaml", state_file)
+    # Act
+    state = _gui_runtime.read_state(state_file)
+    # Assert
+    assert state["started_at"]
+
+
+def test_clear_state_is_idempotent(state_file):
+    # Arrange
+    _gui_runtime.clear_state(state_file)
+    # Act
+    _gui_runtime.clear_state(state_file)
+    # Assert
+    assert not state_file.exists()
+
+
+def test_pid_alive_true_for_own_process():
+    # Arrange
+    pid = os.getpid()
+    # Act
+    alive = _gui_runtime.pid_alive(pid)
+    # Assert
+    assert alive
+
+
+def test_pid_alive_false_for_invalid_pid():
+    # Arrange
+    pid = -1
+    # Act
+    alive = _gui_runtime.pid_alive(pid)
+    # Assert
+    assert not alive
+
+
+def test_pid_alive_false_for_exited_child():
+    # Arrange
+    child = subprocess.Popen([sys.executable, "-c", ""])
+    child.wait()
+    # Act
+    alive = _gui_runtime.pid_alive(child.pid)
+    # Assert
+    assert not alive
+
+
+def test_status_missing_state_reports_not_running(state_file):
+    # Arrange
+    # (state_file is never created)
+    # Act
+    result = _gui_runtime.status(state_file)
+    # Assert
+    assert result == {"running": False}
+
+
+def test_status_live_pid_reports_running_url(state_file):
+    # Arrange
+    _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", None, state_file)
+    # Act
+    result = _gui_runtime.status(state_file)
+    # Assert
+    assert result["url"] == "http://127.0.0.1:5050"
+
+
+def test_status_dead_pid_self_heals_state(state_file):
+    # Arrange
+    child = subprocess.Popen([sys.executable, "-c", ""])
+    child.wait()
+    _gui_runtime.write_state(child.pid, 5050, "127.0.0.1", None, state_file)
+    # Act
+    result = _gui_runtime.status(state_file)
+    # Assert
+    assert result["stale_state_cleared"] and not state_file.exists()
+
+
+def test_stop_without_state_is_idempotent(state_file):
+    # Arrange
+    # (state_file is never created)
+    # Act
+    result = _gui_runtime.stop(state_file)
+    # Assert
+    assert result == {"stopped": False, "running": False}
+
+
+def test_stop_terminates_recorded_process(state_file):
+    # Arrange
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    _gui_runtime.write_state(child.pid, 5050, "127.0.0.1", None, state_file)
+    # Act
+    result = _gui_runtime.stop(state_file, timeout=5.0)
+    child.wait(timeout=5)
+    # Assert
+    assert result["stopped"] and result["terminated"]
+
+
+def test_stop_clears_state_file(state_file):
+    # Arrange
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    _gui_runtime.write_state(child.pid, 5050, "127.0.0.1", None, state_file)
+    # Act
+    _gui_runtime.stop(state_file, timeout=5.0)
+    child.wait(timeout=5)
+    # Assert
+    assert not state_file.exists()
+
+
+def test_state_path_honors_env_override(tmp_path):
+    # Arrange
+    override = tmp_path / "custom_gui.json"
+    os.environ["FIGRECIPE_GUI_STATE"] = str(override)
+    try:
+        # Act
+        resolved = _gui_runtime.state_path()
+    finally:
+        os.environ.pop("FIGRECIPE_GUI_STATE", None)
+    # Assert
+    assert resolved == override

--- a/tests/figrecipe/_cli/test__main.py
+++ b/tests/figrecipe/_cli/test__main.py
@@ -107,7 +107,7 @@ class TestMainCommand:
         # Act
         # Assert
         result = runner.invoke(main, [])
-        assert "figrecipe start-gui" in result.output
+        assert "figrecipe gui open" in result.output
 
 
 class TestVersionCommand:
@@ -291,9 +291,7 @@ class TestReproduceCommand:
         # Act
         # Assert
         output_path = tmp_path / "output.png"
-        result = runner.invoke(
-            main, ["reproduce", str(sample_recipe), "-o", str(output_path)]
-        )
+        runner.invoke(main, ["reproduce", str(sample_recipe), "-o", str(output_path)])
         assert output_path.exists()
 
     def test_reproduce_basic_part_3(self, runner, sample_recipe, tmp_path):
@@ -480,23 +478,121 @@ class TestFontsCommand:
 
 
 class TestGuiCommand:
-    """Test start-gui command."""
+    """Test the `gui` command group (open/serve/status/stop) and the
+    deprecated `start-gui` alias (audit-cli incident:
+    figrecipe-gui-cli-noun-verb-normalize-20260712)."""
 
-    def test_gui_help_part_1(self, runner):
-        """Test start-gui --help."""
+    def test_gui_group_help_part_1(self, runner):
+        """Test `gui --help`."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "--help"])
+        assert result.exit_code == 0
+
+    def test_gui_group_help_lists_open(self, runner):
+        """Test `gui --help` lists the `open` verb."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "--help"])
+        assert "open" in result.output
+
+    def test_gui_group_help_lists_serve(self, runner):
+        """Test `gui --help` lists the `serve` verb."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "--help"])
+        assert "serve" in result.output
+
+    def test_gui_group_help_lists_status(self, runner):
+        """Test `gui --help` lists the `status` verb."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "--help"])
+        assert "status" in result.output
+
+    def test_gui_group_help_lists_stop(self, runner):
+        """Test `gui --help` lists the `stop` verb."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "--help"])
+        assert "stop" in result.output
+
+    def test_gui_open_help_part_1(self, runner):
+        """Test `gui open --help`."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "open", "--help"])
+        assert result.exit_code == 0
+
+    def test_gui_open_help_part_2(self, runner):
+        """Test `gui open --help` documents SOURCE."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "open", "--help"])
+        assert "SOURCE" in result.output or "source" in result.output.lower()
+
+    def test_gui_serve_help_part_1(self, runner):
+        """Test `gui serve --help`."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "serve", "--help"])
+        assert result.exit_code == 0
+
+    def test_gui_status_help(self, runner):
+        """Test `gui status --help`."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "status", "--help"])
+        assert result.exit_code == 0
+
+    def test_gui_stop_help(self, runner):
+        """Test `gui stop --help`."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["gui", "stop", "--help"])
+        assert result.exit_code == 0
+
+    def test_start_gui_alias_help_part_1(self, runner):
+        """Test deprecated `start-gui --help` still works (hidden but callable)."""
         # Arrange
         # Act
         # Assert
         result = runner.invoke(main, ["start-gui", "--help"])
         assert result.exit_code == 0
 
-    def test_gui_help_part_2(self, runner):
-        """Test start-gui --help."""
+    def test_start_gui_alias_help_part_2(self, runner):
+        """Test deprecated `start-gui --help` still documents SOURCE."""
         # Arrange
         # Act
         # Assert
         result = runner.invoke(main, ["start-gui", "--help"])
         assert "SOURCE" in result.output or "source" in result.output.lower()
+
+    def test_start_gui_alias_hidden_from_top_level_help(self, runner):
+        """Test `start-gui` no longer appears in the top-level help listing."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["--help"])
+        assert "start-gui" not in result.output
+
+    def test_start_gui_alias_warns_deprecated(self, runner):
+        """Test `start-gui` emits a deprecation warning."""
+        # Arrange
+        # Act
+        # Assert
+        result = runner.invoke(main, ["start-gui", "--dry-run"])
+        assert "deprecated" in result.output
 
 
 class TestCropCommand:
@@ -727,7 +823,7 @@ legend: true
         # Act
         # Assert
         output_path = tmp_path / "output.png"
-        result = runner.invoke(main, ["plot", str(sample_spec), "-o", str(output_path)])
+        runner.invoke(main, ["plot", str(sample_spec), "-o", str(output_path)])
         assert output_path.exists()
 
     def test_plot_basic_part_3(self, runner, sample_spec, tmp_path):
@@ -773,7 +869,7 @@ legend: true
         # Act
         # Assert
         output_path = tmp_path / "output.png"
-        result = runner.invoke(
+        runner.invoke(
             main, ["plot", str(sample_spec), "-o", str(output_path), "--save-recipe"]
         )
         assert output_path.exists()
@@ -784,7 +880,7 @@ legend: true
         # Act
         # Assert
         output_path = tmp_path / "output.png"
-        result = runner.invoke(
+        runner.invoke(
             main, ["plot", str(sample_spec), "-o", str(output_path), "--save-recipe"]
         )
         recipe_path = tmp_path / "output.yaml"
@@ -825,7 +921,7 @@ plots:
 """
         )
         output_path = tmp_path / "scatter.png"
-        result = runner.invoke(main, ["plot", str(spec_path), "-o", str(output_path)])
+        runner.invoke(main, ["plot", str(spec_path), "-o", str(output_path)])
         assert output_path.exists()
 
     def test_plot_bar_part_1(self, runner, tmp_path):
@@ -865,7 +961,7 @@ ylabel: "Value"
 """
         )
         output_path = tmp_path / "bar.png"
-        result = runner.invoke(main, ["plot", str(spec_path), "-o", str(output_path)])
+        runner.invoke(main, ["plot", str(spec_path), "-o", str(output_path)])
         assert output_path.exists()
 
     def test_plot_multiple_types_part_1(self, runner, tmp_path):
@@ -917,7 +1013,7 @@ legend: true
 """
         )
         output_path = tmp_path / "multi.png"
-        result = runner.invoke(main, ["plot", str(spec_path), "-o", str(output_path)])
+        runner.invoke(main, ["plot", str(spec_path), "-o", str(output_path)])
         assert output_path.exists()
 
     def test_plot_csv_columns_part_1(self, runner, tmp_path):
@@ -985,7 +1081,7 @@ title: "CSV Column Test"
 """
         )
         output_path = tmp_path / "csv_plot.png"
-        result = runner.invoke(main, ["plot", str(spec_path), "-o", str(output_path)])
+        runner.invoke(main, ["plot", str(spec_path), "-o", str(output_path)])
         assert output_path.exists()
 
     def test_plot_csv_invalid_column_part_1(self, runner, tmp_path):
@@ -1039,6 +1135,7 @@ class TestCLIIntegration:
         # Arrange
         import subprocess
         import sys
+
         # Act
         result = subprocess.run(
             [sys.executable, "-m", "figrecipe", "--help"],
@@ -1053,6 +1150,7 @@ class TestCLIIntegration:
         # Arrange
         import subprocess
         import sys
+
         # Act
         result = subprocess.run(
             [sys.executable, "-m", "figrecipe", "--help"],
@@ -1068,6 +1166,7 @@ class TestCLIIntegration:
         # Act
         # Assert
         import figrecipe as fr
+
         fig, axes = fr.subplots(1, 1)
         axes.plot([1, 2, 3], [1, 4, 9])
         recipe_path = tmp_path / "workflow_test.yaml"
@@ -1081,6 +1180,7 @@ class TestCLIIntegration:
         # Act
         # Assert
         import figrecipe as fr
+
         fig, axes = fr.subplots(1, 1)
         axes.plot([1, 2, 3], [1, 4, 9])
         recipe_path = tmp_path / "workflow_test.yaml"
@@ -1098,13 +1198,12 @@ class TestCLIIntegration:
         # Act
         # Assert
         import figrecipe as fr
+
         fig, axes = fr.subplots(1, 1)
         axes.plot([1, 2, 3], [1, 4, 9])
         recipe_path = tmp_path / "workflow_test.yaml"
         fig.save_recipe(recipe_path)
-        result = runner.invoke(main, ["info", str(recipe_path)])
+        runner.invoke(main, ["info", str(recipe_path)])
         output_path = tmp_path / "reproduced.png"
-        result = runner.invoke(
-            main, ["reproduce", str(recipe_path), "-o", str(output_path)]
-        )
+        runner.invoke(main, ["reproduce", str(recipe_path), "-o", str(output_path)])
         assert output_path.exists()


### PR DESCRIPTION
## Summary

figrecipe exposed a flat, foreground-only `start-gui` command with no way to check status or stop a running server from a fresh shell. Ported the `gui open/serve/status/stop` group pattern from scitex-writer (the correct reference implementation) per scitex-dev's fleet CLI canon (`19_gui-commands.md` SS12 -- one canonical `gui` group across all Django-app packages).

- `gui serve` runs the editor server in the foreground and writes PID/port state.
- `gui open` auto-serves a detached background instance when none is running, then opens the browser.
- `gui status` reports whether it's running (self-healing a stale state file if the recorded pid is dead).
- `gui stop` SIGTERMs and clears state, idempotently; refuses without `-y`/`--yes`.
- `start-gui` remains as a hidden deprecated alias for one deprecation cycle, forwarding to `gui open`.

Reuses the real `scitex_config._ecosystem.local_state.runtime_path` helper for the state-file path (importable in this environment) rather than reimplementing path resolution -- figrecipe already depends on `scitex-config>=0.3.0`.

Operator-flagged incident: `figrecipe gui` errored with \"No such command 'gui'\" since the CLI only had the flat verb. Closes scitex-todo card `figrecipe-gui-cli-noun-verb-normalize-20260712`.

## Test plan
- [x] `test__gui.py` / `test__gui_runtime.py` / `test__main.py` (141 tests total across the affected suite) -- all passing, independently re-verified
- [x] `scitex-dev ecosystem audit-python-apis` -- clean, no violations
- [x] Local pre-commit pytest-testmon -- passed before commit landed