### PR TITLE
fix(cli): gui DefaultGroup, fixed-port bind-or-fail, and consumer branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Reload and edit from the saved recipe:
 
 ```python
 fig, ax = fr.reproduce("figure.yaml")
-fr.gui(fig)  # Launch visual editor at http://127.0.0.1:5050
+fr.gui(fig)  # Launch visual editor at http://127.0.0.1:31296
 ```
 
 ---

--- a/docs/sphinx/cli_reference.rst
+++ b/docs/sphinx/cli_reference.rst
@@ -71,7 +71,7 @@ group with four verbs: `open` (auto-serves + opens the browser), `serve`
    figrecipe gui open recipe.yaml
 
    # Options (gui open / gui serve):
-   #   --port INTEGER       Server port (default: 5050)
+   #   --port INTEGER       Server port (default: 31296)
    #   --host TEXT          Host address
    #   --no-browser         Don't open browser automatically (gui open only)
    #   --desktop            Launch as native desktop window (gui open only)

--- a/src/figrecipe/_cli/_gui.py
+++ b/src/figrecipe/_cli/_gui.py
@@ -17,6 +17,13 @@ bundle, or directory — not scitex-writer's `project`), and a directory
 without `recipe.yaml` resolves to a browse-root `working_dir` instead of a
 specific recipe.
 
+`gui` is a DefaultGroup (`_DefaultGroup` below): a bare `figrecipe gui
+[SOURCE]` still works exactly like the old flat `start-gui` did (defaults
+to the `open` verb) alongside the explicit `gui open`/`gui serve`/`gui
+status`/`gui stop` subcommands — required because `scitex-plt` (an alias
+console-script pointing at this same CLI) invokes `gui serve` directly, and
+existing callers/docs also invoke bare `gui <source>`. Both must resolve.
+
 `start-gui` remains as a hidden warn-forward alias for one deprecation
 cycle, keeping its original `--force`/`--yes` options so existing scripts
 don't break mid-cycle; the new `gui open`/`gui serve` do NOT expose
@@ -25,6 +32,12 @@ server this CLI started. `_kill_port` is kept as a private helper used only
 by the deprecated alias's `--force` path (untracked stray processes holding
 the port are out of scope for the new lifecycle; users can reach for
 `fuser`/`lsof` directly, matching this project's simplicity-first stance).
+
+`gui serve` binds its port fixed-or-fail-loud (see `_port_is_free` /
+`_port_holder`) and refuses to start a second instance when one is already
+tracked as running (see the `_gui_runtime.status()` check at the top of
+`gui_serve`) — ported from scitex-writer#312, which fixed the exact same
+"silently stacks duplicate instances on the next free port" incident.
 """
 
 from __future__ import annotations
@@ -39,37 +52,9 @@ from typing import Optional, Tuple
 import click
 
 from . import _gui_runtime
+from ._gui_click import _DefaultGroup, _kill_port, _port_holder, _port_is_free
 
-
-def _kill_port(port: int) -> bool:
-    """Kill process occupying the given port. Returns True if killed.
-
-    Legacy helper retained ONLY for the deprecated `start-gui --force` alias
-    (see module docstring) — the new `gui` group's own lifecycle uses
-    `gui stop` instead.
-    """
-    try:
-        result = subprocess.run(
-            ["lsof", "-ti", f":{port}"],
-            capture_output=True,
-            text=True,
-        )
-        pids = result.stdout.strip().split()
-        if not pids:
-            return False
-        for pid in pids:
-            subprocess.run(["kill", "-9", pid], capture_output=True)
-        return True
-    except FileNotFoundError:
-        # lsof not available, try fuser
-        try:
-            subprocess.run(
-                ["fuser", "-k", f"{port}/tcp"],
-                capture_output=True,
-            )
-            return True
-        except FileNotFoundError:
-            return False
+DEFAULT_PORT = _gui_runtime.DEFAULT_PORT
 
 
 def _resolve_source(
@@ -99,9 +84,13 @@ def _emit_json(payload: dict) -> None:
     click.echo(_json.dumps(payload, indent=2))
 
 
-@click.group("gui")
+@click.group("gui", cls=_DefaultGroup, default_cmd_name="open")
 def gui():
-    """Browser-based editor: open, serve, status, stop."""
+    """Browser-based editor: open, serve, status, stop.
+
+    Bare `figrecipe gui [SOURCE]` implicitly runs `gui open` (source
+    optional; opens a blank figure when omitted).
+    """
 
 
 # =========================================================================
@@ -111,12 +100,20 @@ def gui():
 
 @gui.command("serve")
 @click.argument("source", type=click.Path(exists=True), required=False)
-@click.option("--port", type=int, default=5050, help="Server port (default: 5050).")
+@click.option(
+    "--port",
+    type=int,
+    default=DEFAULT_PORT,
+    help=f"Server port (default: {DEFAULT_PORT}).",
+)
 @click.option("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1).")
 @click.option("--dry-run", is_flag=True, default=False, help="Print, don't launch.")
 @click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
 def gui_serve(source, port, host, dry_run, as_json):
     """Run the editor server in the foreground (Ctrl-C to stop).
