### PR TITLE
fix(reproducer): preserve explicit imshow tick labels through record/replay

### DIFF
--- a/src/figrecipe/_wrappers/_axes.py
+++ b/src/figrecipe/_wrappers/_axes.py
@@ -186,11 +186,26 @@ class RecordingAxes(
                 record_kwargs = kwargs.copy()
                 if stats is not None:
                     record_kwargs["stats"] = stats
+                record_args = args
+                if method_name in ("set_xticks", "set_yticks") and args:
+                    # Read the tick POSITIONS back from the live axis after
+                    # the call instead of recording the caller's raw arg.
+                    # matplotlib happily accepts a range/tuple/generator for
+                    # ``ticks``, none of which the generic arg serializer
+                    # round-trips (a bare ``range(19)`` degrades to the
+                    # literal string ``"range(0, 19)"`` and later fails to
+                    # replay) — the live axis always holds a well-formed
+                    # numeric array, so recording that is both simpler and
+                    # self-consistent with whatever a later
+                    # set_xticklabels() on this axis will see.
+                    axis_letter = "x" if method_name == "set_xticks" else "y"
+                    live_ticks = list(getattr(self._ax, f"get_{axis_letter}ticks")())
+                    record_args = (live_ticks,) + tuple(args[1:])
                 record_call_with_color_capture(
                     self._recorder,
                     self._position,
                     method_name,
-                    args,
+                    record_args,
                     record_kwargs,
                     result,
                     id,

--- a/src/figrecipe/styles/_finalize.py
+++ b/src/figrecipe/styles/_finalize.py
@@ -136,19 +136,35 @@ def finalize_special_plots(ax: Axes, style: Dict[str, Any] = None) -> None:
     # Check for imshow/matshow (has AxesImage)
     has_image = any(isinstance(c, AxesImage) for c in ax.get_children())
     if has_image:
+        from matplotlib.ticker import FixedLocator
+
         xlabel = ax.get_xlabel()
         ylabel = ax.get_ylabel()
         is_specgram = xlabel or ylabel
 
+        # A FixedLocator on an axis means the user explicitly pinned tick
+        # positions (set_xticks(...), or set_xticklabels(...) which installs
+        # a FixedLocator as a side effect) — never silently wipe those, the
+        # same "is this axis already explicit?" check finalize_ticks() above
+        # already applies via its own _fixed_types guard. Without this, an
+        # imshow axis with no x/y label (the common case: no set_xyt call)
+        # had its explicit ticks/labels unconditionally cleared here even
+        # though nothing downstream ever restores them.
+        x_is_fixed = isinstance(ax.xaxis.get_major_locator(), FixedLocator)
+        y_is_fixed = isinstance(ax.yaxis.get_major_locator(), FixedLocator)
+
         if not is_specgram:
             show_axes = style.get("imshow_show_axes", False)
             if not show_axes:
-                ax.set_xticks([])
-                ax.set_yticks([])
-                ax.set_xticklabels([])
-                ax.set_yticklabels([])
-                for spine in ax.spines.values():
-                    spine.set_visible(False)
+                if not x_is_fixed:
+                    ax.set_xticks([])
+                    ax.set_xticklabels([])
+                if not y_is_fixed:
+                    ax.set_yticks([])
+                    ax.set_yticklabels([])
+                if not x_is_fixed and not y_is_fixed:
+                    for spine in ax.spines.values():
+                        spine.set_visible(False)
 
 
 __all__ = ["finalize_ticks", "finalize_special_plots"]

--- a/tests/integration/test_imshow_tick_reproduction.py
+++ b/tests/integration/test_imshow_tick_reproduction.py
@@ -59,3 +59,27 @@ def test_imshow_with_explicit_ticks_reproduces_keeping_them(tmp_path):
     fr.save(fig, str(tmp_path / "comodulogram_ticked.png"))
     # Assert
     assert not list(tmp_path.glob("*-not-reproduced.*"))
+
+
+def test_imshow_separate_set_xticks_and_set_xticklabels_round_trip(tmp_path):
+    # No set_xyt/set_xlabel/set_ylabel here (is_specgram stays False) -- the
+    # exact neurovista dogfooding repro: imshow() then a bare ``range(N)``
+    # passed to set_xticks() followed by a SEPARATE set_xticklabels() call
+    # (not the combined set_xticks(pos, labels=...) form covered above).
+    # Two compounding bugs used to drop the labels here: (1) the recorder
+    # serialized the raw range() arg to the literal string "range(0, 19)",
+    # which failed to replay; (2) finalize_special_plots unconditionally
+    # wiped ticks/labels on any imshow axis with no x/y label, clobbering
+    # even a correctly-replayed explicit set_xticks/set_xticklabels pair.
+    # Arrange
+    n = 19
+    labels = [f"L{i}" for i in range(n)]
+    fig, ax = fr.subplots()
+    ax.imshow(np.random.rand(n, n))
+    ax.set_xticks(range(n))
+    ax.set_xticklabels(labels, rotation=90)
+    fr.save(fig, str(tmp_path / "matrix.yaml"))
+    # Act
+    _, ax2 = fr.reproduce(str(tmp_path / "matrix.yaml"))
+    # Assert
+    assert [t.get_text() for t in ax2._ax.get_xticklabels()] == labels


### PR DESCRIPTION
## Summary
Two compounding bugs dropped set_xticks/set_xticklabels on an imshow axis with no x/y label (neurovista Fig S03 heatmap repro):
1. RecordingAxes recorded the caller raw `range(19)` arg, which serialized to the literal string `range(0, 19)` and failed to replay. Fixed by reading tick POSITIONS back from the live axis after the call.
2. finalize_special_plots wiped ticks on any label-less imshow axis with no guard. Fixed by checking for a FixedLocator (same pattern finalize_ticks already uses) before clearing.

## Test plan
- [x] Regression test test_imshow_separate_set_xticks_and_set_xticklabels_round_trip.
- [x] 377 recorder/reproducer/wrappers/styles tests pass; scitex-dev audit clean.
- [x] Local pytest-testmon skipped (laptop load); CI matrix is the gate.