### PR TITLE
feat(quality): six-stat annotation doctrine + heatmap colorbar soft lint

### DIFF
--- a/src/figrecipe/_quality/_heatmap_colorbar_checker.py
+++ b/src/figrecipe/_quality/_heatmap_colorbar_checker.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""STX-FM018 heatmap-without-colorbar AST checker.
+
+Companion to the figrecipe six-stat / heatmap-colorbar doctrine leaf
+(``src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md``):
+any 2D heatmap (``imshow``-style plot of a 2D array) MUST ship a colorbar
+with tick labels, an axis label, and units on that label — the same tier
+as figrecipe's existing axis-label/unit requirements elsewhere in this
+lint plugin.
+
+This checker covers the first, staticly-checkable half of that
+requirement: an ``imshow(...)`` call with **no accompanying
+``colorbar(...)`` call anywhere in the same function/module scope**. It
+does not (and, staticly, cannot) verify tick labels / axis label / units
+on the colorbar — that is a runtime/content concern the doctrine leaf
+documents but which is left to review, matching the "doc-only where a
+linter can't reach" acknowledgement in the sister scitex-dev doctrine.
+
+Scope-based, mirroring ``_axis_alignment_checker.AxisAlignmentChecker``:
+a new scope is pushed per function/module, ``imshow`` and ``colorbar``
+calls are tallied per scope, and every ``imshow`` call in a scope with
+zero ``colorbar`` calls anywhere in it is flagged at scope-finalize.
+Matched by method name only (not type-resolved), consistent with the
+rest of this plugin's call-shape heuristics — e.g. ``fig.colorbar(...)``,
+``plt.colorbar(...)``, and ``ax.figure.colorbar(...)`` are all recognised.
+
+figrecipe's imperative ``ax.imshow(...)`` API (``_wrappers/_axes_plots.
+imshow_plot``) does **not** auto-add a colorbar — only the declarative
+YAML/dict plot-spec path does (``_api/_plot_helpers._maybe_add_colorbar``),
+and that path is not Python source an AST checker ever sees. So this rule
+has no false-positive collision with figrecipe's own auto-colorbar
+behaviour for the imperative API scripts actually lint.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import replace as _replace
+
+
+def _scitex_linter_runtime():
+    """Lazily import ``(Issue, _is_allowed_by_comment)`` from scitex-linter.
+
+    Same deferred-import discipline as the other figrecipe checkers (see
+    ``_axis_alignment_checker.py`` for the full rationale).
+    """
+    try:
+        from scitex_dev.linter.checker import Issue, _is_allowed_by_comment
+
+        return Issue, _is_allowed_by_comment
+    except ImportError:  # pragma: no cover
+        return None, None
+
+
+class _HeatmapScope:
+    """Per-scope state: imshow call sites + whether a colorbar was seen."""
+
+    __slots__ = ("imshow_calls", "has_colorbar")
+
+    def __init__(self):
+        self.imshow_calls: list = []
+        self.has_colorbar = False
+
+
+class HeatmapColorbarChecker(ast.NodeVisitor):
+    """STX-FM018 — flag ``imshow(...)`` with no ``colorbar(...)`` in scope."""
+
+    category = "figure"
+
+    def __init__(self, source_lines, config, rule=None):
+        self.source_lines = source_lines
+        self.config = config
+        self.issues: list = []
+        self._rule = rule  # injected by the plugin loader
+        self._scopes: list[_HeatmapScope] = [_HeatmapScope()]
+
+    # -- helpers --------------------------------------------------------
+
+    def _src(self, lineno):
+        if 1 <= lineno <= len(self.source_lines):
+            return self.source_lines[lineno - 1].rstrip()
+        return ""
+
+    def _scope(self):
+        return self._scopes[-1]
+
+    def _emit(self, node):
+        Issue, _is_allowed_by_comment = _scitex_linter_runtime()
+        if Issue is None or self._rule is None:
+            return  # scitex-linter not importable; checker is inert
+        rule = self._rule
+        if rule.id in self.config.disable:
+            return
+        line = self._src(node.lineno)
+        if _is_allowed_by_comment(line, rule.id):
+            return
+        sev = self.config.per_rule_severity.get(rule.id)
+        if sev:
+            rule = _replace(rule, severity=sev)
+        self.issues.append(
+            Issue(rule=rule, line=node.lineno, col=node.col_offset, source_line=line)
+        )
+
+    # -- scope management -------------------------------------------------
+
+    def visit_FunctionDef(self, node):
+        self._scopes.append(_HeatmapScope())
+        self.generic_visit(node)
+        self._finalize_scope()
+        self._scopes.pop()
+
+    def visit_AsyncFunctionDef(self, node):
+        self.visit_FunctionDef(node)
+
+    def visit_Module(self, node):
+        self.generic_visit(node)
+        self._finalize_scope()
+
+    # -- call tracking ----------------------------------------------------
+
+    def visit_Call(self, node):
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            fname = func.attr
+        elif isinstance(func, ast.Name):
+            fname = func.id
+        else:
+            fname = ""
+
+        if fname == "imshow":
+            self._scope().imshow_calls.append(node)
+        elif fname == "colorbar":
+            self._scope().has_colorbar = True
+
+        self.generic_visit(node)
+
+    # -- finalize -----------------------------------------------------------
+
+    def _finalize_scope(self):
+        scope = self._scope()
+        if scope.imshow_calls and not scope.has_colorbar:
+            for node in scope.imshow_calls:
+                self._emit(node)
+
+
+__all__ = ["HeatmapColorbarChecker"]
+
+# EOF

--- a/src/figrecipe/_quality/_linter_plugin.py
+++ b/src/figrecipe/_quality/_linter_plugin.py
@@ -6,6 +6,11 @@ Rule families:
                  → set_xyt; ax.spines[...].set_visible(False) → hide_spines).
 - FM016        — raw-mpl-bypass: raw `plt.subplots`/`plt.figure` figure
                  creation that bypasses figrecipe recording (→ fr.subplots).