+
+    Binds exactly the requested port, and refuses to start when that port
+    is taken or when an editor server is already running.
 
     SOURCE is the optional path to a .yaml recipe file or a directory.
     If not provided, creates a new blank figure.
@@ -124,7 +121,7 @@ def gui_serve(source, port, host, dry_run, as_json):
     \b
     Example:
         $ figrecipe gui serve
-        $ figrecipe gui serve figure.yaml --port 5051
+        $ figrecipe gui serve figure.yaml --port 31297
     """
     source_path, working_dir = _resolve_source(source)
     if working_dir is not None:
@@ -142,6 +139,28 @@ def gui_serve(source, port, host, dry_run, as_json):
         else:
             click.echo(f"Would serve editor at http://{host}:{port}.")
         return 0
+
+    current = _gui_runtime.status()
+    if current.get("running"):
+        click.echo(
+            f"Error: editor already running at {current['url']} "
+            f"(pid {current['pid']}).\n"
+            "Open that URL, or stop it first: figrecipe gui stop -y",
+            err=True,
+        )
+        # `return 1` would be silently discarded by Click's standalone mode
+        # (see `gui_open`'s comment below) — raise explicitly.
+        raise SystemExit(1)
+    if not _port_is_free(host, port):
+        holder = _port_holder(port)
+        held_by = f"\nHeld by: {holder}" if holder else ""
+        click.echo(
+            f"Error: port {port} is already in use on {host}.{held_by}\n"
+            "Rerun on another port (--port <other>), free the port, or stop a "
+            "stray editor: figrecipe gui stop -y",
+            err=True,
+        )
+        raise SystemExit(1)
 
     import os
 
@@ -197,7 +216,12 @@ def _autoserve(source: Optional[str], port: int, host: str) -> dict:
 
 @gui.command("open")
 @click.argument("source", type=click.Path(exists=True), required=False)
-@click.option("--port", type=int, default=5050, help="Server port (default: 5050).")
+@click.option(
+    "--port",
+    type=int,
+    default=DEFAULT_PORT,
+    help=f"Server port (default: {DEFAULT_PORT}).",
+)
 @click.option("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1).")
 @click.option("--no-browser", is_flag=True, default=False, help="Don't open browser.")
 @click.option(
@@ -217,7 +241,7 @@ def gui_open(source, port, host, no_browser, desktop, dry_run, as_json):
     \b
     Example:
         $ figrecipe gui open
-        $ figrecipe gui open figure.yaml --port 5051
+        $ figrecipe gui open figure.yaml --port 31297
         $ figrecipe gui open --desktop
     """
     source_path, working_dir = _resolve_source(source)
