### PR TITLE
feat(styles): comma tick formatter + sample-size annotation helper

### DIFF
--- a/src/figrecipe/_scitex_compat/__init__.py
+++ b/src/figrecipe/_scitex_compat/__init__.py
@@ -7,6 +7,7 @@ These are wired into RecordingAxes as stx_* methods.
 Code is preserved here for easy recovery and maintenance.
 """
 
+from ._annotate_n import stx_annotate_n
 from ._heatmap import stx_heatmap
 from ._scientific import stx_conf_mat, stx_ecdf, stx_raster, stx_scatter_hist
 from ._shaded_lines import (
@@ -25,6 +26,7 @@ from ._simple import (
 )
 
 __all__ = [
+    "stx_annotate_n",
     "stx_conf_mat",
     "stx_ecdf",
     "stx_fillv",

--- a/src/figrecipe/_scitex_compat/_annotate_n.py
+++ b/src/figrecipe/_scitex_compat/_annotate_n.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Sample-size annotation helper: ``stx_annotate_n``.
+
+Standardizes the "n=340" / "N=12 patients" style sample-size annotation
+convention placed next to a data point or group, so callers do not need to
+hand-roll ``f"{n:,}"`` formatting and ad-hoc ``ax.text`` placement for every
+figure. Sibling module to ``_simple.py`` (kept separate to stay under the
+project's per-file line budget).
+"""
+
+import warnings
+
+from matplotlib.axes import Axes
+
+__all__ = ["stx_annotate_n"]
+
+
+def stx_annotate_n(
+    ax: Axes,
+    x,
+    y,
+    n,
+    *,
+    prefix="n",
+    suffix="",
+    comma=True,
+    fontsize=None,
+    color="black",
+    avoid_overlap=True,
+    offset_pt=(6.0, 6.0),
+    step=6.0,
+    max_radius=160.0,
+    **kwargs,
+):
+    """Annotate a data point with a sample-size label (e.g. "n=340").
+
+    Standardizes the sample-size annotation convention used throughout a
+    paper (``n=340``, ``N=12 patients`` next to a group / data point):
+    consistent font size (the active style's ``annotation_pt``, matching
+    ``ax.annotate``/``ax.text``), consistent color (black by default), and
+    a placement that avoids the plotted data and other labels.
+
+    Font sizes follow the active rcParams / SCITEX style ``annotation_pt``
+    (no hardcoded ``fontsize=`` unless explicitly passed).
+
+    Parameters
+    ----------
+    ax : Axes
+        Target axes. Placement uses the axes' current data limits and
+        already-drawn artists, so call this after the data is plotted.
+    x, y : float
+        Data-coordinate anchor point the annotation belongs to.
+    n : int or str
+        Sample size. An ``int`` is thousands-comma formatted by default
+        (``comma=True``, e.g. ``1234`` -> ``"1,234"``); a ``str`` is used
+        verbatim (e.g. ``n="12 patients"``, ``prefix="N"`` -> ``"N=12
+        patients"``).
+    prefix : str, default "n"
+        Label prefix, e.g. ``"n"`` or ``"N"``.
+    suffix : str, default ""
+        Text appended after the number, e.g. ``" patients"``.
+    comma : bool, default True
+        Thousands-comma format an integer ``n``.
+    fontsize : float, optional
+        Defaults to the active style's ``fonts.annotation_pt`` (falls back
+        to 6pt if no style is active).
+    color : default "black"
+        Text color.
+    avoid_overlap : bool, default True
+        Nudge the label clear of existing plotted ink / legend / other
+        labels using the same deterministic ring-search solver that backs
+        ``scatter_labels`` (``figrecipe._declutter.solve_label_positions``)
+        rather than re-implementing collision avoidance. Falls back to the
+        plain ``offset_pt`` position (with a warning) if the figure cannot
+        be rendered or no clear spot is found within reach -- never
+        silent.
+    offset_pt : (float, float), default (6.0, 6.0)
+        Initial (dx, dy) offset from the anchor, in points, used as the
+        search center for ``avoid_overlap`` (or as the final position when
+        ``avoid_overlap=False``).
+    step, max_radius : float
+        Ring-search granularity / reach, in display pixels. See
+        ``solve_label_positions``.
+    **kwargs
+        Passed to ``ax.text``.
+
+    Returns
+    -------
+    matplotlib.text.Text
+
+    Examples
+    --------
+    >>> ax.stx_annotate_n(1.0, 2.5, 340)  # "n=340"
+    >>> ax.stx_annotate_n(1.0, 2.5, "12 patients", prefix="N")  # "N=12 patients"
+    """
+    from ..styles._internal import get_style
+
+    if isinstance(n, str):
+        text = f"{prefix}={n}{suffix}"
+    elif comma:
+        text = f"{prefix}={n:,}{suffix}"
+    else:
+        text = f"{prefix}={n}{suffix}"
+
+    if fontsize is None:
+        style = get_style()
+        if style:
+            fontsize = style.get("fonts", {}).get("annotation_pt", None)
+    if fontsize is None:
+        fontsize = 6
+
+    xd, yd = _offset_point(ax, float(x), float(y), offset_pt)
+
+    if avoid_overlap:
+        resolved = _resolve_position(
+            ax, xd, yd, text, fontsize, step=step, max_radius=max_radius
+        )
+        if resolved is not None:
+            xd, yd = resolved
+
+    text_kwargs = dict(kwargs)
+    text_kwargs.setdefault("ha", "center")
+    text_kwargs.setdefault("va", "center")
+    text_kwargs["fontsize"] = fontsize
+    text_kwargs["color"] = color
+
+    return ax.text(xd, yd, text, **text_kwargs)
+
+
+def _offset_point(ax, x, y, offset_pt):
+    """Data-coordinate point offset from ``(x, y)`` by ``offset_pt`` points."""
+    dpi = ax.figure.dpi
+    dx_px = offset_pt[0] * dpi / 72.0
+    dy_px = offset_pt[1] * dpi / 72.0
+    disp = ax.transData.transform((x, y))
+    xd, yd = ax.transData.inverted().transform((disp[0] + dx_px, disp[1] + dy_px))
+    return float(xd), float(yd)
+
+
+def _resolve_position(ax, x, y, text, fontsize, *, step, max_radius):
+    """Nudge ``(x, y)`` clear of existing ink/labels via the declutter solver.
+
+    Reuses ``figrecipe._declutter.solve_label_positions`` (the same
+    deterministic ring-search solver behind ``scatter_labels``) instead of
+    re-implementing collision avoidance. Best-effort: returns ``None`` (and
+    warns) if the figure cannot be rendered or no clear spot is found, so
+    the caller keeps the plain offset position -- never a silent fallback.
+    """
+    try:
+        from .._declutter import solve_label_positions
+        from .._quality._overlap import _render_ink_mask
+
+        fig = ax.figure
+        fig.canvas.draw()
+        renderer = fig._get_renderer()
+
+        anchor = tuple(ax.transData.transform((x, y)))
+        temp = ax.text(0.0, 0.0, text, fontsize=fontsize, ha="center", va="center")
+        try:
+            bbox = temp.get_window_extent(renderer=renderer)
+            size = (float(bbox.width), float(bbox.height))
+        finally:
+            temp.remove()
+
+        rendered = _render_ink_mask(fig, None)
+        ink_mask, height = rendered if rendered is not None else (None, 0)
+
+        obstacles = []
+        legend = ax.get_legend()
+        if legend is not None and legend.get_visible():
+            lb = legend.get_window_extent(renderer=renderer)
+            obstacles.append((lb.x0, lb.y0, lb.x1, lb.y1))
+
+        ab = ax.get_window_extent(renderer=renderer)
+        clip_rect = (ab.x0, ab.y0, ab.x1, ab.y1)
+
+        centers, placed_clear = solve_label_positions(
+            [anchor],
+            [size],
+            ink_mask,
+            height,
+            obstacles,
+            clip_rect,
+            step=step,
+            max_radius=max_radius,
+        )
+        if not placed_clear[0]:
+            warnings.warn(
+                "stx_annotate_n: no clear spot found within reach; label "
+                "placed at its offset anchor (crowded axes -- consider "
+                "enlarging the panel).",
+                UserWarning,
+                stacklevel=3,
+            )
+        cx, cy = centers[0]
+        xd, yd = ax.transData.inverted().transform((cx, cy))
+        return float(xd), float(yd)
+    except Exception as exc:  # pragma: no cover - defensive, non-interactive backends
+        warnings.warn(
+            f"stx_annotate_n: overlap avoidance unavailable ({exc!r}); "
+            "falling back to the plain offset position.",
+            UserWarning,
+            stacklevel=3,
+        )
+        return None
+
+
+# EOF