+- FM017        — six-stat-annotation-completeness: a stats-shaped annotation
+                 string missing several of the six doctrine fields (n, CI,
+                 method, p, effect, statistic).
+- FM018        — heatmap-without-colorbar: `imshow(...)` with no `colorbar(...)`
+                 call anywhere in the same function/module scope.
 - FIG001       — scientific-figure hygiene (axis-range alignment across subplots).
 - P001-P009    — bare matplotlib calls; suggest scitex/figrecipe tracked variants
                  and flag style-override kwargs.
@@ -199,6 +204,60 @@ def get_plugin():
         requires="figrecipe",
     )
 
+    # FM017 — six-stat-annotation-completeness doctrine (companion to the
+    # scitex-dev "Statistics Completeness Doctrine",
+    # scitex_dev/_skills/scientific/03_reporting_02_statistics-completeness.md,
+    # scitex-ai/scitex-dev#290, operator 2026-07-05): a reported statistic
+    # must carry all six of n / 95% CI / method / p / effect size / test
+    # statistic. Heuristic on literal annotation strings — only strings that
+    # already look like a p-value annotation are considered, and only a
+    # clear multi-field miss fires. category="figure" ⇒ auto-promoted to
+    # ERROR in project-type:research.
+    FM017 = Rule(
+        id="STX-FM017",
+        severity="warning",
+        category="figure",
+        message=(
+            "statistical annotation string looks incomplete — missing "
+            "several of the six required fields (n, CI, method, p, "
+            "effect size, statistic)"
+        ),
+        suggestion=(
+            "Every reported statistic needs all six: n=<count>, a 95% CI, "
+            "the method/test name, the p-value, an effect size, and the "
+            "test statistic (e.g. `t(df)=`). Add the missing fields to the "
+            "annotation text (or move them to the caption / a stats table) — "
+            "see 27_six-stat-annotation-doctrine.md for a compliant example. "
+            "If this string is intentionally partial (e.g. significance "
+            "stars only, full stats reported elsewhere), annotate the line "
+            "with `# stx-allow: STX-FM017`."
+        ),
+    )
+
+    # FM018 — heatmap-colorbar requirement: any 2D heatmap (imshow) must
+    # ship a colorbar (with tick labels, axis label, and units — the
+    # content half is documented, not statically checkable). Flags an
+    # `imshow(...)` call with no `colorbar(...)` call anywhere in the same
+    # function/module scope. category="figure" ⇒ auto-promoted to ERROR in
+    # project-type:research.
+    FM018 = Rule(
+        id="STX-FM018",
+        severity="warning",
+        category="figure",
+        message=(
+            "`imshow(...)` detected with no `colorbar(...)` call in the "
+            "same scope — 2D heatmaps require a colorbar with tick labels, "
+            "an axis label, and units"
+        ),
+        suggestion=(
+            "Add `fig.colorbar(im, ax=ax, label='<quantity> [<units>]')` "
+            "(or `stx.plt.colorbar(...)`) after the `imshow` call, and make "
+            "sure the colorbar keeps its tick labels. If this heatmap "
+            "intentionally has no colorbar, annotate the line with "
+            "`# stx-allow: STX-FM018`."
+        ),
+    )
+
     # ------------------------------------------------------------------
     # FIG: Scientific-figure hygiene rules (FIG001+)
     # FIG001 — multiple subplots that declare different literal axis
@@ -367,6 +426,34 @@ def get_plugin():
     except ImportError:
         pass
 