@@ -358,7 +382,7 @@ def gui_stop(dry_run, yes, as_json):
 
 @click.command("start-gui", hidden=True)
 @click.argument("source", type=click.Path(exists=True), required=False)
-@click.option("--port", type=int, default=5050)
+@click.option("--port", type=int, default=DEFAULT_PORT)
 @click.option("--host", default="127.0.0.1")
 @click.option("--no-browser", is_flag=True, default=False)
 @click.option("--desktop", is_flag=True, default=False)

--- a/src/figrecipe/_cli/_gui_click.py
+++ b/src/figrecipe/_cli/_gui_click.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/figrecipe/_cli/_gui_click.py
+
+"""Generic Click/networking helpers used by `_gui.py`.
+
+Split out of `_gui.py` purely to keep that module under the project's
+512-line file-size convention -- nothing here is figrecipe-specific
+(the `gui` command wiring, `_resolve_source`, and the Django launch call
+all stay in `_gui.py`).
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+from typing import Optional
+
+import click
+
+
+def _port_is_free(host: str, port: int) -> bool:
+    """True when ``host:port`` can be bound right now."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return False
+    return True
+
+
+def _port_holder(port: int) -> Optional[str]:
+    """Best-effort description of the process listening on ``port``.
+
+    Returns None (never raises) when `ss` isn't available or nothing is
+    found -- this is a diagnostic nicety, not load-bearing.
+    """
+    try:
+        proc = subprocess.run(
+            ["ss", "-ltnp"], capture_output=True, text=True, timeout=3
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    for line in proc.stdout.splitlines():
+        if f":{port} " in line:
+            _, _, users = line.partition("users:")
+            return (users.strip() or line.strip()) or None
+    return None
+
+
+def _kill_port(port: int) -> bool:
+    """Kill process occupying the given port. Returns True if killed.
+
+    Legacy helper retained ONLY for `_gui.py`'s deprecated `start-gui
+    --force` alias -- the `gui` group's own lifecycle uses `gui stop`
+    instead.
+    """
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True,
+            text=True,
+        )
+        pids = result.stdout.strip().split()
+        if not pids:
+            return False
+        for pid in pids:
+            subprocess.run(["kill", "-9", pid], capture_output=True)
+        return True
+    except FileNotFoundError:
+        # lsof not available, try fuser
+        try:
+            subprocess.run(
+                ["fuser", "-k", f"{port}/tcp"],
+                capture_output=True,
+            )
+            return True
+        except FileNotFoundError:
+            return False
+
+
+class _DefaultGroup(click.Group):
+    """A `click.Group` that falls back to a default subcommand.
+
+    Looks at the first NON-option token (skipping any leading `-`/`--`
+    flags) rather than strictly `args[0]`: when it isn't a registered
+    subcommand name, the WHOLE arg list is treated as belonging to
+    `default_cmd_name` instead of raising an unknown-command error. This is
+    what lets `figrecipe gui figure.yaml` (and a bare `figrecipe gui
+    --dry-run`, no positional at all) keep working -- implicitly `gui open
+    ...` -- alongside the explicit `gui open`/`serve`/`status`/`stop`.
+
+    Known limitation (accepted, matches other default-group CLIs e.g.
+    docker/git plumbing): options meant for the default command must come
+    AFTER the positional, not before it bare (`gui figure.yaml --port 8080`
+    works; `gui --port 8080 figure.yaml` does not, since the first
+    non-option token, "figure.yaml", is never reached when an earlier `-`
+    token was already handed to the group's own (empty) option parser).
+    """
+
+    def __init__(self, *args, default_cmd_name: str, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.default_cmd_name = default_cmd_name
+
+    def parse_args(self, ctx, args):
+        # A bare `-h`/`--help` (with no other positional) must show the
+        # GROUP's own help (listing open/serve/status/stop), not silently
+        # default to `open --help` -- so leave it untouched and let click's
+        # normal group parsing handle it.
+        if any(a in ("-h", "--help") for a in args):
+            return super().parse_args(ctx, args)
+        first_non_option = next((a for a in args if not a.startswith("-")), None)
+        if first_non_option is None or first_non_option not in self.commands:
+            args = [self.default_cmd_name, *args]
+        return super().parse_args(ctx, args)
+
+
+# EOF

--- a/src/figrecipe/_cli/_gui_runtime.py
+++ b/src/figrecipe/_cli/_gui_runtime.py
@@ -40,6 +40,13 @@ from typing import Optional, Union
 
 PathLike = Union[str, Path]
 
+#: figrecipe's fixed slot in the fleet-wide GUI port scheme (figrecipe=31296,
+#: scholar=31297, writer=31298, todo=31299). The GUI binds exactly this port
+#: (or an explicit ``--port``) and fails loud when it is taken — it never
+#: silently drifts to the next free port (see
+#: scitex-writer#312 for the incident this pattern fixes).
+DEFAULT_PORT = 31296
+
 # "source" (not "project") to match figrecipe's own CLI argument semantics
 # (a .yaml recipe path, a bundle/directory, or None for a blank figure).
 _STATE_FIELDS = ("pid", "port", "host", "source", "started_at")

--- a/src/figrecipe/_cli/_main.py
+++ b/src/figrecipe/_cli/_main.py
@@ -105,6 +105,34 @@ def _print_command_help(cmd, prefix: str, parent_ctx) -> None:
             _print_command_help(sub_cmd, f"{prefix} {sub_name}", sub_ctx)
 
 
+#: Console-script name -> (GUI page title, favicon hex color). Consumer
+#: packages (scitex-plt today; scitex-scholar/etc. potentially later) alias
+#: this same CLI/Django app under their own entry point
+#: (`[project.scripts]` -> `figrecipe._cli:main`, see figrecipe's own
+#: pyproject.toml and scitex-plt's) -- this is the one place that tells
+#: them apart, so branding is set here rather than forked per-consumer.
+_CONSUMER_BRANDING = {
+    "scitex-plt": ("SciTeX Plot", "#001f3f"),  # navy
+}
+
+
+def _apply_consumer_branding(prog_name: str) -> None:
+    """Set FIGRECIPE_APP_LABEL/FIGRECIPE_FAVICON_COLOR for aliased consumers.
+
+    Read by `_django.views.editor_page` when it renders the GUI shell.
+    `setdefault` so an explicit env override (e.g. tests, a future
+    `--title` flag) always wins over this program-name inference.
+    """
+    import os
+
+    branding = _CONSUMER_BRANDING.get(prog_name)
+    if branding is None:
+        return
+    label, favicon_color = branding
+    os.environ.setdefault("FIGRECIPE_APP_LABEL", label)
+    os.environ.setdefault("FIGRECIPE_FAVICON_COLOR", favicon_color)
+
+
 @click.group(
     cls=CategorizedGroup,
     invoke_without_command=True,
@@ -132,6 +160,7 @@ def main(
     # Stash --json so subcommands can read it via ctx.obj
     ctx.ensure_object(dict)
     ctx.obj["as_json"] = as_json
+    _apply_consumer_branding(ctx.info_name)
 
     if version:
         click.echo(f"figrecipe {__version__}")

--- a/src/figrecipe/_dev/browser/_recorder.py
+++ b/src/figrecipe/_dev/browser/_recorder.py
@@ -38,7 +38,7 @@ class DemoRecorder(ABC):
     duration_target : int
         Target duration in seconds.
     url : str
-        URL to navigate to (default: http://127.0.0.1:5050).
+        URL to navigate to (default: http://127.0.0.1:31296).
     output_dir : Path
         Directory for output files.
 
@@ -61,7 +61,7 @@ class DemoRecorder(ABC):
     title: str = "Demo"
     demo_id: str = ""  # e.g., "01" for numbered output filenames
     duration_target: int = 10
-    url: str = "http://127.0.0.1:5050"
+    url: str = "http://127.0.0.1:31296"
     output_dir: Path = Path("examples/demo_movie/outputs")
 
     def __init__(

--- a/src/figrecipe/_django/templates/figrecipe/standalone.html
+++ b/src/figrecipe/_django/templates/figrecipe/standalone.html
@@ -1,6 +1,7 @@
 {% extends "scitex_ui/standalone_shell.html" %}
 {% load static %}
 {% block extra_css %}
+    {% if favicon_href %}<link rel="icon" href="{{ favicon_href }}">{% endif %}
     <link rel="stylesheet"
           crossorigin
           href="{% static 'figrecipe/assets/index.css' %}">

--- a/src/figrecipe/_django/views.py
+++ b/src/figrecipe/_django/views.py
@@ -81,6 +81,22 @@ _NO_EDITOR_ENDPOINTS = {
 }
 
 
+def _favicon_data_uri(hex_color: str) -> str:
+    """Build a `data:` URI for a plain rounded-square favicon in `hex_color`.
+
+    No image asset needed — generated inline so per-brand favicons (see
+    FIGRECIPE_FAVICON_COLOR below) don't require shipping a new static file
+    per consumer package.
+    """
+    from urllib.parse import quote
+
+    svg = (
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>"
+        f"<rect width='100' height='100' rx='20' fill='{hex_color}'/></svg>"
+    )
+    return f"data:image/svg+xml,{quote(svg)}"
+
+
 def editor_page(request):
     """Serve the React SPA inside the scitex-ui workspace shell."""
     import os
@@ -91,13 +107,22 @@ def editor_page(request):
     try:
         working_dir = os.environ.get("FIGRECIPE_WORKING_DIR", "")
         working_dir_name = Path(working_dir).name if working_dir else "Files"
+        # Consumer packages that alias this same CLI/Django app under their
+        # own console-script (e.g. scitex-plt) can rebrand the page title
+        # and favicon by setting these two env vars before launching the
+        # editor (see figrecipe._cli._main's program-name detection) rather
+        # than forking the template.
+        favicon_color = os.environ.get("FIGRECIPE_FAVICON_COLOR", "")
         html = render_to_string(
             "figrecipe/standalone.html",
             {
                 "app_name": "figrecipe",
-                "app_label": "FigRecipe Editor",
+                "app_label": os.environ.get("FIGRECIPE_APP_LABEL", "FigRecipe Editor"),
                 "working_dir": working_dir,
                 "working_dir_name": working_dir_name,
+                "favicon_href": (
+                    _favicon_data_uri(favicon_color) if favicon_color else ""
+                ),
             },
             request=request,
         )

--- a/src/figrecipe/_editor/__init__.py
+++ b/src/figrecipe/_editor/__init__.py
@@ -109,7 +109,7 @@ def _resolve_style(style):
 def gui(
     source: Optional[Union[str, Path]] = None,
     style: Optional[Union[str, Dict[str, Any]]] = None,
-    port: int = 5050,
+    port: int = 31296,
     host: str = "127.0.0.1",
     open_browser: bool = True,
     hot_reload: bool = False,
@@ -125,7 +125,9 @@ def gui(
     style : str or dict, optional
         Style preset name or dict.
     port : int
-        Server port (default: 5050).
+        Server port (default: 31296 — figrecipe's reserved port in the
+        scitex-dev 3129X per-package GUI scheme; see
+        scitex-todo card figrecipe-gui-cli-noun-verb-normalize-20260712).
     host : str
         Host to bind (default: "127.0.0.1").
     open_browser : bool

--- a/tests/figrecipe/_cli/test__gui.py
+++ b/tests/figrecipe/_cli/test__gui.py
@@ -222,3 +222,188 @@ class TestGuiStop:
         runner.invoke(main, args)
         # Assert
         assert isolated_state.exists()
+
+
+class TestGuiDefaultGroup:
+    """`gui` falls back to `open` when the first token isn't a known verb."""
+
+    def test_bare_source_dry_run_resolves_to_open(self, runner, tmp_path):
+        # Arrange
+        source = tmp_path / "figure.yaml"
+        source.write_text("")
+        args = ["gui", str(source), "--dry-run", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload["would_open"]
+
+    def test_bare_source_dry_run_carries_source_path(self, runner, tmp_path):
+        # Arrange
+        source = tmp_path / "figure.yaml"
+        source.write_text("")
+        args = ["gui", str(source), "--dry-run", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload["source"] == str(source)
+
+    def test_bare_no_args_dry_run_resolves_to_open(self, runner):
+        # Arrange
+        args = ["gui", "--dry-run", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload["would_open"]
+
+    def test_explicit_serve_verb_still_resolves_to_serve(self, runner, tmp_path):
+        # Arrange
+        source = tmp_path / "figure.yaml"
+        source.write_text("")
+        args = ["gui", "serve", str(source), "--dry-run", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload["would_serve"]
+
+    def test_explicit_status_verb_still_resolves_to_status(
+        self, runner, isolated_state
+    ):
+        # Arrange
+        args = ["gui", "status", "--json"]
+        # Act
+        result = runner.invoke(main, args)
+        payload = json.loads(result.output)
+        # Assert
+        assert payload == {"running": False}
+
+    def test_bare_help_shows_group_help_not_open_help(self, runner):
+        # Arrange: --help must never silently default to `open --help`.
+        args = ["gui", "--help"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert "serve" in result.output and "status" in result.output
+
+
+class TestGuiServeBindOrFail:
+    """`gui serve` never silently drifts to a different port than requested."""
+
+    def test_refuses_when_port_already_bound(self, runner, isolated_state):
+        # Arrange: hold a real socket on an ephemeral port first.
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        held_port = sock.getsockname()[1]
+        args = ["gui", "serve", "--port", str(held_port)]
+        # Act
+        try:
+            result = runner.invoke(main, args)
+        finally:
+            sock.close()
+        # Assert
+        assert result.exit_code == 1
+
+    def test_refuses_when_port_already_bound_message(self, runner, isolated_state):
+        # Arrange
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        held_port = sock.getsockname()[1]
+        args = ["gui", "serve", "--port", str(held_port)]
+        # Act
+        try:
+            result = runner.invoke(main, args)
+        finally:
+            sock.close()
+        # Assert
+        assert "already in use" in result.output
+
+    def test_refuses_when_port_taken_leaves_no_state_file(self, runner, isolated_state):
+        # Arrange
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        held_port = sock.getsockname()[1]
+        args = ["gui", "serve", "--port", str(held_port)]
+        # Act
+        try:
+            runner.invoke(main, args)
+        finally:
+            sock.close()
+        # Assert: no silent instance is ever recorded as running.
+        assert not isolated_state.exists()
+
+    def test_refuses_when_already_recorded_running(self, runner, isolated_state):
+        # Arrange: a live pid (our own test process) recorded as running.
+        _gui_runtime.write_state(os.getpid(), 31296, "127.0.0.1", None, isolated_state)
+        args = ["gui", "serve"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert result.exit_code == 1
+
+    def test_refuses_when_already_recorded_running_message(
+        self, runner, isolated_state
+    ):
+        # Arrange
+        _gui_runtime.write_state(os.getpid(), 31296, "127.0.0.1", None, isolated_state)
+        args = ["gui", "serve"]
+        # Act
+        result = runner.invoke(main, args)
+        # Assert
+        assert "already running" in result.output
+
+
+class TestGuiConsumerBranding:
+    """Consumer console-scripts (e.g. scitex-plt) get a rebranded GUI title/favicon."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_branding_env(self):
+        for key in ("FIGRECIPE_APP_LABEL", "FIGRECIPE_FAVICON_COLOR"):
+            os.environ.pop(key, None)
+        yield
+        for key in ("FIGRECIPE_APP_LABEL", "FIGRECIPE_FAVICON_COLOR"):
+            os.environ.pop(key, None)
+
+    def test_scitex_plt_prog_name_sets_app_label(self, runner):
+        # Arrange
+        args = ["--version"]
+        # Act
+        runner.invoke(main, args, prog_name="scitex-plt")
+        # Assert
+        assert os.environ.get("FIGRECIPE_APP_LABEL") == "SciTeX Plot"
+
+    def test_scitex_plt_prog_name_sets_favicon_color(self, runner):
+        # Arrange
+        args = ["--version"]
+        # Act
+        runner.invoke(main, args, prog_name="scitex-plt")
+        # Assert
+        assert os.environ.get("FIGRECIPE_FAVICON_COLOR") == "#001f3f"
+
+    def test_figrecipe_prog_name_sets_no_branding(self, runner):
+        # Arrange
+        args = ["--version"]
+        # Act
+        runner.invoke(main, args, prog_name="figrecipe")
+        # Assert
+        assert os.environ.get("FIGRECIPE_APP_LABEL") is None
+
+    def test_existing_env_override_wins_over_inference(self, runner):
+        # Arrange
+        os.environ["FIGRECIPE_APP_LABEL"] = "Custom Title"
+        args = ["--version"]
+        # Act
+        runner.invoke(main, args, prog_name="scitex-plt")
+        # Assert
+        assert os.environ.get("FIGRECIPE_APP_LABEL") == "Custom Title"


### PR DESCRIPTION
## Summary — operator top priority, 3 related fixes to the PR #284 gui group

1. **Port**: default changed 5050 -> 31296 (figrecipe's reserved slot in the corrected scitex-dev 3129X per-package scheme; 5050 collided live with scitex-writer, discovered while starting a standalone GUI). `gui serve` now binds the requested port or fails loud -- never silently drifts to the next free port -- and refuses a second instance when one is already tracked running. Ported from scitex-writer#312, the incident that established this pattern.

2. **DefaultGroup**: `gui` is now a DefaultGroup (`_gui_click._DefaultGroup`) so a bare `figrecipe gui [SOURCE]` still resolves to `gui open` (matching the old flat `start-gui` ergonomic) alongside the explicit `gui open/serve/status/stop` subcommands. Required because `scitex-plt` (a console-script alias pointing at this same CLI) invokes `gui serve` directly -- that failed before this fix since "serve" was read as a SOURCE path.

3. **Consumer branding**: `scitex-plt`'s GUI now shows its own page title (\"SciTeX Plot\") and a navy favicon via `FIGRECIPE_APP_LABEL`/`FIGRECIPE_FAVICON_COLOR` env vars, set from the invoked program name (`ctx.info_name`) -- the one signal that distinguishes `figrecipe` from `scitex-plt` since they share one entry point.

`_gui.py` split into `_gui.py` + `_gui_click.py` (generic Click/networking helpers) to stay under this project's 512-line file convention.

Closes scitex-todo card `figrecipe-gui-cli-noun-verb-normalize-20260712` (follow-up to #284).

## Test plan
- [x] 15 new tests: DefaultGroup fallback (bare source, no-args, --help-not-hijacked), bind-or-fail (real socket held), idempotent-running-refusal, consumer branding env injection -- all passing
- [x] 156/156 total in the affected suite (test__gui.py / test__gui_runtime.py / test__main.py), no regressions
- [x] `scitex-dev ecosystem audit-python-apis` -- clean
- [x] Manually verified via real CLI invocation: `figrecipe gui --help` (group help), `figrecipe gui figure.yaml --dry-run` (implicit open), `figrecipe gui serve --dry-run` (explicit verb), `figrecipe gui --dry-run --json` (bare, no positional)