--- a/src/figrecipe/_wrappers/_axes_scitex.py
+++ b/src/figrecipe/_wrappers/_axes_scitex.py
@@ -253,6 +253,28 @@ class SciTexMixin:
             self._record_stx_call("stx_scalebar", (x_len, y_len), kwargs, id)
         return result
 
+    def stx_annotate_n(self, x, y, n, *, id=None, track=True, **kwargs):
+        """Annotate a data point with a sample-size label (e.g. "n=340").
+
+        Style-consistent font size (active style's ``annotation_pt``) and
+        color (black by default), with basic overlap avoidance against
+        existing plotted ink / labels. See the underlying ``stx_annotate_n``
+        for the full parameter list (``prefix``, ``suffix``, ``comma``,
+        ``fontsize``, ``color``, ``avoid_overlap``, ``offset_pt``).
+
+        Examples
+        --------
+        >>> ax.stx_annotate_n(1.0, 2.5, 340)  # "n=340"
+        >>> ax.stx_annotate_n(1.0, 2.5, "12 patients", prefix="N")
+        """
+        from .._scitex_compat._annotate_n import stx_annotate_n
+
+        with self._no_record():
+            result = stx_annotate_n(self._ax, x, y, n, **kwargs)
+        if self._track and track:
+            self._record_stx_call("stx_annotate_n", (x, y, n), kwargs, id)
+        return result
+
 
 __all__ = ["SciTexMixin"]
 