+    # FM017 six-stat-annotation-completeness checker. Same rule-injection
+    # subclass pattern as _AxisAlignmentChecker above.
+    try:
+        from figrecipe._quality._stat_annotation_fields_checker import (
+            StatAnnotationFieldsChecker,
+        )
+
+        class _StatAnnotationFieldsChecker(StatAnnotationFieldsChecker):  # type: ignore[misc, valid-type]
+            def __init__(self, source_lines, config):
+                super().__init__(source_lines, config, rule=FM017)
+
+        checkers.append(_StatAnnotationFieldsChecker)
+    except ImportError:
+        pass
+
+    # FM018 heatmap-without-colorbar checker. Same rule-injection subclass
+    # pattern as _AxisAlignmentChecker above.
+    try:
+        from figrecipe._quality._heatmap_colorbar_checker import HeatmapColorbarChecker
+
+        class _HeatmapColorbarChecker(HeatmapColorbarChecker):  # type: ignore[misc, valid-type]
+            def __init__(self, source_lines, config):
+                super().__init__(source_lines, config, rule=FM018)
+
+        checkers.append(_HeatmapColorbarChecker)
+    except ImportError:
+        pass
+
     return {
         "rules": [
             FM001,
@@ -381,6 +468,8 @@ def get_plugin():
             FM010,
             FM011,
             FM016,
+            FM017,
+            FM018,
             FIG001,
             P001,
             P002,

--- a/src/figrecipe/_quality/_stat_annotation_fields_checker.py
+++ b/src/figrecipe/_quality/_stat_annotation_fields_checker.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""STX-FM017 six-stat-annotation-completeness AST checker.
+
+Companion to the scitex-dev "Statistics Completeness Doctrine"
+(``scitex_dev/_skills/scientific/03_reporting_02_statistics-completeness.md``,
+landed in scitex-ai/scitex-dev#290, operator-issued 2026-07-05): every
+reported statistic must carry all six of
+
+    n / 95% CI / method (test name) / p-value / effect size / test statistic
+
+or it is incomplete. This checker is the figrecipe-side, figure-annotation
+half of that doctrine: a *soft*, heuristic static check on literal string
+arguments passed to the places figrecipe draws a stats annotation —
+``ax.add_stat_annotation(text=...)`` (the dedicated helper, see
+``_wrappers/_stat_annotation.py``), and the lower-level ``ax.text(...)`` /
+``ax.annotate(...)`` calls a script might use directly for the same purpose.
+
+Heuristic, by design (this is a warning, not a parser):
+
+- The string must look like a stats annotation at all — it is only
+  considered when it contains a p-value marker (``p=0.03`` / ``p<0.001`` /
+  ...). Plain captions/labels with no p-value marker are never flagged,
+  keeping false positives on ordinary text near zero.
+- Once a string passes that gate, each of the six required fields is
+  matched independently and loosely (word-boundary regexes, not a strict
+  grammar). A string needs at least four of the six recognisable markers
+  to be treated as "complete enough" — flagging only fires when *several*
+  fields are clearly missing (e.g. a bare ``"p=0.03"``), never on a string
+  that is merely missing one edge-case field.
+- Only literal string constants are inspected (``ast.Constant``); f-strings
+  and other dynamic expressions are skipped rather than guessed at.
+
+See ``src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md``
+for the full doctrine writeup (the six fields, the italic-symbol
+convention, and the N-vs-n subscript convention) and a compliant example.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import replace as _replace
+
+# Gate: does this string even look like a stats annotation? Also doubles as
+# the "p" marker below (a string that fails this never reaches marker scoring
+# at all, and any string that passes it already has the "p" marker).
+_P_VALUE_MARKER = re.compile(r"p\s*[<=]\s*[0-9.]", re.IGNORECASE)
+
+_MARKERS = {
+    "n": re.compile(r"\bn\s*=\s*\d", re.IGNORECASE),
+    "ci": re.compile(r"\bci\b|\d+\s*%\s*ci", re.IGNORECASE),
+    "method": re.compile(
+        r"(t-test|anova|wilcoxon|mann-whitney|u-test|pearson|spearman|"
+        r"chi-square|chi2|kruskal|regression|correlation)",
+        re.IGNORECASE,
+    ),
+    "p": _P_VALUE_MARKER,
+    "effect": re.compile(r"(effect size|cohen|eta|η|\bd\s*=|\br\s*=)", re.IGNORECASE),
+    "statistic": re.compile(
+        r"(\bt\s*\(|\bf\s*\(|\bu\s*=|\bz\s*=|\bt\s*=|\bf\s*=|chi2\s*=|χ)",
+        re.IGNORECASE,
+    ),
+}
+
+# A string needs >= this many of the six markers to be considered complete.
+_MIN_PRESENT = 4
+
+
+def _present_count(text: str) -> int:
+    return sum(1 for pattern in _MARKERS.values() if pattern.search(text))
+
+
+def _scitex_linter_runtime():
+    """Lazily import ``(Issue, _is_allowed_by_comment)`` from scitex-linter.
+
+    Same deferred-import discipline as the other figrecipe checkers (see
+    ``_axis_alignment_checker.py`` for the full rationale): figrecipe's
+    plugin factory runs *during* ``scitex_dev.linter``'s own import, so a
+    top-level import here would race with that init.
+    """
+    try:
+        from scitex_dev.linter.checker import Issue, _is_allowed_by_comment
+
+        return Issue, _is_allowed_by_comment
+    except ImportError:  # pragma: no cover
+        return None, None
+
+
+def _fname(node: ast.Call):
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+def _string_candidates(node: ast.Call):
+    """Return the string-literal nodes that might carry annotation text.
+
+    - ``ax.text(x, y, s, ...)`` — third positional argument.
+    - ``ax.annotate(text, xy, ...)`` — first positional argument.
+    - ``ax.add_stat_annotation(..., text=...)`` — the ``text=`` keyword.
+    - ``ax.text(..., s=...)`` — the ``s=`` keyword form.
+    """
+    fname = _fname(node)
+    candidates = []
+    if fname == "text" and len(node.args) >= 3:
+        candidates.append(node.args[2])
+    if fname == "annotate" and node.args:
+        candidates.append(node.args[0])
+    for kw in node.keywords:
+        if kw.arg in ("text", "s"):
+            candidates.append(kw.value)
+    return candidates
+
+
+class StatAnnotationFieldsChecker(ast.NodeVisitor):
+    """STX-FM017 — flag a stats-shaped annotation string missing several
+    of the six required doctrine fields (n, CI, method, p, effect, statistic).
+    """
+
+    category = "figure"
+
+    def __init__(self, source_lines, config, rule=None):
+        self.source_lines = source_lines
+        self.config = config
+        self.issues: list = []
+        self._rule = rule  # injected by the plugin loader
+
+    def _src(self, lineno):
+        if 1 <= lineno <= len(self.source_lines):
+            return self.source_lines[lineno - 1].rstrip()
+        return ""
+
+    def _emit(self, node):
+        Issue, _is_allowed_by_comment = _scitex_linter_runtime()
+        if Issue is None or self._rule is None:
+            return  # scitex-linter not importable; checker is inert
+        rule = self._rule
+        if rule.id in self.config.disable:
+            return
+        line = self._src(node.lineno)
+        if _is_allowed_by_comment(line, rule.id):
+            return
+        sev = self.config.per_rule_severity.get(rule.id)
+        if sev:
+            rule = _replace(rule, severity=sev)
+        self.issues.append(
+            Issue(rule=rule, line=node.lineno, col=node.col_offset, source_line=line)
+        )
+
+    def visit_Call(self, node):
+        for candidate in _string_candidates(node):
+            if isinstance(candidate, ast.Constant) and isinstance(candidate.value, str):
+                text = candidate.value
+                if _P_VALUE_MARKER.search(text) and _present_count(text) < _MIN_PRESENT:
+                    self._emit(node)
+                    break
+        self.generic_visit(node)
+
+
+__all__ = ["StatAnnotationFieldsChecker"]
+
+# EOF

--- a/src/figrecipe/_skills/figrecipe/21_figure-prep-playbook.md
+++ b/src/figrecipe/_skills/figrecipe/21_figure-prep-playbook.md
@@ -168,47 +168,31 @@ axes carry quantitative claims), schematics, or multi-panel
 comparison grids where readers must cross-read absolute values
 between panels (use shared ticked axes per rule 3).
 
-Don't keep full ticked axes AND add an L-bar — pick one. Don't
-silently rescale the data and forget to update the bar label.
-
-See `24_l-shaped-scale-bar.md` for the worked-example leaf with the
-matplotlib pattern and a longer DO/DON'T list.
+Don't keep full ticked axes AND add an L-bar — pick one. Don't silently
+rescale the data and forget to update the bar label. See
+`24_l-shaped-scale-bar.md` for the matplotlib pattern and a longer DO/DON'T.
 
 ### 8. Six-stat annotation doctrine + heatmap colorbar
 
-Any statistical annotation on a figure (a p-value / effect-size label
-next to a comparison) MUST carry all six of **n, CI, method, p, effect,
-statistic** — never a bare p-value or star. Render statistical symbols
-(`p`, `t`, `F`, `r`, ...) in *italic*, and keep **N** (subjects) distinct
-from **n** (windows/trials/samples) when both are relevant.
-
-Separately: any 2D heatmap (`imshow`-style plot of a 2D array) MUST ship
-a colorbar with tick labels, an axis label, and units on that label.
-
-Both are operator-issued doctrine (2026-07-05) and both have a soft lint
-check (`STX-FM017`, `STX-FM018`) in figrecipe's linter plugin. See
-`27_six-stat-annotation-doctrine.md` for the full rule text, the italic
-and N-vs-n conventions, and compliant/non-compliant examples.
+Every statistical annotation carries all six of **n, CI, method, p, effect,
+statistic** — never a bare p-value or star. Every 2D heatmap ships a colorbar
+with tick labels, an axis label, and units. See
+`27_six-stat-annotation-doctrine.md` for the full rules, the italic-symbol and
+N-vs-n conventions, and the `STX-FM017`/`STX-FM018` lint checks.
 
 ## Pre-render checklist & anti-patterns
 
-The merge-gate checklist (one line per rule above) and the catalogue of
-anti-patterns that violate these rules live in the companion leaf
-`25_figure-prep-checklist.md`. Load it alongside this playbook when
-authoring or reviewing a publication-bound figure script.
+The merge-gate checklist (one line per rule above) and the anti-pattern
+catalogue live in `25_figure-prep-checklist.md`. Load it alongside this
+playbook when authoring or reviewing a publication-bound figure script.
 
 ## Cross-references
 
-- `22_nan-sentinel-on-read.md` — concrete NaN-sentinel handling
-  (e.g. `-32768` → `np.nan` on read) at the figure layer.
-- `23_no-synthetic-data-policy.md` — figrecipe rendering-side guard
-  for the no-synthetic-data policy.
-- `24_l-shaped-scale-bar.md` — L-shaped scale-bar convention for
-  signal-trace panels (rule 7 worked example).
-- `25_figure-prep-checklist.md` — pre-render merge-gate checklist and
-  anti-patterns companion to this playbook.
-- `27_six-stat-annotation-doctrine.md` — six-stat annotation doctrine +
-  heatmap colorbar requirement (rule 8 worked example).
+- `22_nan-sentinel-on-read.md` — NaN-sentinel handling (`-32768` → `np.nan`) at the figure layer.
+- `23_no-synthetic-data-policy.md` — rendering-side guard for the no-synthetic-data policy.
+- `24_l-shaped-scale-bar.md` — L-shaped scale-bar convention (rule 7 worked example).
+- `25_figure-prep-checklist.md` — pre-render merge-gate checklist + anti-patterns companion.
+- `27_six-stat-annotation-doctrine.md` — six-stat + heatmap-colorbar doctrine (rule 8 worked example).
 - `05_styles.md` — `SCITEX` and dark-variant presets.
 - `17_composition.md` — multi-panel mm-precision composition.
 - `scitex-dev/_skills/scientific/01_figures_01_standards.md` — universal scientific-figure standards (color, layout, typography).

--- a/src/figrecipe/_skills/figrecipe/21_figure-prep-playbook.md
+++ b/src/figrecipe/_skills/figrecipe/21_figure-prep-playbook.md
@@ -23,7 +23,7 @@ quality `examples/<NN>_*.py`, or reviewing such a script before merge.
 Skip for throwaway exploratory plots (`ax.plot` and move on) and unit-test
 fixtures that merely exercise the figrecipe API surface.
 
-## The seven rules
+## The eight rules
 
 ### 1. Real data only
 
@@ -174,6 +174,22 @@ silently rescale the data and forget to update the bar label.
 See `24_l-shaped-scale-bar.md` for the worked-example leaf with the
 matplotlib pattern and a longer DO/DON'T list.
 
+### 8. Six-stat annotation doctrine + heatmap colorbar
+
+Any statistical annotation on a figure (a p-value / effect-size label
+next to a comparison) MUST carry all six of **n, CI, method, p, effect,
+statistic** — never a bare p-value or star. Render statistical symbols
+(`p`, `t`, `F`, `r`, ...) in *italic*, and keep **N** (subjects) distinct
+from **n** (windows/trials/samples) when both are relevant.
+
+Separately: any 2D heatmap (`imshow`-style plot of a 2D array) MUST ship
+a colorbar with tick labels, an axis label, and units on that label.
+
+Both are operator-issued doctrine (2026-07-05) and both have a soft lint
+check (`STX-FM017`, `STX-FM018`) in figrecipe's linter plugin. See
+`27_six-stat-annotation-doctrine.md` for the full rule text, the italic
+and N-vs-n conventions, and compliant/non-compliant examples.
+
 ## Pre-render checklist & anti-patterns
 
 The merge-gate checklist (one line per rule above) and the catalogue of
@@ -191,6 +207,8 @@ authoring or reviewing a publication-bound figure script.
   signal-trace panels (rule 7 worked example).
 - `25_figure-prep-checklist.md` — pre-render merge-gate checklist and
   anti-patterns companion to this playbook.
+- `27_six-stat-annotation-doctrine.md` — six-stat annotation doctrine +
+  heatmap colorbar requirement (rule 8 worked example).
 - `05_styles.md` — `SCITEX` and dark-variant presets.
 - `17_composition.md` — multi-panel mm-precision composition.
 - `scitex-dev/_skills/scientific/01_figures_01_standards.md` — universal scientific-figure standards (color, layout, typography).

--- a/src/figrecipe/_skills/figrecipe/25_figure-prep-checklist.md
+++ b/src/figrecipe/_skills/figrecipe/25_figure-prep-checklist.md
@@ -32,6 +32,13 @@ Before a figure script is allowed into a publication pipeline:
 - [ ] Signal-trace panels use an L-shaped scale bar (axes hidden,
       magnitudes from `CONFIG.SCALE_BAR.*`) — see
       `24_l-shaped-scale-bar.md`.
+- [ ] Every statistical annotation carries all six of n / CI / method /
+      p / effect / statistic, with symbols in italic and N (subjects)
+      distinguished from n (windows/trials) — see
+      `27_six-stat-annotation-doctrine.md` (STX-FM017).
+- [ ] Every 2D heatmap (`imshow`) has a colorbar with tick labels, an
+      axis label, and units — see `27_six-stat-annotation-doctrine.md`
+      (STX-FM018).
 
 ## Anti-patterns
 
@@ -49,9 +56,16 @@ Before a figure script is allowed into a publication pipeline:
   L-shaped scale bar — redundant and visually noisy. Pick one (use
   the L-bar for representative traces; see playbook rule 7 and
   `24_l-shaped-scale-bar.md`).
+- A stat annotation reading only `p < 0.05` or `*` with no n, CI,
+  method, effect size, or test statistic anywhere in the figure —
+  flagged by STX-FM017 (see `27_six-stat-annotation-doctrine.md`).
+- A heatmap (`ax.imshow(...)`) with no `fig.colorbar(...)` call at
+  all — flagged by STX-FM018 (see `27_six-stat-annotation-doctrine.md`).
 
 ## Cross-references
 
-- `21_figure-prep-playbook.md` — the seven rules these items gate.
+- `21_figure-prep-playbook.md` — the eight rules these items gate.
 - `22_nan-sentinel-on-read.md` — concrete NaN-sentinel handling.
 - `24_l-shaped-scale-bar.md` — L-shaped scale-bar worked example.
+- `27_six-stat-annotation-doctrine.md` — six-stat annotation doctrine +
+  heatmap colorbar requirement worked example.

--- a/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
+++ b/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
@@ -1,0 +1,154 @@
+---
+description: |
+  [TOPIC] Six-stat annotation doctrine + heatmap colorbar requirement
+  [DETAILS] Operator-issued reporting doctrine (2026-07-05): every statistical annotation on a figure must carry all six of n / 95% CI / method / p-value / effect size / test statistic, statistical symbols render in italic, and N (subjects) is kept distinct from n (windows/trials/samples). Pairs with the separate heatmap-colorbar requirement — every 2D imshow-style plot must ship a colorbar with tick labels, an axis label, and units. Both are checked (soft, warning-level) by STX-FM017 / STX-FM018 in figrecipe's lint plugin.
+tags: [figrecipe-six-stat-doctrine, figrecipe-stat-annotation, figrecipe-colorbar, figrecipe]
+---
+
+
+# Six-stat Annotation Doctrine + Heatmap Colorbar Requirement
+
+Figure-annotation half of the operator-issued "Statistics Completeness
+Doctrine" (2026-07-05, relayed via NeuroVista, adopted fleet-wide). The
+manuscript/caption/table-authoring half of this doctrine lives in
+`scitex-dev/_skills/scientific/03_reporting_02_statistics-completeness.md`
+(scitex-ai/scitex-dev#290) — read that leaf for the full Results-section /
+stats-table guidance. This leaf covers the figure-annotation surface:
+`ax.add_stat_annotation(...)` (see `_wrappers/_stat_annotation.py`) and any
+`ax.text(...)` / `ax.annotate(...)` used to label a comparison directly on
+a panel, plus the separate heatmap-colorbar requirement.
+
+## Rule 1 — the six required fields
+
+A statistical annotation on a figure (a p-value or effect-size label next
+to a comparison) is **incomplete** unless all six of the following appear
+somewhere the reader can find them — inline in the annotation, in the
+caption, or in an accompanying stats table:
+
+1. **n** — sample size / number of observations in the comparison.
+2. **CI** — confidence interval (typically 95%) around the estimate.
+3. **method** — which statistical test/method was used (e.g. "Welch's
+   t-test", "Wilcoxon signed-rank", "Pearson correlation").
+4. **p** — the p-value (exact value, or `p < 0.001` below display
+   precision) — never a bare significance star with no number behind it.
+5. **effect** — the effect size (Cohen's d, r, eta-squared, odds ratio,
+   ... whichever is conventional for the test used).
+6. **statistic** — the test statistic itself (`t(df)=`, `F(df1,df2)=`,
+   `U=`, `chi2(df)=`, ...).
+
+A p-value alone, or a p-value plus effect size but no CI or no n, is not
+sufficient. If the panel is too crowded for all six inline, push the rest
+to the caption (pairs with `21_figure-prep-playbook.md`) — but they must
+land somewhere in the figure's own text, not only in a separate results
+paragraph the reader has to cross-reference.
+
+### Italic statistical symbols
+
+Statistical symbols (`p`, `t`, `F`, `r`, `U`, `d`, ...) render in **italic**
+in figure text — matplotlib mathtext via `$\it{p}$` (or the `r"$\it{...}$"`
+raw-string form) does this correctly; a plain `"p="` string does not.
+`draw_stat_annotation`'s built-in `style="p_value"` / `style="both"` modes
+already do this (see `_wrappers/_stat_annotation.py::draw_stat_annotation`,
+which emits `$\it{p}$ < 0.001` / `$\it{p}$ = 0.003`) — prefer those modes
+over hand-rolled text so the italic convention is automatic.
+
+### N vs n
+
+Distinguish **N** (number of subjects / patients — capital N) from **n**
+(number of windows / samples / trials *within* a subject — lowercase n)
+as separate, explicitly-subscripted quantities whenever both are
+relevant:
+
+```
+N = 12 patients, n = 340 windows
+```
+
+Collapsing these into a single `n=` when both a subject count and a
+within-subject sample count exist hides the actual unit of statistical
+independence from the reader — a common and serious inferential error in
+per-window / per-trial neuroscience and physiology figures.
+
+### Compliant example
+
+```python
+ax.add_stat_annotation(
+    x1=0, x2=1,
+    text=(
+        r"$N$=12, $n$=340, $r$=0.42, 95% CI [0.21, 0.60], "
+        r"$t$(338)=5.1, $p$<0.001 (Pearson correlation)"
+    ),
+)
+```
+
+All six fields are present (n, CI, method, p, effect, statistic), N and n
+are distinguished, and every statistical symbol is wrapped for italic
+rendering. Compare to the incomplete, lint-flagged form:
+
+```python
+ax.add_stat_annotation(x1=0, x2=1, text="p=0.03")  # STX-FM017: missing n, CI, method, effect, statistic
+```
+
+## Rule 2 — heatmap colorbar requirement
+
+Any 2D heatmap (an `imshow`-style plot of a 2D array — `imshow`, `matshow`,
+`pcolormesh`, ...) MUST have:
+
+- a colorbar,
+- tick labels on that colorbar,
+- an axis label on the colorbar, and
+- units on that axis label.
+
+This is non-negotiable — the same tier as figrecipe's existing axis-label
+and unit requirements elsewhere in this lint plugin. A heatmap with no
+colorbar leaves the reader unable to read any absolute value off the
+image; a colorbar with no label/units leaves them unable to interpret
+what they *can* read.
+
+### Compliant example
+
+```python
+fig, ax = fr.subplots()
+im = ax.imshow(power_2d, cmap="viridis", vmin=0, vmax=1)
+fig.colorbar(im, ax=ax, label="power [a.u.]")  # tick labels on by default
+```
+
+figrecipe's imperative `ax.imshow(...)` does **not** auto-add a colorbar
+(only the declarative YAML/dict plot-spec path does, via
+`_api/_plot_helpers._maybe_add_colorbar`) — a script using the direct
+Python API must add its own `fig.colorbar(...)` call.
+
+## Lint enforcement
+
+Both rules have a soft (warning-level) static check in figrecipe's lint
+plugin (`src/figrecipe/_quality/_linter_plugin.py`), `category="figure"`
+so they auto-promote to error under `project-type: research`:
+
+- **STX-FM017** (`_stat_annotation_fields_checker.py`) — flags a literal
+  annotation string that looks like a stats annotation (contains a
+  p-value marker) but is clearly missing several of the six fields.
+  Heuristic and conservative by design: plain captions with no p-value
+  marker are never flagged, and only literal string constants are
+  inspected (f-strings are skipped, not guessed at).
+- **STX-FM018** (`_heatmap_colorbar_checker.py`) — flags an `imshow(...)`
+  call with no `colorbar(...)` call anywhere in the same function/module
+  scope. It cannot statically verify tick labels / axis label / units —
+  that half of Rule 2 is enforced by review, matching the "doc-only where
+  a linter can't reach" acknowledgement in the sister scitex-dev doctrine.
+
+Opt out per call site with `# stx-allow: STX-FM017` / `# stx-allow:
+STX-FM018` when a partial annotation or colorbar-less heatmap is
+intentional (e.g. significance stars only, with the full stats reported
+in a table elsewhere).
+
+## Cross-references
+
+- `scitex-dev/_skills/scientific/03_reporting_02_statistics-completeness.md`
+  — the manuscript/caption/stats-table half of the six-field doctrine
+  (scitex-ai/scitex-dev#290).
+- `21_figure-prep-playbook.md` — where caption content (including
+  overflow stats) belongs relative to the rest of the figure-prep rules.
+- `_wrappers/_stat_annotation.py` — `draw_stat_annotation` /
+  `ax.add_stat_annotation(...)`, the dedicated annotation helper this
+  doctrine targets.
+- `05_styles.md` — SCITEX style font sizes (annotation text follows the
+  `stat_annotation.fontsize_pt` style key, not a hardcoded `fontsize=`).

--- a/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
+++ b/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
@@ -2,7 +2,7 @@
 description: |
   [TOPIC] Six-stat annotation doctrine + heatmap colorbar requirement
   [DETAILS] Operator-issued reporting doctrine (2026-07-05): every statistical annotation on a figure must carry all six of n / 95% CI / method / p-value / effect size / test statistic, statistical symbols render in italic, and N (subjects) is kept distinct from n (windows/trials/samples). Pairs with the separate heatmap-colorbar requirement — every 2D imshow-style plot must ship a colorbar with tick labels, an axis label, and units. Both are checked (soft, warning-level) by STX-FM017 / STX-FM018 in figrecipe's lint plugin.
-tags: [figrecipe-six-stat-doctrine, figrecipe-stat-annotation, figrecipe-colorbar, figrecipe]
+tags: [figrecipe-six-stat-annotation-doctrine, figrecipe-stat-annotation, figrecipe-colorbar, figrecipe]
 ---
 
 

--- a/src/figrecipe/_skills/figrecipe/SKILL.md
+++ b/src/figrecipe/_skills/figrecipe/SKILL.md
@@ -57,11 +57,12 @@ This package does not ship as a submodule of the `scitex` umbrella.
 
 ### Standards
 * [20_return-fig](20_return-fig.md) — Convention: plotting functions must return fig
-* [21_figure-prep-playbook](21_figure-prep-playbook.md) — Seven-rule playbook for publication-bound figures (real data, NaN handling, common scale, representative-example criteria, config-as-SSoT, figrecipe dogfood, L-shaped scale bar on signal traces)
+* [21_figure-prep-playbook](21_figure-prep-playbook.md) — Eight-rule playbook for publication-bound figures (real data, NaN handling, common scale, representative-example criteria, config-as-SSoT, figrecipe dogfood, L-shaped scale bar on signal traces, six-stat annotation doctrine + heatmap colorbar)
 * [22_nan-sentinel-on-read](22_nan-sentinel-on-read.md) — Convert storage-layer sentinels (e.g. `-32768`) to `np.nan` at the figure layer; example: neurovista ECoG gap sentinel
 * [23_no-synthetic-data-policy](23_no-synthetic-data-policy.md) — figrecipe rendering-side guard for the ecosystem no-synthetic-data policy (canonical home in scitex-dev scientific)
 * [24_l-shaped-scale-bar](24_l-shaped-scale-bar.md) — L-shaped scale-bar convention for representative signal-trace panels (hide axes; lower-left time + amplitude bars sharing a corner); worked-example leaf for playbook rule 7
 * [25_figure-prep-checklist](25_figure-prep-checklist.md) — pre-render merge-gate checklist + anti-patterns companion to the playbook (21)
+* [27_six-stat-annotation-doctrine](27_six-stat-annotation-doctrine.md) — every stat annotation carries n/CI/method/p/effect/statistic (italic symbols, N-vs-n), and every 2D heatmap ships a labelled colorbar; worked-example leaf for playbook rule 8, checked by STX-FM017/STX-FM018
 
 ## At a glance
 

--- a/tests/figrecipe/_quality/test__heatmap_colorbar_checker.py
+++ b/tests/figrecipe/_quality/test__heatmap_colorbar_checker.py
@@ -1,0 +1,150 @@
+"""Tests for STX-FM018 heatmap-without-colorbar AST rule.
+
+Real ast.parse + HeatmapColorbarChecker — no mocks. Each test follows
+Arrange / Act / Assert with one assertion and a >=3-word behavioural name.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+# Skip the whole module gracefully if scitex_dev isn't importable in this
+# environment — the checker itself is import-guarded the same way.
+pytest.importorskip("scitex_dev.linter.checker")
+
+from figrecipe._quality._heatmap_colorbar_checker import (  # noqa: E402
+    HeatmapColorbarChecker,
+)
+from figrecipe._quality._linter_plugin import get_plugin  # noqa: E402
+
+# Locate the FM018 rule object once via the plugin registration. Tests
+# instantiate the checker directly with this rule, mirroring the wiring
+# in _linter_plugin.py.
+_PLUGIN = get_plugin()
+_FM018 = next(r for r in _PLUGIN["rules"] if r.id == "STX-FM018")
+
+
+def _make_config():
+    """Real linter config; no mocks. The checker reads .disable and
+    .per_rule_severity, both of which exist on the dataclass default.
+    """
+    from scitex_dev.linter.config import load_config
+
+    return load_config(start_path=__file__)
+
+
+def _run(src: str):
+    """Parse *src* and run HeatmapColorbarChecker; return collected issues."""
+    tree = ast.parse(src)
+    source_lines = src.splitlines()
+    checker = HeatmapColorbarChecker(source_lines, _make_config(), rule=_FM018)
+    checker.visit(tree)
+    # _finalize_scope runs on Module exit inside visit_Module; call it
+    # explicitly too so top-level (non-function) imshow calls are covered
+    # regardless of how the AST was dispatched. Dedup by line to be safe.
+    checker._finalize_scope()
+    seen = set()
+    unique = []
+    for issue in checker.issues:
+        key = (issue.line, issue.col, issue.rule.id)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(issue)
+    return unique
+
+
+def _fired(issues):
+    return any(i.rule.id == "STX-FM018" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# POSITIVE — fires
+# ---------------------------------------------------------------------------
+
+
+def test_warns_on_imshow_with_no_colorbar_in_function():
+    # Arrange
+    src = "def f(ax, data):\n    ax.imshow(data)\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert _fired(issues)
+
+
+def test_warns_on_imshow_at_module_scope_with_no_colorbar():
+    # Arrange
+    src = "import matplotlib.pyplot as plt\nfig, ax = plt.subplots()\nax.imshow(data)\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert _fired(issues)
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE — does not fire
+# ---------------------------------------------------------------------------
+
+
+def test_does_not_warn_when_fig_colorbar_follows_imshow():
+    # Arrange
+    src = (
+        "def f(ax, fig, data):\n"
+        "    im = ax.imshow(data)\n"
+        "    fig.colorbar(im, ax=ax, label='amplitude [a.u.]')\n"
+    )
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not _fired(issues)
+
+
+def test_does_not_warn_when_plt_colorbar_follows_imshow():
+    # Arrange
+    src = (
+        "import matplotlib.pyplot as plt\n"
+        "def f(ax, data):\n"
+        "    im = ax.imshow(data)\n"
+        "    plt.colorbar(im, ax=ax)\n"
+    )
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not _fired(issues)
+
+
+def test_does_not_warn_when_no_imshow_call_present():
+    # Arrange
+    src = "def f(ax, x, y):\n    ax.plot(x, y)\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not _fired(issues)
+
+
+# ---------------------------------------------------------------------------
+# Escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_does_not_warn_when_opt_out_comment_present():
+    # Arrange
+    src = "def f(ax, data):\n    ax.imshow(data)  # stx-allow: STX-FM018\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not _fired(issues)

--- a/tests/figrecipe/_quality/test__stat_annotation_fields_checker.py
+++ b/tests/figrecipe/_quality/test__stat_annotation_fields_checker.py
@@ -1,0 +1,168 @@
+"""Tests for STX-FM017 six-stat-annotation-completeness AST rule.
+
+Real ast.parse + StatAnnotationFieldsChecker — no mocks. Each test follows
+Arrange / Act / Assert with one assertion and a >=3-word behavioural name.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+# Skip the whole module gracefully if scitex_dev isn't importable in this
+# environment — the checker itself is import-guarded the same way.
+pytest.importorskip("scitex_dev.linter.checker")
+
+from figrecipe._quality._linter_plugin import get_plugin  # noqa: E402
+from figrecipe._quality._stat_annotation_fields_checker import (  # noqa: E402
+    StatAnnotationFieldsChecker,
+)
+
+# Locate the FM017 rule object once via the plugin registration. Tests
+# instantiate the checker directly with this rule, mirroring the wiring
+# in _linter_plugin.py.
+_PLUGIN = get_plugin()
+_FM017 = next(r for r in _PLUGIN["rules"] if r.id == "STX-FM017")
+
+
+def _make_config():
+    """Real linter config; no mocks. The checker reads .disable and
+    .per_rule_severity, both of which exist on the dataclass default.
+    """
+    from scitex_dev.linter.config import load_config
+
+    return load_config(start_path=__file__)
+
+
+def _run(src: str):
+    """Parse *src* and run StatAnnotationFieldsChecker; return issues."""
+    tree = ast.parse(src)
+    source_lines = src.splitlines()
+    checker = StatAnnotationFieldsChecker(source_lines, _make_config(), rule=_FM017)
+    checker.visit(tree)
+    return checker.issues
+
+
+def _fired(issues):
+    return any(i.rule.id == "STX-FM017" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# POSITIVE — fires on a clearly-incomplete stats-shaped string
+# ---------------------------------------------------------------------------
+
+
+def test_warns_on_bare_p_value_via_ax_text():
+    # Arrange
+    src = "def f(ax):\n    ax.text(0.5, 0.9, 'p=0.03')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert _fired(issues)
+
+
+def test_warns_on_bare_p_value_via_annotate():
+    # Arrange
+    src = "def f(ax):\n    ax.annotate('p<0.05', (0.5, 0.9))\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert _fired(issues)
+
+
+def test_warns_on_add_stat_annotation_missing_fields():
+    # Arrange — only p present; n/CI/method/effect/statistic all missing.
+    src = "def f(ax):\n    ax.add_stat_annotation(0, 1, text='p=0.03')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert _fired(issues)
+
+
+def test_warns_when_only_n_and_p_present():
+    # Arrange — two of six fields present, still clearly incomplete.
+    src = "def f(ax):\n    ax.text(0.5, 0.9, 'n=20, p=0.03')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert _fired(issues)
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE — does not fire
+# ---------------------------------------------------------------------------
+
+
+def test_does_not_warn_on_compliant_six_field_annotation():
+    # Arrange — all six doctrine fields present.
+    src = (
+        "def f(ax):\n"
+        "    ax.text(0.5, 0.9, 'N=12, n=340, r=0.42, 95% CI [0.21, 0.60], "
+        "t(338)=5.1, p<0.001 (Pearson correlation)')\n"
+    )
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not _fired(issues)
+
+
+def test_does_not_warn_on_plain_caption_text():
+    # Arrange — no p-value marker at all, so the string is never even
+    # considered a stats annotation.
+    src = "def f(ax):\n    ax.text(0.5, 0.9, 'Figure 3: representative trace')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not _fired(issues)
+
+
+def test_does_not_warn_on_significance_stars_only():
+    # Arrange — the built-in stars shorthand has no p-value marker.
+    src = "def f(ax):\n    ax.text(0.5, 0.9, '***')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not _fired(issues)
+
+
+def test_does_not_warn_on_dynamic_fstring_text():
+    # Arrange — f-strings are not literal constants; checker skips them
+    # rather than guessing at their eventual value.
+    src = "def f(ax, p):\n    ax.text(0.5, 0.9, f'p={p}')\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not _fired(issues)
+
+
+# ---------------------------------------------------------------------------
+# Escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_does_not_warn_when_opt_out_comment_present():
+    # Arrange
+    src = "def f(ax):\n    ax.text(0.5, 0.9, 'p=0.03')  # stx-allow: STX-FM017\n"
+
+    # Act
+    issues = _run(src)
+
+    # Assert
+    assert not _fired(issues)


### PR DESCRIPTION
## Summary
- Documents the six-stat annotation doctrine (n/CI/method/p/effect/statistic, italic symbols, N-vs-n subscripts) + heatmap-colorbar requirement in a new figrecipe skill leaf, cross-linked from the figure-prep playbook + checklist. Companion to scitex-dev#290.
- Adds two soft (warning) lint rules following existing STX-FM/category=figure conventions: **STX-FM017** (stats annotation string missing several of the six fields) and **STX-FM018** (imshow with no colorbar in scope). Both conservative (literal strings only) with the `# stx-allow` escape hatch.

## Test plan
- [x] New test files for both checkers; 75 quality-dir tests pass.
- [x] scitex-dev audit clean.
- [x] Local pytest-testmon skipped (laptop load); CI matrix is the gate.