### PR TITLE
fix(ci): make SIF scratch TMPDIR unique per run

### DIFF
--- a/.github/ci/build-in-sif.sh
+++ b/.github/ci/build-in-sif.sh
@@ -30,9 +30,15 @@ export LC_ALL=C.UTF-8 LANG=C.UTF-8
 
 # Writable scratch (the runner's TMPDIR=~/.cache/tmp is a host path that does
 # NOT resolve inside the container). Node-local /tmp is writable + ephemeral.
-TMPDIR="/tmp/build-figrecipe-$V"
+#
+# RUN-UNIQUE (incident 2026-07-12, same fix as run-in-sif.sh): a fixed
+# per-version path let a stuck leftover from a prior run block this run's
+# `rm -rf` with "Directory not empty". Suffix with the run id so this run's
+# path can never collide with a stale one; old-path cleanup is best-effort.
+RUN_TAG="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-$$}"
+TMPDIR="/tmp/build-figrecipe-$V-$RUN_TAG"
 export TMPDIR
-rm -rf "$TMPDIR"
+rm -rf "$TMPDIR" 2>/dev/null || echo "warning: pre-existing $TMPDIR not fully removable, continuing (run-unique path avoids reusing it)"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 
 # The compute-node $HOME is RO inside the container — point every cache the

--- a/.github/ci/publish-in-sif.sh
+++ b/.github/ci/publish-in-sif.sh
@@ -49,9 +49,13 @@ echo "=== dist to publish ==="
 ls -l dist
 
 # --- writable scratch (compute-node HOME is RO inside the container) ---
-TMPDIR="/tmp/publish-figrecipe-$V"
+# RUN-UNIQUE (incident 2026-07-12, same fix as run-in-sif.sh/build-in-sif.sh):
+# suffix with the run id so this run's path can never collide with a stuck
+# leftover from a prior run; old-path cleanup is best-effort, not fatal.
+RUN_TAG="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-$$}"
+TMPDIR="/tmp/publish-figrecipe-$V-$RUN_TAG"
 export TMPDIR
-rm -rf "$TMPDIR"
+rm -rf "$TMPDIR" 2>/dev/null || echo "warning: pre-existing $TMPDIR not fully removable, continuing (run-unique path avoids reusing it)"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 export UV_CACHE_DIR="$TMPDIR/uv-cache"
 export XDG_CACHE_HOME="$TMPDIR"

--- a/.github/ci/run-in-sif.sh
+++ b/.github/ci/run-in-sif.sh
@@ -30,8 +30,20 @@ export LC_ALL=C.UTF-8 LANG=C.UTF-8
 # path that does NOT resolve inside the container; tests (tmp_path) and the
 # install target both need a working, writable tmp. Node-local /tmp is writable
 # + ephemeral and per-version-isolated so concurrent matrix legs don't collide.
-export TMPDIR="/tmp/ci-figrecipe-$V"
-rm -rf "$TMPDIR"
+#
+# RUN-UNIQUE, not just version-unique (incident 2026-07-12): a fixed
+# /tmp/ci-figrecipe-$V path let a killed/OOM'd worker from a PRIOR run leave a
+# file handle open in there, so the next run's `rm -rf` on that same fixed
+# path failed loud with "Directory not empty" and took the whole leg down —
+# hit twice in one day, on two different python legs, during the v0.30.0
+# release. Suffixing with the run id makes this run's path impossible to
+# collide with any leftover from a previous one; the stale-path cleanup below
+# is now best-effort so a still-stuck prior directory WARNS instead of
+# aborting a run that no longer depends on it.
+RUN_TAG="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-$$}"
+TMPDIR="/tmp/ci-figrecipe-$V-$RUN_TAG"
+export TMPDIR
+rm -rf "$TMPDIR" 2>/dev/null || echo "warning: pre-existing $TMPDIR not fully removable, continuing (run-unique path avoids reusing it)"
 mkdir -p "$TMPDIR/site" "$TMPDIR/uv-cache"
 
 # The HPC compute-node $HOME is READ-ONLY inside the container, so uv/pip cannot


### PR DESCRIPTION
## Summary
- `run-in-sif.sh`/`build-in-sif.sh`/`publish-in-sif.sh` all used a fixed `/tmp/<role>-figrecipe-<pyver>` scratch path per matrix leg.
- Hit twice in one day during the v0.30.0 release, on two different python legs: `rm -rf "$TMPDIR"` failed with `Directory not empty` because a killed/OOM'd worker from a prior run left something un-removable in there, taking the whole CI leg down.
- Both times were "fixed" by re-running the job, which just got lucky with a clean node next time -- not a real fix.

## Fix
- Suffix `TMPDIR` with `$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT` (falls back to a local pid for manual/non-Actions runs) so this run's scratch path can never collide with a leftover from a previous run.
- Make the stale-path cleanup best-effort (`warn`, don't abort) since a run on its own unique path no longer depends on that cleanup succeeding.

## Test plan
- [x] `bash -n` on all three modified scripts.
- [x] `scitex-dev ecosystem audit-python-apis figrecipe` clean.
- [x] Pre-commit hook chain passed on commit.
- Reported to scitex-dev in case other packages copied the same fixed-TMPDIR pattern from this template.