--- a/src/figrecipe/_wrappers/_axes_style_mixin.py
+++ b/src/figrecipe/_wrappers/_axes_style_mixin.py
@@ -242,6 +242,32 @@ class AxesStyleMixin:
 
         return sci_note(self._ax, axis, scilimits)
 
+    def comma_format(
+        self,
+        x: bool = True,
+        y: bool = False,
+        fformat: str = "{:,.0f}",
+    ):
+        """Format tick labels with thousands-separator commas (e.g. 12,000).
+
+        Parameters
+        ----------
+        x : bool
+            Comma-format the x-axis tick labels. Default: True.
+        y : bool
+            Comma-format the y-axis tick labels. Default: False.
+        fformat : str
+            ``str.format``-style spec per tick value. Default: ``"{:,.0f}"``.
+
+        Examples
+        --------
+        >>> ax.comma_format(x=True)  # "0", "12,000", "24,000"
+        >>> ax.comma_format(x=True, y=True, fformat="{:,.1f}")
+        """
+        from ..styles._axis_helpers import comma_format
+
+        return comma_format(self._ax, x=x, y=y, fformat=fformat)
+
     def force_aspect(self, ratio: float = 1.0):
         """Force aspect ratio.
 

--- a/src/figrecipe/styles/__init__.py
+++ b/src/figrecipe/styles/__init__.py
@@ -22,7 +22,7 @@ Public API:
     Axis Helpers (also available as ax.method() via RecordingAxes):
         - hide_spines, show_spines, toggle_spines
         - rotate_labels, set_n_ticks, map_ticks
-        - sci_note, force_aspect, extend
+        - sci_note, comma_format, force_aspect, extend
 
     Font Utilities:
         - check_font, list_available_fonts
@@ -34,6 +34,8 @@ Public API:
 
 # Style management
 # Axis helper utilities (user-facing)
+from ._axis_helpers import CommaFormatter as CommaFormatter
+from ._axis_helpers import comma_format as comma_format
 from ._axis_helpers import extend as extend
 from ._axis_helpers import force_aspect as force_aspect
 from ._axis_helpers import hide_spines as hide_spines
@@ -82,6 +84,8 @@ __all__ = [
     "set_y_ticks",
     "map_ticks",
     "sci_note",
+    "comma_format",
+    "CommaFormatter",
     "force_aspect",
     "extend",
 ]

--- a/src/figrecipe/styles/_axis_helpers/__init__.py
+++ b/src/figrecipe/styles/_axis_helpers/__init__.py
@@ -9,6 +9,9 @@ This is an internal module. Use the public API instead:
     ax.rotate_labels(x=45)
 """
 
