### PR TITLE
fix(django): dont 500 the file tree when one file escapes the root

### DIFF
--- a/src/figrecipe/_django/handlers/_files_tree.py
+++ b/src/figrecipe/_django/handlers/_files_tree.py
@@ -62,6 +62,15 @@ def _find_default_working_dir():
     return Path.cwd()
 
 
+# A file the backend refuses to read is simply "not a recipe" -- never a
+# server error. scitex-app's FileSystemBackend raises ValueError("Path
+# traversal detected") when a listed path resolves outside the root (e.g. a
+# symlinked node_modules/@scitex/ui -> ../../scitex-ui in the figrecipe source
+# tree). Without ValueError here, that single unreadable entry propagated out
+# of the per-file recipe check and 500'd the whole /api/files tree.
+_UNREADABLE = (OSError, UnicodeDecodeError, FileNotFoundError, ValueError)
+
+
 def _is_figrecipe_yaml(path: Path, files_backend=None) -> bool:
     """Check if a YAML file is a figrecipe recipe (has figure: and axes: keys)."""
     try:
@@ -70,7 +79,7 @@ def _is_figrecipe_yaml(path: Path, files_backend=None) -> bool:
         else:
             text = path.read_text(errors="ignore")[:2048]
         return "figure:" in text and "axes:" in text
-    except (OSError, UnicodeDecodeError, FileNotFoundError):
+    except _UNREADABLE:
         return False
 
 
@@ -79,7 +88,7 @@ def _is_figrecipe_yaml_rel(rel_path: str, files_backend) -> bool:
     try:
         text = files_backend.read(rel_path)[:2048]
         return "figure:" in text and "axes:" in text
-    except (OSError, UnicodeDecodeError, FileNotFoundError):
+    except _UNREADABLE:
         return False
 
 

--- a/tests/figrecipe/_django/handlers/test__files_tree.py
+++ b/tests/figrecipe/_django/handlers/test__files_tree.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression tests for the file-tree recipe-detection helpers.
+
+Guards the 2026-07-13 fix: a listed file the backend refuses to read (e.g. a
+symlinked node_modules/@scitex/ui escaping the root, which scitex-app's
+FileSystemBackend rejects with ``ValueError("Path traversal detected")``) must
+be treated as "not a recipe", never propagate out and 500 the whole
+``/api/files`` tree.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+django = pytest.importorskip("django")
+
+
+@pytest.fixture(scope="module")
+def _django_ready():
+    # Importing the handlers package (via _files_tree) wires Django models
+    # from scitex-app's chat app, so settings must be configured first.
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "figrecipe._django.settings")
+    django.setup()
+
+
+class _RaisingBackend:
+    """Files backend whose read() raises, mimicking the traversal guard."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def read(self, path):
+        raise self._exc
+
+    def exists(self, path):
+        return False
+
+
+def test_is_figrecipe_yaml_rel_returns_false_on_value_error(_django_ready):
+    # Arrange -- backend rejects the path like scitex-app's traversal guard.
+    from figrecipe._django.handlers._files_tree import _is_figrecipe_yaml_rel
+
+    backend = _RaisingBackend(ValueError("Path traversal detected: 'x'"))
+    # Act
+    result = _is_figrecipe_yaml_rel("escaping/symlink.yml", backend)
+    # Assert
+    assert result is False
+
+
+def test_is_figrecipe_yaml_rel_returns_false_on_os_error(_django_ready):
+    # Arrange -- pre-existing behaviour must be preserved.
+    from figrecipe._django.handlers._files_tree import _is_figrecipe_yaml_rel
+
+    backend = _RaisingBackend(OSError("boom"))
+    # Act
+    result = _is_figrecipe_yaml_rel("unreadable.yml", backend)
+    # Assert
+    assert result is False
+
+
+def test_enrich_tree_skips_value_error_file_without_raising(_django_ready):
+    # Arrange -- a one-file tree whose only entry escapes the root.
+    from figrecipe._django.handlers._files_tree import _enrich_tree
+
+    backend = _RaisingBackend(ValueError("Path traversal detected: 'x'"))
+    tree = [{"type": "file", "name": "codecov.yml", "path": "node_modules/x.yml"}]
+    # Act -- must not propagate the ValueError up to the API dispatcher.
+    enriched = _enrich_tree(tree, Path("/tmp"), None, backend)
+    # Assert
+    assert enriched == []
+
+
+# EOF


### PR DESCRIPTION
## Summary
- `scitex-plt gui serve` in the figrecipe source repo returned **500 on GET /api/files**, repeatedly logging `ValueError: Path traversal detected: src/figrecipe/_django/frontend/node_modules/@scitex/ui/codecov.yml`.
- Root cause: `node_modules/@scitex/ui` is a symlink escaping the project root. scitex-app FileSystemBackend correctly raises `ValueError` to block the traversal, but figrecipe _files_tree only caught `(OSError, UnicodeDecodeError, FileNotFoundError)`, so that one unreadable entry propagated out and 500 the entire recursive tree.
- Fix: a file the backend refuses to read is simply not a recipe -> return False and skip it. Added `ValueError` to the caught tuple in both recipe-detection helpers.

## Test plan
- [x] New `test__files_tree.py`: rel helper returns False on ValueError (OSError behaviour preserved), and _enrich_tree skips the offending file instead of raising (3 tests, pass).
- [x] scitex-dev audit clean.
- [x] Local pytest-testmon skipped (structurally cannot complete under laptop load); CI matrix is the gate.