### PR TITLE
fix(django): use scitex_app.chat public lazy API instead of private _chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "scipy>=1.7.0",
     "click>=8.0.0",
     "rich>=13.0.0",
-    "scitex-app>=0.2.0",
+    "scitex-app>=0.3.0",
     "scitex-config>=0.3.0",
     "scitex-dev>=0.12.2",
 ]
@@ -59,7 +59,7 @@ dev = [
     "scitex-dev>=0.12.2",
     # Mirror runtime extras so `pip install -e .[dev]` runs the full suite.
     # Tests import these unguarded; PS210 audit invariants.
-    "scitex-app>=0.1.0",
+    "scitex-app>=0.3.0",
     "scitex-ui>=0.1.0",
     "scitex-logging",
     "scitex-pd",
@@ -83,7 +83,7 @@ seaborn = [
     "pandas>=1.3.0",
 ]
 scitex = [
-    "scitex-app>=0.1.0",
+    "scitex-app>=0.3.0",
     "scitex-ui>=0.1.0",
     "scitex-logging",
     "scitex-pd",
@@ -97,7 +97,7 @@ editor = [
 app = [
     "django>=4.2.0",
     "Pillow>=9.0.0",
-    "scitex-app>=0.1.0",
+    "scitex-app>=0.3.0",
     "scitex-ui>=0.1.0",
 ]
 desktop = [

--- a/src/figrecipe/_django/handlers/__init__.py
+++ b/src/figrecipe/_django/handlers/__init__.py
@@ -5,17 +5,14 @@
 Exports HANDLERS dict for the catch-all dispatcher.
 """
 
-# Chat: single source of truth from scitex-app (no figrecipe-specific fallback)
-from scitex_app._chat import chat_stream_view as _raw_chat_stream
-from scitex_app._chat import (
-    session_detail_view as _raw_session_detail,
-)
-from scitex_app._chat import (
-    session_list_view as _raw_session_list,
-)
-from scitex_app._chat import (
-    session_messages_view as _raw_session_messages,
-)
+# Chat: single source of truth from scitex-app (no figrecipe-specific fallback).
+# `scitex_app.chat` is a lazily-exposed package attribute (PEP 562
+# `__getattr__`), not a real importable submodule -- `from scitex_app.chat
+# import X` raises ModuleNotFoundError since that form requires the import
+# system to resolve `scitex_app.chat` as an actual submodule. `from
+# scitex_app import chat` works: it falls back to attribute lookup on the
+# already-imported `scitex_app` package.
+from scitex_app import chat as _chat
 
 from .annotation import (
     handle_get_captions,
@@ -82,6 +79,11 @@ from .style import (
     handle_style,
     handle_switch_theme,
 )
+
+_raw_chat_stream = _chat.chat_stream_view
+_raw_session_detail = _chat.session_detail_view
+_raw_session_list = _chat.session_list_view
+_raw_session_messages = _chat.session_messages_view
 
 
 def handle_api_chat_stream(request, editor):


### PR DESCRIPTION
## Summary
- `figrecipe/_django/handlers/__init__.py` hard-imported chat views from the **private** `scitex_app._chat` module. scitex-app 0.3.0 ships them under a public, lazily-exposed `scitex_app.chat` surface with full API parity (root cause per scitex-app: their own docs/scaffolds were teaching the private-module import; fixed on their side in scitex-app #48).
- Switched to the public API and bumped the `scitex-app` floor `>=0.1.0/0.2.0` -> `>=0.3.0` across all four `pyproject.toml` occurrences.

## Note on the import form
`scitex_app.chat` is a package-level `__getattr__` lazy attribute, **not** a real importable submodule -- so `from scitex_app.chat import X` raises `ModuleNotFoundError`. The working form is `from scitex_app import chat` (bare `from pkg import name` falls back to attribute lookup), then `chat.X`. Verified against a fresh scitex-app 0.3.0 install.

`_django/apps.py`'s `ScitexAppChatConfig.name = "scitex_app._chat"` is left unchanged -- that's a Django AppConfig pointing at the real physical package containing the ChatSession/ChatMessage models, which the lazy re-export layer cannot serve.

## Test plan
- [x] Smoke: `figrecipe._django.handlers.HANDLERS` imports cleanly (50 entries) under a configured Django with scitex-app 0.3.0.
- [x] `scitex-dev ecosystem audit-python-apis figrecipe` clean.
- [x] ruff / ruff-format / pre-commit chain passed on commit.