+# Thousands-separator formatting
+from ._comma_format import CommaFormatter, comma_format
+
 # Geometry utilities
 from ._geometry import extend, force_aspect
 
@@ -48,6 +51,9 @@ __all__ = [
     # Scientific notation
     "sci_note",
     "OOMFormatter",
+    # Thousands-separator formatting
+    "comma_format",
+    "CommaFormatter",
     # Geometry
     "force_aspect",
     "extend",

--- a/src/figrecipe/styles/_axis_helpers/_comma_format.py
+++ b/src/figrecipe/styles/_axis_helpers/_comma_format.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Thousands-separator (comma) tick-label formatting for matplotlib axes.
+
+Mirrors the ``OOMFormatter`` / ``sci_note`` pattern in ``_sci_note.py``: a
+small ``matplotlib.ticker.Formatter`` subclass plus a public helper that
+wires it onto an axis via ``set_major_formatter``. Added per a downstream
+(neurovista) request that hand-rolled ``f"{n:,}"`` for tick labels and
+sample-size annotation numbers -- this gives both a single, reusable
+formatter to hook into instead.
+"""
+
+__all__ = ["CommaFormatter", "comma_format"]
+
+from typing import Any
+
+import matplotlib.ticker
+
+from ._base import get_axis_from_wrapper, validate_axis
+
+
+class CommaFormatter(matplotlib.ticker.Formatter):
+    """Format tick values with thousands-separator commas (e.g. ``12,000``).
+
+    Parameters
+    ----------
+    fformat : str, optional
+        A ``str.format``-style spec applied to each tick value. Default is
+        ``"{:,.0f}"`` (integer, comma-grouped). Use e.g. ``"{:,.2f}"`` for
+        two decimal places.
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> from figrecipe.styles import CommaFormatter
+    >>> fig, ax = plt.subplots()
+    >>> ax.plot([0, 12000, 24000], [0, 1, 2])
+    >>> ax.xaxis.set_major_formatter(CommaFormatter())
+    """
+
+    def __init__(self, fformat: str = "{:,.0f}"):
+        self.fformat = fformat
+
+    def __call__(self, x: float, pos: Any = None) -> str:
+        return self.fformat.format(x)
+
+
+def comma_format(
+    ax: Any,
+    x: bool = False,
+    y: bool = False,
+    fformat: str = "{:,.0f}",
+) -> Any:
+    """Apply thousands-separator comma formatting to tick labels.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The Axes object to modify (a figrecipe ``RecordingAxes`` wrapper is
+        also accepted -- the underlying axes is unwrapped automatically).
+    x : bool
+        Whether to comma-format the x-axis. Default: False.
+    y : bool
+        Whether to comma-format the y-axis. Default: False.
+    fformat : str
+        ``str.format``-style spec per tick value. Default: ``"{:,.0f}"``.
+
+    Returns
+    -------
+    Axes
+        The modified Axes object.
+
+    Examples
+    --------
+    >>> import figrecipe as fr
+    >>> fig, ax = fr.subplots()
+    >>> ax.plot([0, 12000, 24000], [0, 1, 2])
+    >>> fr.styles.comma_format(ax, x=True)  # "0", "12,000", "24,000"
+    >>> # Or via the RecordingAxes wrapper method:
+    >>> ax.comma_format(x=True)
+    """
+    validate_axis(ax)
+    ax = get_axis_from_wrapper(ax)
+
+    if x:
+        ax.xaxis.set_major_formatter(CommaFormatter(fformat))
+    if y:
+        ax.yaxis.set_major_formatter(CommaFormatter(fformat))
+
+    return ax
+
+
+# EOF

--- a/tests/figrecipe/_scitex_compat/test__annotate_n.py
+++ b/tests/figrecipe/_scitex_compat/test__annotate_n.py
@@ -178,10 +178,10 @@ class TestAnnotateN:
         xx, yy = np.meshgrid(np.linspace(0, 1, 60), np.linspace(0, 1, 60))
         ax.pcolormesh(xx, yy, xx + yy)
         # Act
-        with pytest.warns(UserWarning) as warnings_raised:
-            stx_annotate_n(ax, 0.5, 0.5, 10, max_radius=8.0)
+        warns_on_fallback = pytest.warns(UserWarning)
         # Assert
-        assert len(warnings_raised) >= 1
+        with warns_on_fallback:
+            stx_annotate_n(ax, 0.5, 0.5, 10, max_radius=8.0)
 
     def test_recording_axes_method_returns_result(self):
         # Arrange

--- a/tests/figrecipe/_scitex_compat/test__annotate_n.py
+++ b/tests/figrecipe/_scitex_compat/test__annotate_n.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the ``stx_annotate_n`` sample-size annotation helper."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+
+class TestAnnotateN:
+    """Tests for the standalone ``stx_annotate_n`` implementation."""
+
+    @pytest.fixture(autouse=True)
+    def reset_matplotlib(self):
+        plt.close("all")
+        matplotlib.rcdefaults()
+        yield
+        plt.close("all")
+
+    def test_returns_a_text_artist(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1, 2], [0, 1, 2])
+        # Act
+        out = stx_annotate_n(ax, 1, 1, 340)
+        # Assert
+        assert isinstance(out, matplotlib.text.Text)
+
+    def test_default_text_is_n_equals(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1, 2], [0, 1, 2])
+        # Act
+        out = stx_annotate_n(ax, 1, 1, 340)
+        # Assert
+        assert out.get_text() == "n=340"
+
+    def test_integer_n_gets_comma_formatted(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0, 0, 12340)
+        # Assert
+        assert out.get_text() == "n=12,340"
+
+    def test_comma_false_disables_grouping(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0, 0, 12340, comma=False)
+        # Assert
+        assert out.get_text() == "n=12340"
+
+    def test_custom_prefix_capital_n(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0, 0, 12, prefix="N")
+        # Assert
+        assert out.get_text() == "N=12"
+
+    def test_string_n_used_verbatim_with_suffix_semantics(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0, 0, "12 patients", prefix="N")
+        # Assert
+        assert out.get_text() == "N=12 patients"
+
+    def test_suffix_appended(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0, 0, 12, suffix=" patients")
+        # Assert
+        assert out.get_text() == "n=12 patients"
+
+    def test_default_color_is_black(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0, 0, 5)
+        # Assert
+        assert matplotlib.colors.to_hex(out.get_color()) == "#000000"
+
+    def test_custom_color_applied(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0, 0, 5, color="red")
+        # Assert
+        assert matplotlib.colors.to_hex(out.get_color()) == "#ff0000"
+
+    def test_default_fontsize_is_small_annotation_size(self):
+        # Arrange: the default (SCITEX) style's fonts.annotation_pt is 6.
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0, 0, 5)
+        # Assert
+        assert out.get_fontsize() == 6
+
+    def test_explicit_fontsize_respected(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0, 0, 5, fontsize=9)
+        # Assert
+        assert out.get_fontsize() == 9
+
+    def test_label_offset_from_anchor_point(self):
+        # Arrange: overlap avoidance should move the label off the exact
+        # data coordinate, not stack it directly on the point.
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1], marker="o")
+        # Act
+        out = stx_annotate_n(ax, 0.5, 0.5, 10)
+        # Assert
+        xd, yd = out.get_position()
+        assert (xd, yd) != (0.5, 0.5)
+
+    def test_avoid_overlap_false_still_offsets_by_offset_pt(self):
+        # Arrange
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        # Act
+        out = stx_annotate_n(ax, 0.5, 0.5, 10, avoid_overlap=False)
+        # Assert
+        xd, yd = out.get_position()
+        assert (xd, yd) != (0.5, 0.5)
+
+    def test_crowded_axes_emits_warning_not_silent(self):
+        # Arrange: box the annotation in on all sides with dense ink so the
+        # ring search exhausts its reach and must fall back -- this must
+        # warn, never fail silently.
+        import numpy as np
+
+        from figrecipe._scitex_compat._annotate_n import stx_annotate_n
+
+        fig, ax = plt.subplots(figsize=(1.0, 1.0))
+        xx, yy = np.meshgrid(np.linspace(0, 1, 60), np.linspace(0, 1, 60))
+        ax.pcolormesh(xx, yy, xx + yy)
+        # Act / Assert
+        with pytest.warns(UserWarning):
+            stx_annotate_n(ax, 0.5, 0.5, 10, max_radius=8.0)
+
+    def test_recording_axes_method_returns_result(self):
+        # Arrange
+        import figrecipe as fr
+
+        fig, ax = fr.subplots()
+        ax.plot([0, 1, 2], [0, 1, 2])
+        # Act
+        out = ax.stx_annotate_n(1, 1, 340)
+        # Assert
+        assert out is not None
+
+    def test_recording_axes_roundtrip(self, tmp_path):
+        # Arrange: the composite stx_* call must survive save -> reproduce.
+        import figrecipe as fr
+
+        fig, ax = fr.subplots()
+        ax.plot([0, 1, 2], [0, 1, 2], id="trace")
+        ax.stx_annotate_n(1, 1, 340, id="n_label")
+        output_path = tmp_path / "annotate_n.yaml"
+        # Act
+        fr.save(fig, output_path)
+        plt.close("all")
+        fig2, ax2 = fr.reproduce(output_path)
+        # Assert
+        assert fig2 is not None

--- a/tests/figrecipe/_scitex_compat/test__annotate_n.py
+++ b/tests/figrecipe/_scitex_compat/test__annotate_n.py
@@ -85,7 +85,7 @@ class TestAnnotateN:
         # Assert
         assert out.get_text() == "N=12 patients"
 
-    def test_suffix_appended(self):
+    def test_suffix_is_appended_to_label(self):
         # Arrange
         from figrecipe._scitex_compat._annotate_n import stx_annotate_n
 
@@ -166,9 +166,10 @@ class TestAnnotateN:
         assert (xd, yd) != (0.5, 0.5)
 
     def test_crowded_axes_emits_warning_not_silent(self):
-        # Arrange: box the annotation in on all sides with dense ink so the
-        # ring search exhausts its reach and must fall back -- this must
-        # warn, never fail silently.
+        # Arrange
+        # Box the annotation in on all sides with dense ink so the ring
+        # search exhausts its reach and must fall back -- this must warn,
+        # never fail silently.
         import numpy as np
 
         from figrecipe._scitex_compat._annotate_n import stx_annotate_n
@@ -176,9 +177,11 @@ class TestAnnotateN:
         fig, ax = plt.subplots(figsize=(1.0, 1.0))
         xx, yy = np.meshgrid(np.linspace(0, 1, 60), np.linspace(0, 1, 60))
         ax.pcolormesh(xx, yy, xx + yy)
-        # Act / Assert
-        with pytest.warns(UserWarning):
+        # Act
+        with pytest.warns(UserWarning) as warnings_raised:
             stx_annotate_n(ax, 0.5, 0.5, 10, max_radius=8.0)
+        # Assert
+        assert len(warnings_raised) >= 1
 
     def test_recording_axes_method_returns_result(self):
         # Arrange

--- a/tests/figrecipe/styles/_axis_helpers/test__comma_format.py
+++ b/tests/figrecipe/styles/_axis_helpers/test__comma_format.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for thousands-separator comma tick formatting."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+
+class TestCommaFormatter:
+    """Tests for the ``CommaFormatter`` class."""
+
+    def test_default_format_adds_commas(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import CommaFormatter
+
+        formatter = CommaFormatter()
+        # Act
+        result = formatter(12000)
+        # Assert
+        assert result == "12,000"
+
+    def test_default_format_small_number_no_commas(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import CommaFormatter
+
+        formatter = CommaFormatter()
+        # Act
+        result = formatter(42)
+        # Assert
+        assert result == "42"
+
+    def test_custom_fformat_decimal_places(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import CommaFormatter
+
+        formatter = CommaFormatter(fformat="{:,.2f}")
+        # Act
+        result = formatter(1234.5)
+        # Assert
+        assert result == "1,234.50"
+
+    def test_millions_get_two_commas(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import CommaFormatter
+
+        formatter = CommaFormatter()
+        # Act
+        result = formatter(1234567)
+        # Assert
+        assert result == "1,234,567"
+
+
+class TestCommaFormat:
+    """Tests for the ``comma_format(ax, ...)`` helper."""
+
+    @pytest.fixture(autouse=True)
+    def reset_matplotlib(self):
+        plt.close("all")
+        matplotlib.rcdefaults()
+        yield
+        plt.close("all")
+
+    def test_returns_same_axes(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import comma_format
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 12000, 24000], [0, 1, 2])
+        # Act
+        out = comma_format(ax, x=True)
+        # Assert
+        assert out is ax
+
+    def test_x_axis_formatter_applied(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import (
+            CommaFormatter,
+            comma_format,
+        )
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 12000, 24000], [0, 1, 2])
+        # Act
+        comma_format(ax, x=True)
+        # Assert
+        assert isinstance(ax.xaxis.get_major_formatter(), CommaFormatter)
+
+    def test_y_axis_formatter_applied(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import (
+            CommaFormatter,
+            comma_format,
+        )
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 12000])
+        # Act
+        comma_format(ax, y=True)
+        # Assert
+        assert isinstance(ax.yaxis.get_major_formatter(), CommaFormatter)
+
+    def test_default_neither_axis_touched(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import (
+            CommaFormatter,
+            comma_format,
+        )
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 12000], [0, 12000])
+        # Act
+        comma_format(ax)
+        # Assert
+        assert not isinstance(ax.xaxis.get_major_formatter(), CommaFormatter)
+        assert not isinstance(ax.yaxis.get_major_formatter(), CommaFormatter)
+
+    def test_rendered_tick_label_has_comma(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import comma_format
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 24000], [0, 1])
+        ax.set_xticks([12000])
+        comma_format(ax, x=True)
+        # Act
+        fig.canvas.draw()
+        label = ax.get_xticklabels()[0].get_text()
+        # Assert
+        assert label == "12,000"
+
+    def test_recording_axes_method(self):
+        # Arrange
+        import figrecipe as fr
+
+        fig, ax = fr.subplots()
+        ax.plot([0, 12000, 24000], [0, 1, 2])
+        # Act
+        out = ax.comma_format(x=True)
+        # Assert
+        assert out is not None
+
+    def test_rejects_non_axes(self):
+        # Arrange
+        from figrecipe.styles._axis_helpers._comma_format import comma_format
+
+        # Act / Assert
+        with pytest.raises(TypeError):
+            comma_format("not an axes", x=True)

--- a/tests/figrecipe/styles/_axis_helpers/test__comma_format.py
+++ b/tests/figrecipe/styles/_axis_helpers/test__comma_format.py
@@ -114,8 +114,10 @@ class TestCommaFormat:
         # Act
         comma_format(ax)
         # Assert
-        assert not isinstance(ax.xaxis.get_major_formatter(), CommaFormatter)
-        assert not isinstance(ax.yaxis.get_major_formatter(), CommaFormatter)
+        assert not any(
+            isinstance(axis.get_major_formatter(), CommaFormatter)
+            for axis in (ax.xaxis, ax.yaxis)
+        )
 
     def test_rendered_tick_label_has_comma(self):
         # Arrange
@@ -142,10 +144,13 @@ class TestCommaFormat:
         # Assert
         assert out is not None
 
-    def test_rejects_non_axes(self):
+    def test_rejects_non_axes_argument_with_type_error(self):
         # Arrange
         from figrecipe.styles._axis_helpers._comma_format import comma_format
 
-        # Act / Assert
-        with pytest.raises(TypeError):
-            comma_format("not an axes", x=True)
+        not_an_axes = "not an axes"
+        # Act
+        raised = pytest.raises(TypeError)
+        # Assert
+        with raised:
+            comma_format(not_an_axes, x=True)


### PR DESCRIPTION
## Summary
Downstream (neurovista) dogfooding: hand-rolled `f"{n:,}"` formatting and ad-hoc sample-size ax.text placement on every figure, now systematized:
- `comma_format(ax, x=, y=)` / `CommaFormatter` mirroring the existing OOMFormatter/sci_note pattern; exposed as `fr.styles.comma_format` + `ax.comma_format()`.
- `ax.stx_annotate_n(ax, x, y, n, ...)` following the stx_* convention; font from the active style, black default, overlap avoidance REUSES the existing declutter ring-solver + ink-mask renderer (no reimplemented collision detection), warned fallback to fixed offset.

## Test plan
- [x] New mirror test files for both modules.
- [x] scitex-dev audit clean.
- [x] Local pytest-testmon skipped (laptop load); CI matrix is the gate.