### PR TITLE
fix(ci): create the GitHub Release via API action, not the runner's gh CLI

### DIFF
--- a/.github/workflows/pypi-publish-and-github-release-on-tag.yml
+++ b/.github/workflows/pypi-publish-and-github-release-on-tag.yml
@@ -165,14 +165,27 @@ jobs:
           if [ ! -s release-notes.md ]; then
             echo "Release v${VERSION}. See CHANGELOG.md for details." > release-notes.md
           fi
+      # The `release` job runs on the self-hosted Spartan runner, where
+      # $HOME=/home/ywatanabe is shared with the operator's account. `gh` loads
+      # that account's machine-local config at startup, and there it ABORTS:
+      #   failed to create root command: failed to read configuration:
+      #   invalid config file /home/ywatanabe/.config/gh/config.yml: invalid yaml
+      # That happens during config-load, BEFORE gh ever reads GH_TOKEN -- which
+      # is why the token below (already the correct built-in one) never helped,
+      # and why no PAT would help either. The cure is to stop depending on the
+      # runner's `gh` at all: this JS action calls the GitHub Releases API
+      # directly with the built-in per-run ${{ github.token }} that Actions
+      # injects (the job already grants `permissions: contents: write`).
+      # Same fix as scitex-ui#68 / scitex-writer / scitex-todo / scitex-dev /
+      # scitex-agent-container (ci-gh-selfhosted-release-guard).
       - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ needs.build.outputs.version }}" \
-            --title "${{ needs.build.outputs.version }}" \
-            --notes-file release-notes.md \
-            dist/*
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.build.outputs.version }}
+          name: ${{ needs.build.outputs.version }}
+          body_path: release-notes.md
+          files: dist/*
+          fail_on_unmatched_files: true
 
   sync-main:
     # Open develop→main PR so main always equals the latest released
@@ -191,6 +204,15 @@ jobs:
       - name: Open develop→main PR if diverged
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same self-hosted $HOME=/home/ywatanabe problem as the release job:
+          # gh aborts while parsing the operator's machine-local
+          # ~/.config/gh/config.yml ("invalid yaml") before it ever reads
+          # GH_TOKEN. These are genuine gh-CLI operations (pr list/create/merge)
+          # with no drop-in JS action, so rather than remove gh we point it at a
+          # per-job config dir -- exactly as scitex-math#5 does for
+          # GIT_CONFIG_GLOBAL. gh then starts clean and authenticates from the
+          # built-in GH_TOKEN above. No PAT involved.
+          GH_CONFIG_DIR: ${{ runner.temp }}/gh
         run: |
           set -e
           git fetch origin main


### PR DESCRIPTION
## Symptom

The `release` job fails at **Create GitHub Release** on the self-hosted Spartan
runner. `publish` has already succeeded by then, so PyPI ships but the GitHub
Release page is never created.

## Root cause (this is NOT a token problem)

From the live failure log:

```
failed to create root command: failed to read configuration:
invalid config file /home/ywatanabe/.config/gh/config.yml: invalid yaml
```

The self-hosted runner executes as the operator's account, so `$HOME` is
`/home/ywatanabe` and `gh` picks up that account's **machine-local** config.
That config is currently corrupt, and `gh` aborts while parsing it — during
**config-load, before it ever reads `GH_TOKEN`**.

This matters, because the natural assumption is "the token expired, mint a PAT."
It is worth being precise:

* The step **already passed the correct token** (`GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
  — the built-in, per-run token Actions injects automatically).
* `gh` never got far enough to use it. **No token — built-in or PAT — could
  have fixed this**, because the failure precedes authentication entirely.

So the bug is the dependency on the runner's `gh` CLI and its machine-local
state, not on any credential.

## Fix

Drop the `gh` dependency for this step. `softprops/action-gh-release@v2` is a JS
action that calls the GitHub Releases API directly using the built-in per-run
`${{ github.token }}`. It reads no machine-local config, so runner state cannot
break it. The job already grants the `permissions: contents: write` it needs, so
that is unchanged.

**No secret is created, requested, or stored by this PR.**

Same fix already merged in scitex-ui#68 and applied in scitex-writer /
scitex-todo / scitex-dev / scitex-agent-container (`ci-gh-selfhosted-release-guard`);
this completes the batch.

## Related

`scitex-math#5` fixes the same class of bug from the other direction — the
shared `$HOME` on the Spartan runner leaking the operator's `~/.gitconfig` into
CI — by redirecting the config to a per-job temp path. The general lesson: on
these runners, anything that reads `$HOME` dotfiles is a latent CI failure.


## Also in this PR: the same bug in `sync-main`

`sync-main` ("Open develop→main PR if diverged") runs on the same self-hosted
runner and shells out to `gh pr list/create/merge`, so it dies for the identical
reason — and it failed in the same run. Those are genuine `gh` operations with
no drop-in JS-action equivalent, so instead of removing `gh` this points it at a
per-job config directory (`GH_CONFIG_DIR: ${{ runner.temp }}/gh`). `gh` then
starts from a clean config and authenticates from the built-in `GH_TOKEN` it is
already given. This mirrors the `GIT_CONFIG_GLOBAL` isolation in scitex-math#5.
Again: no PAT.
