### PR TITLE
feat(stats): StatResult — make the six-stat doctrine executable, not just documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.0] - 2026-07-14
+
+### Added
+- **`figrecipe.StatResult`** — the display-side port for a completed statistical
+  test, and the first half of the six-stat doctrine that is *executable* rather
+  than merely documented. 0.31.0 shipped the doctrine and a lint for it, but the
+  only way to satisfy it was still to hand-type the mathtext
+  (`text=r"$\it{N}$=12, $\it{n}$=340, ..."`) — tedious, easy to typo, and
+  impossible to verify, since a forgotten field looks exactly like a complete
+  one. `StatResult` builds that string instead:
+
+  ```python
+  result = fr.StatResult(
+      p_value=welch.pvalue, method="Welch's t-test",
+      statistic=welch.statistic, statistic_name="t", dof=welch.df,
+      effect_size=d, effect_name="d", ci=(0.85, 1.16),
+      n=720, n_subjects=12, n_unit="windows", n_subjects_unit="patients",
+  )
+  ax.add_stat_annotation(0, 1, stat=result, stars=True)
+  ```
+
+  figrecipe DISPLAYS statistics; it never computes them. A producer
+  (scitex-stats, scipy, a stored results table) fills the fields — via the
+  constructor or `StatResult.from_mapping(result_dict)`, the adapter seam that
+  accepts the common key spellings and preserves unrecognised keys in `extras`.
+  Neither package imports the other; the only coupling is the field names.
+
+  - `.missing_fields()` names the doctrine fields a result cannot render — the
+    check the STX-FM017 lint structurally cannot do, since it only sees literal
+    strings and skips f-strings.
+  - Rendering an incomplete result **warns** (naming the missing fields) rather
+    than silently emitting a partial annotation; `require_complete=False` opts
+    out when the rest genuinely lives in the caption.
+  - Italic symbols, `N`-vs-`n`, Greek statistics (`chi2` → *χ²*), comma-grouped
+    sample sizes, and Welch's fractional dof (`694.053` → `t(694.1)`) are all
+    handled, so the conventions are automatic instead of remembered.
+  - `stars=True` prepends the significance stars — never as a *substitute* for
+    the p-value, which is always rendered alongside them.
+- **`examples/12_six_stat_annotation.py`** — worked example; every number in the
+  rendered figure is computed, none typed.
+
+### Changed
+- `ax.add_stat_annotation(...)` accepts `stat=`, `stars=`, `sep=` and
+  `precision=`, and defaults to the new `style="six_stat"` when a `stat` is
+  supplied (unchanged `style="stars"` behaviour otherwise). Its recording half
+  moved to `_wrappers/_stat_annotation.py::record_stat_annotation`, beside the
+  drawing code it wraps; a supplied `StatResult` is resolved to plain text
+  before recording, so recipes replay without the producer's result object.
+
 ## [0.31.0] - 2026-07-13
 
 ### Added

--- a/examples/12_six_stat_annotation.py
+++ b/examples/12_six_stat_annotation.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+12_six_stat_annotation.py
+
+Statistical annotations that satisfy the six-stat doctrine without hand-typing
+mathtext.
+
+The doctrine (skill 27) requires every statistical annotation on a figure to carry
+all six of n / CI / method / p-value / effect size / test statistic, with italic
+statistical symbols. Until ``StatResult`` existed, the only way to comply was to
+type the mathtext by hand::
+
+    ax.add_stat_annotation(x1=0, x2=1, text=r"$\\it{N}$=12, $\\it{n}$=340, ...")
+
+which is tedious, easy to typo, and — worst — impossible to check: a forgotten
+field looks exactly like a complete one. ``StatResult`` is the display-side port
+for a computed test result. A producer (scitex-stats, scipy, a stored results
+table) fills in the fields; figrecipe renders them. Neither imports the other.
+
+Every number in this figure is COMPUTED from the generated data below and passed
+through ``StatResult`` — nothing is hand-typed.
+
+Also demonstrates, from the same release line:
+- ``ax.stx_annotate_n(...)`` — sample-size labels that dodge existing ink.
+- ``ax.comma_format(...)`` — thousands-separator tick labels.
+- The heatmap colorbar requirement (doctrine rule 2): colorbar + label + units.
+"""
+
+from pathlib import Path
+
+import numpy as np
+from scipy import stats
+
+import figrecipe as fr
+
+OUT = Path(__file__).parent / "12_six_stat_annotation_out"
+
+
+def cohens_d(a: np.ndarray, b: np.ndarray) -> float:
+    """Standardised mean difference, pooled SD."""
+    n_a, n_b = len(a), len(b)
+    pooled_var = ((n_a - 1) * a.var(ddof=1) + (n_b - 1) * b.var(ddof=1)) / (
+        n_a + n_b - 2
+    )
+    return (b.mean() - a.mean()) / np.sqrt(pooled_var)
+
+
+def cohens_d_ci(d: float, n_a: int, n_b: int, level: float = 0.95) -> tuple:
+    """Confidence interval on Cohen's d itself.
+
+    The CI must bracket the effect size it is reported next to. A CI on the raw
+    mean *difference* printed beside a standardised *d* reads as a contradiction
+    (the interval does not contain the number it appears to qualify), so compute
+    the interval on d.
+    """
+    se = np.sqrt((n_a + n_b) / (n_a * n_b) + d**2 / (2 * (n_a + n_b)))
+    crit = stats.norm.ppf(1 - (1 - level) / 2)
+    return (d - crit * se, d + crit * se)
+
+
+def main() -> int:
+    OUT.mkdir(exist_ok=True)
+    rng = np.random.default_rng(42)
+
+    fig, axes = fr.subplots(1, 3, figsize=(180 / 25.4, 55 / 25.4))
+
+    # === Panel A: two-group comparison, six-stat annotation ==================
+    # The data. n_subjects (N) and per-subject windows (n) are kept distinct —
+    # collapsing them hides the unit of statistical independence.
+    n_subjects, windows_per_subject = 12, 30
+    control = rng.normal(2.1, 0.8, n_subjects * windows_per_subject)
+    treated = rng.normal(3.0, 0.9, n_subjects * windows_per_subject)
+
+    # The statistics: computed, never typed. Treated first, so a positive t and a
+    # positive d describe the same direction of effect.
+    welch = stats.ttest_ind(treated, control, equal_var=False)
+    effect = cohens_d(control, treated)
+    result = fr.StatResult(
+        p_value=float(welch.pvalue),
+        method="Welch's t-test",
+        statistic=float(welch.statistic),
+        statistic_name="t",
+        dof=float(welch.df),
+        effect_size=effect,
+        effect_name="d",
+        ci=cohens_d_ci(effect, len(control), len(treated)),
+        n=len(control) + len(treated),
+        n_subjects=n_subjects,
+        n_unit="windows",
+        n_subjects_unit="patients",
+    )
+    print(f"Panel A missing fields: {result.missing_fields()}")  # -> []
+
+    ax = axes[0]
+    means = [control.mean(), treated.mean()]
+    errors = [control.std(ddof=1), treated.std(ddof=1)]
+    ax.bar([0, 1], means, yerr=errors, capsize=2.3, id="bars_a")
+    ax.set_xticks([0, 1])
+    ax.set_xticklabels(["Control", "Treated"])
+    ax.set_ylabel("Firing rate [Hz]")
+    ax.set_ylim(0, 7.4)
+
+    # Per-group sample sizes, printed inside the bars. avoid_overlap is OFF here on
+    # purpose: it dodges existing ink, and the bar *is* the ink -- leaving it on
+    # would push a white label off the bar and onto the white background.
+    for position, group in zip((0, 1), (control, treated)):
+        ax.stx_annotate_n(
+            position, 0.5, len(group), color="white", avoid_overlap=False, ha="center"
+        )
+
+    # One call renders the bracket, the stars, AND all six fields in italic. The
+    # stars never replace the p-value -- the exact number is right underneath them.
+    ax.add_stat_annotation(0, 1, stat=result, y=4.6, sep=",\n", stars=True, id="stat_a")
+
+    # === Panel B: correlation over many samples, comma ticks + n label =======
+    n_windows = 24_000
+    x = rng.normal(12_000, 4_000, n_windows)
+    y = 0.42 * (x - x.mean()) / x.std() + rng.normal(0, 1, n_windows)
+
+    pearson = stats.pearsonr(x, y)
+    correlation = fr.StatResult(
+        p_value=float(pearson.pvalue),
+        method="Pearson correlation",
+        statistic=float(
+            pearson.statistic
+            * np.sqrt((n_windows - 2))
+            / np.sqrt(1 - pearson.statistic**2)
+        ),
+        statistic_name="t",
+        dof=n_windows - 2,
+        effect_size=float(pearson.statistic),
+        effect_name="r",
+        ci=tuple(pearson.confidence_interval()),
+        n=n_windows,
+        n_unit="windows",
+        n_subjects=n_subjects,
+        n_subjects_unit="patients",
+    )
+
+    ax = axes[1]
+    ax.scatter(x, y, s=0.5, alpha=0.15, id="scatter_b")
+    ax.set_xlabel("Stimulus intensity [a.u.]")
+    ax.set_ylabel("Normalised response [z]")
+    # Thousands separators, so "24000" reads as "24,000".
+    ax.comma_format(x=True)
+    # The full six-stat line, rendered from the computed correlation. (No separate
+    # n label here -- the annotation already carries N and n; repeating them would
+    # be redundant ink.)
+    ax.text(
+        0.02,
+        0.02,
+        correlation.annotation(sep=",\n"),
+        transform=ax.transAxes,
+        fontsize=5,
+        va="bottom",
+    )
+
+    # === Panel C: heatmap — colorbar with label AND units (doctrine rule 2) ==
+    ax = axes[2]
+    time = np.linspace(0, 1, 60)
+    freq = np.linspace(4, 80, 40)
+    power = np.exp(-((freq[:, None] - 40) ** 2) / 300) * np.exp(
+        -((time[None, :] - 0.5) ** 2) / 0.05
+    )
+    # pcolormesh, not imshow: the SCITEX style strips ticks and spines from every
+    # imshow -- right for a photo, wrong for a time-by-frequency map whose axes
+    # carry physical meaning, and not overridable (the style is re-applied on save).
+    image = ax.pcolormesh(time, freq, power, cmap="viridis", id="heatmap_c")
+    ax.set_xlabel("Time [s]")
+    ax.set_ylabel("Frequency [Hz]")
+    # Doctrine rule 2: a heatmap needs a colorbar, with a label AND units.
+    fig.colorbar(image, ax=ax._ax, label="Power [dB]")
+
+    fig.add_panel_labels(["A", "B", "C"])
+    fr.save(fig, OUT / "six_stat_annotation.png", validate=False)
+    print(f"Output: {OUT / 'six_stat_annotation.png'}")
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.31.0"
+version = "0.32.0"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -173,6 +173,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "configure_mpl": ("._configure_mpl", "configure_mpl"),
     # ._diagram
     "Diagram": ("._diagram", "Diagram"),
+    "StatResult": ("._annotations", "StatResult"),
     "_Graphviz": ("._diagram._graphviz.graphviz", "Graphviz"),
     "_Mermaid": ("._diagram._mermaid.mermaid", "Mermaid"),
     # ._graph._presets
@@ -313,6 +314,8 @@ __all__ = [
     "list_presets",
     # Diagram
     "Diagram",
+    # Statistics display port (six-stat annotation doctrine)
+    "StatResult",
     # Color utilities
     "colors",
     "color",

--- a/src/figrecipe/_annotations/__init__.py
+++ b/src/figrecipe/_annotations/__init__.py
@@ -45,6 +45,7 @@ from ._stat_bracket import (
     remove_stat_bracket,
     update_stat_bracket,
 )
+from ._stat_result import StatResult
 from ._stat_text import add_stat_text, list_stat_texts, remove_stat_text
 
 __all__ = [
@@ -59,6 +60,8 @@ __all__ = [
     "list_stat_texts",
     # Auto-placement
     "auto_y_position",
+    # Display port for a computed test result (six-stat doctrine)
+    "StatResult",
 ]
 
 # EOF

--- a/src/figrecipe/_annotations/_stat_result.py
+++ b/src/figrecipe/_annotations/_stat_result.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``StatResult`` — the display-side port for a completed statistical test.
+
+figrecipe DISPLAYS statistics; it never computes them. This dataclass is the
+boundary between those two concerns (ports & adapters): a producer — scitex-stats,
+scipy, R, a CSV of pre-computed results — fills in the fields, and figrecipe turns
+them into a doctrine-compliant, italic-symbol annotation string. figrecipe does not
+import scitex-stats, and scitex-stats does not know figrecipe exists; the only
+coupling is the field names below.
+
+The doctrine (see ``_skills/figrecipe/27_six-stat-annotation-doctrine.md``) requires
+all six of n / CI / method / p / effect size / test statistic on every statistical
+annotation. Before this module the only way to satisfy it was to hand-type the
+mathtext:
+
+    ax.add_stat_annotation(x1=0, x2=1, text=r"$\\it{N}$=12, $\\it{n}$=340, ...")
+
+which is both tedious and unverifiable — a typo'd exponent or a forgotten field
+looks fine until review. ``StatResult`` builds that string instead, so the six
+fields are structurally present or you get a warning naming exactly which ones
+are not.
+"""
+
+from __future__ import annotations
+
+__all__ = ["StatResult", "MISSING_STAT_FIELD_WARNING"]
+
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence, Tuple, Union
+
+MISSING_STAT_FIELD_WARNING = (
+    "Statistical annotation is missing required field(s): {missing}. The six-stat "
+    "doctrine requires n, CI, method, p-value, effect size, and test statistic "
+    "(see figrecipe skill 27_six-stat-annotation-doctrine). Supply them, or move "
+    "them into the caption and pass require_complete=False to silence this."
+)
+
+# Statistical symbols that are NOT simply an italicised latin letter.
+_SYMBOL_MATHTEXT = {
+    "chi2": r"\chi^2",
+    "chisq": r"\chi^2",
+    "eta2": r"\eta^2",
+    "eta_squared": r"\eta^2",
+    "partial_eta2": r"\eta_p^2",
+    "omega2": r"\omega^2",
+    "rho": r"\rho",
+    "tau": r"\tau",
+}
+
+_DofT = Union[float, int, Sequence[float], None]
+
+
+def _mathtext(symbol: str) -> str:
+    """Render a statistical symbol as italic mathtext (doctrine rule: italics)."""
+    special = _SYMBOL_MATHTEXT.get(symbol.lower())
+    body = special if special is not None else rf"\it{{{symbol}}}"
+    return f"${body}$"
+
+
+def _format_one_dof(dof: float) -> str:
+    """Integer dof render bare; a fractional dof (Welch) keeps one decimal.
+
+    Welch's correction produces a non-integer dof (e.g. 694.053). Printing its
+    full float precision is noise -- no reader needs the third decimal of a
+    degrees-of-freedom -- so collapse it to a single decimal, and to a bare
+    integer when it is one.
+    """
+    if float(dof).is_integer():
+        return f"{int(dof)}"
+    return f"{dof:.1f}"
+
+
+def _format_dof(dof: _DofT) -> str:
+    """Render degrees of freedom as ``(338)`` or ``(2, 57)``; empty when absent."""
+    if dof is None:
+        return ""
+    if isinstance(dof, (int, float)):
+        return f"({_format_one_dof(dof)})"
+    return "(" + ", ".join(_format_one_dof(d) for d in dof) + ")"
+
+
+def _format_p(p_value: float, precision: int = 3) -> str:
+    """Render a p-value, collapsing to ``< 0.001`` below display precision."""
+    floor = 10.0**-precision
+    symbol = _mathtext("p")
+    if p_value < floor:
+        return f"{symbol} < {floor:g}"
+    return f"{symbol} = {p_value:.{precision}f}"
+
+
+@dataclass(frozen=True)
+class StatResult:
+    """A completed statistical test, ready to be rendered onto a figure.
+
+    Only ``p_value`` is structurally required — a result with no p-value is not a
+    test result at all. The other five doctrine fields are optional at the type
+    level but their absence is reported by :meth:`missing_fields` and warned about
+    at render time, because "incomplete but loud" is more useful than "complete or
+    TypeError": a producer that genuinely cannot supply a CI (e.g. a permutation
+    test) should still be able to render, with the gap visible.
+
+    Parameters
+    ----------
+    p_value : float
+        The p-value of the test.
+    method : str, optional
+        Human-readable test name, e.g. ``"Welch's t-test"``. Rendered upright.
+    statistic : float, optional
+        The test statistic's value.
+    statistic_name : str
+        Symbol for the test statistic (``"t"``, ``"F"``, ``"U"``, ``"chi2"``, ...).
+    dof : float or sequence of float, optional
+        Degrees of freedom; a scalar renders ``t(338)``, a pair renders ``F(2, 57)``.
+    effect_size : float, optional
+        The effect size's value.
+    effect_name : str
+        Symbol for the effect size (``"d"``, ``"r"``, ``"eta2"``, ...).
+    ci : tuple of (float, float), optional
+        Confidence interval around the estimate.
+    ci_level : int
+        Confidence level as a percentage. Default 95.
+    n : int, optional
+        Number of observations (windows / trials / samples) — lowercase *n*.
+    n_subjects : int, optional
+        Number of subjects — capital *N*. Keep distinct from ``n``: collapsing the
+        two hides the unit of statistical independence from the reader.
+    n_unit, n_subjects_unit : str
+        Optional units, e.g. ``"windows"`` / ``"patients"``.
+
+    Examples
+    --------
+    >>> result = StatResult(
+    ...     p_value=0.0004, method="Pearson correlation",
+    ...     statistic=5.1, statistic_name="t", dof=338,
+    ...     effect_size=0.42, effect_name="r", ci=(0.21, 0.60),
+    ...     n=340, n_subjects=12,
+    ... )
+    >>> result.stars
+    '***'
+    >>> "Pearson correlation" in result.annotation()
+    True
+    """
+
+    p_value: float
+    method: Optional[str] = None
+    statistic: Optional[float] = None
+    statistic_name: str = "t"
+    dof: _DofT = None
+    effect_size: Optional[float] = None
+    effect_name: str = "d"
+    ci: Optional[Tuple[float, float]] = None
+    ci_level: int = 95
+    n: Optional[int] = None
+    n_subjects: Optional[int] = None
+    n_unit: str = ""
+    n_subjects_unit: str = ""
+    extras: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def stars(self) -> str:
+        """Significance stars for this p-value."""
+        # Single source of truth: the same threshold table the bracket helper uses.
+        from .._wrappers._stat_annotation import p_to_stars
+
+        return p_to_stars(self.p_value)
+
+    def missing_fields(self) -> list:
+        """Names of the doctrine's six fields that this result cannot render."""
+        missing = []
+        if self.n is None and self.n_subjects is None:
+            missing.append("n")
+        if self.ci is None:
+            missing.append("CI")
+        if not self.method:
+            missing.append("method")
+        if self.effect_size is None:
+            missing.append("effect size")
+        if self.statistic is None:
+            missing.append("test statistic")
+        return missing
+
+    def _sample_size_part(self) -> str:
+        parts = []
+        for symbol, value, unit in (
+            ("N", self.n_subjects, self.n_subjects_unit),
+            ("n", self.n, self.n_unit),
+        ):
+            if value is None:
+                continue
+            suffix = f" {unit}" if unit else ""
+            parts.append(f"{_mathtext(symbol)} = {value:,}{suffix}")
+        return ", ".join(parts)
+
+    def annotation(
+        self,
+        sep: str = ", ",
+        precision: int = 3,
+        stars: bool = False,
+        require_complete: bool = True,
+    ) -> str:
+        """Render the six-stat annotation string, with italic statistical symbols.
+
+        Parameters
+        ----------
+        sep : str
+            Separator between fields. Pass ``",\\n"`` to wrap onto two lines when a
+            panel is too narrow for one.
+        precision : int
+            Decimal places for the p-value before it collapses to ``< 0.001``.
+        stars : bool
+            Prepend the significance stars on their own line. The stars are a
+            convenience for the reader, never a substitute for the p-value — the
+            exact number is always rendered alongside them.
+        require_complete : bool
+            Warn (never raise) when any of the six doctrine fields is absent. Set
+            False when the missing fields genuinely live in the caption instead.
+
+        Returns
+        -------
+        str
+            e.g. ``"$N$ = 12, $n$ = 340, Pearson correlation, $t$(338) = 5.10,
+            $p$ < 0.001, $r$ = 0.42, 95% CI [0.21, 0.60]"``
+        """
+        if require_complete:
+            missing = self.missing_fields()
+            if missing:
+                warnings.warn(
+                    MISSING_STAT_FIELD_WARNING.format(missing=", ".join(missing)),
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+        parts = []
+        sample_sizes = self._sample_size_part()
+        if sample_sizes:
+            parts.append(sample_sizes)
+        if self.method:
+            parts.append(self.method)
+        if self.statistic is not None:
+            symbol = _mathtext(self.statistic_name)
+            parts.append(f"{symbol}{_format_dof(self.dof)} = {self.statistic:.2f}")
+        parts.append(_format_p(self.p_value, precision=precision))
+        if self.effect_size is not None:
+            parts.append(f"{_mathtext(self.effect_name)} = {self.effect_size:.2f}")
+        if self.ci is not None:
+            low, high = self.ci
+            parts.append(f"{self.ci_level}% CI [{low:.2f}, {high:.2f}]")
+
+        body = sep.join(parts)
+        return f"{self.stars}\n{body}" if stars else body
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Any]) -> "StatResult":
+        """Build a ``StatResult`` from a producer's result dict — the adapter seam.
+
+        This is how scitex-stats (or scipy, or a stored results table) hands a test
+        result to figrecipe without either side importing the other. Common key
+        spellings are accepted. Keys that match nothing are preserved verbatim in
+        ``extras`` rather than dropped, so a producer whose schema drifts leaves a
+        trace instead of vanishing into a silently-incomplete annotation — and the
+        render-time completeness warning still names whatever field went missing.
+
+        Raises
+        ------
+        KeyError
+            If no p-value key is present — that is not a test result.
+        """
+        aliases = {
+            "p_value": ("p_value", "pval", "p", "pvalue"),
+            "method": ("method", "test", "test_name", "testname"),
+            "statistic": ("statistic", "stat", "test_statistic"),
+            "statistic_name": ("statistic_name", "stat_name", "statistic_symbol"),
+            "dof": ("dof", "df", "degrees_of_freedom"),
+            "effect_size": ("effect_size", "effect", "effsize"),
+            "effect_name": ("effect_name", "effect_type", "effect_symbol"),
+            "ci": ("ci", "conf_int", "confidence_interval"),
+            "ci_level": ("ci_level", "confidence_level"),
+            "n": ("n", "nobs", "n_samples", "sample_size"),
+            "n_subjects": ("n_subjects", "N", "n_subj"),
+            "n_unit": ("n_unit",),
+            "n_subjects_unit": ("n_subjects_unit",),
+        }
+        consumed = set()
+        kwargs = {}
+        for target, keys in aliases.items():
+            for key in keys:
+                if key in mapping:
+                    kwargs[target] = mapping[key]
+                    consumed.add(key)
+                    break
+
+        if "p_value" not in kwargs:
+            raise KeyError(
+                "StatResult.from_mapping requires a p-value; none of "
+                f"{aliases['p_value']} found in keys {sorted(mapping)}."
+            )
+
+        # A CI split across two scalar keys is the other common producer shape.
+        if "ci" not in kwargs and {"ci_lower", "ci_upper"} <= set(mapping):
+            kwargs["ci"] = (mapping["ci_lower"], mapping["ci_upper"])
+            consumed |= {"ci_lower", "ci_upper"}
+
+        unmapped = set(mapping) - consumed
+        if unmapped:
+            kwargs["extras"] = {key: mapping[key] for key in sorted(unmapped)}
+
+        if kwargs.get("ci") is not None:
+            kwargs["ci"] = tuple(kwargs["ci"])
+        return cls(**kwargs)
+
+
+# EOF

--- a/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
+++ b/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
@@ -68,25 +68,37 @@ within-subject sample count exist hides the actual unit of statistical
 independence from the reader — a common and serious inferential error in
 per-window / per-trial neuroscience and physiology figures.
 
-### Compliant example
+### Compliant example — build it, do not type it
+
+Do NOT hand-type the mathtext. Pass a `figrecipe.StatResult` (see
+`_annotations/_stat_result.py`) and let figrecipe render it: the six fields
+are then structurally present or you get a warning naming exactly which are
+missing, and the italic / N-vs-n conventions are applied for you.
 
 ```python
-ax.add_stat_annotation(
-    x1=0, x2=1,
-    text=(
-        r"$N$=12, $n$=340, $r$=0.42, 95% CI [0.21, 0.60], "
-        r"$t$(338)=5.1, $p$<0.001 (Pearson correlation)"
-    ),
+result = fr.StatResult(
+    p_value=pearson.pvalue, method="Pearson correlation",
+    statistic=t_stat, statistic_name="t", dof=338,
+    effect_size=pearson.statistic, effect_name="r", ci=(0.21, 0.60),
+    n=340, n_subjects=12, n_unit="windows", n_subjects_unit="patients",
 )
+ax.add_stat_annotation(0, 1, stat=result, stars=True)
+result.missing_fields()  # -> []  (the check the lint cannot do on an f-string)
 ```
 
-All six fields are present (n, CI, method, p, effect, statistic), N and n
-are distinguished, and every statistical symbol is wrapped for italic
-rendering. Compare to the incomplete, lint-flagged form:
+`StatResult` is the DISPLAY-side port: figrecipe renders statistics, it never
+computes them. A producer (scitex-stats, scipy, a stored results table) fills
+the fields — via the constructor or `StatResult.from_mapping(result_dict)`,
+the adapter seam — and neither package imports the other. Every number must
+come from a computation, never a keyboard.
+
+Compare to the incomplete, lint-flagged form:
 
 ```python
 ax.add_stat_annotation(x1=0, x2=1, text="p=0.03")  # STX-FM017: missing n, CI, method, effect, statistic
 ```
+
+Working example: `examples/12_six_stat_annotation.py`.
 
 ## Rule 2 — heatmap colorbar requirement
 

--- a/src/figrecipe/_wrappers/_axes_methods.py
+++ b/src/figrecipe/_wrappers/_axes_methods.py
@@ -282,92 +282,17 @@ class RecordingAxesMethods:
             **kwargs,
         )
 
-    def add_stat_annotation(
-        self,
-        x1: float,
-        x2: float,
-        p_value: Optional[float] = None,
-        text: Optional[str] = None,
-        y: Optional[float] = None,
-        style: str = "stars",
-        bracket_height: Optional[float] = None,
-        text_offset: Optional[float] = None,
-        color: Optional[str] = None,
-        linewidth: Optional[float] = None,
-        fontsize: Optional[float] = None,
-        fontweight: Optional[str] = None,
-        id: Optional[str] = None,
-        track: bool = True,
-        **kwargs,
-    ):
+    def add_stat_annotation(self, x1: float, x2: float, **kwargs):
         """Add a statistical comparison annotation (bracket with stars/p-value).
 
-        Parameters
-        ----------
-        x1, x2 : float
-            X positions of the two groups being compared.
-        p_value : float, optional
-            P-value for automatic star conversion.
-        text : str, optional
-            Custom text (overrides p_value formatting).
-        y : float, optional
-            Y position for bracket (auto-calculated if None).
-        style : str
-            "stars", "p_value", "both", or "bracket_only".
+        Pass ``stat=StatResult(...)`` to render the full six-stat doctrine
+        annotation (n, CI, method, p, effect size, test statistic — italic symbols)
+        instead of hand-typing the mathtext; pass ``p_value=`` for stars only.
+        See ``_stat_annotation.record_stat_annotation`` for the full signature.
         """
-        from ._stat_annotation import draw_stat_annotation
+        from ._stat_annotation import record_stat_annotation
 
-        # Draw the annotation
-        artists = draw_stat_annotation(
-            self._ax,
-            x1,
-            x2,
-            y=y,
-            text=text,
-            p_value=p_value,
-            style=style,
-            bracket_height=bracket_height,
-            text_offset=text_offset,
-            color=color,
-            linewidth=linewidth,
-            fontsize=fontsize,
-            fontweight=fontweight,
-            **kwargs,
-        )
-
-        # Record if tracking
-        if self._track and track:
-            call_id = id if id else self._recorder._generate_call_id("stat_annotation")
-            record_kwargs = {
-                "x1": x1,
-                "x2": x2,
-                "p_value": p_value,
-                "text": text,
-                "y": y,
-                "style": style,
-                "bracket_height": bracket_height,
-                "text_offset": text_offset,
-                "color": color,
-                "linewidth": linewidth,
-                "fontsize": fontsize,
-            }
-            record_kwargs.update(kwargs)
-            # Remove None values
-            record_kwargs = {k: v for k, v in record_kwargs.items() if v is not None}
-
-            from .._recorder import CallRecord
-
-            record = CallRecord(
-                id=call_id,
-                function="stat_annotation",
-                args=[],
-                kwargs=record_kwargs,
-                ax_position=self._position,
-            )
-            ax_record = self._recorder.figure_record.get_or_create_axes(*self._position)
-            ax_record.add_decoration(record)
-
-        return artists
+        return record_stat_annotation(self, x1, x2, **kwargs)
 
     def _serialize_transform(self, transform) -> str:
         """Convert matplotlib transform to serializable marker."""

--- a/src/figrecipe/_wrappers/_stat_annotation.py
+++ b/src/figrecipe/_wrappers/_stat_annotation.py
@@ -227,6 +227,134 @@ def draw_stat_annotation(
     return artists
 
 
+def record_stat_annotation(
+    recording_axes: Any,
+    x1: float,
+    x2: float,
+    p_value: Optional[float] = None,
+    text: Optional[str] = None,
+    y: Optional[float] = None,
+    style: Optional[str] = None,
+    stat: Optional[Any] = None,
+    require_complete: bool = True,
+    sep: str = ", ",
+    precision: int = 3,
+    stars: bool = False,
+    id: Optional[str] = None,
+    track: bool = True,
+    **kwargs,
+) -> List[Any]:
+    """Draw a stat annotation on a ``RecordingAxes`` and record it for replay.
+
+    The recording half of ``RecordingAxes.add_stat_annotation`` — kept here, beside
+    the drawing code it wraps, rather than in ``_axes_methods.py`` where it is only
+    a method by accident of the mixin.
+
+    A supplied ``stat`` (a :class:`figrecipe.StatResult`) is resolved to plain
+    ``text`` + ``p_value`` *before* recording, so the recipe stores the rendered
+    string and replays byte-identically without needing to re-import the producer's
+    result object.
+
+    Parameters
+    ----------
+    recording_axes : RecordingAxes
+        The wrapper whose ``_ax`` is drawn on and whose recorder is updated.
+    stat : StatResult, optional
+        Completed test result. Under the default ``style="six_stat"`` its six
+        doctrine fields are rendered inline with italic symbols.
+    require_complete : bool
+        Warn when ``stat`` is missing any of the six required fields.
+    sep : str
+        Separator between the six fields. Pass ``",\\n"`` to wrap the annotation
+        onto two lines when a panel is too narrow for one. Ignored unless ``stat``
+        is rendering the text.
+    precision : int
+        Decimal places on the p-value before it collapses to ``< 0.001``.
+    stars : bool
+        Prepend the significance stars above the six-stat line.
+    """
+    if style is None:
+        style = "six_stat" if stat is not None else "stars"
+
+    if stat is not None:
+        if p_value is None:
+            p_value = stat.p_value
+        if text is None and style == "six_stat":
+            text = stat.annotation(
+                sep=sep,
+                precision=precision,
+                stars=stars,
+                require_complete=require_complete,
+            )
+
+    draw_kwargs = {
+        key: value
+        for key, value in kwargs.items()
+        if key
+        not in (
+            "bracket_height",
+            "text_offset",
+            "color",
+            "linewidth",
+            "fontsize",
+            "fontweight",
+        )
+    }
+    styling = {
+        key: kwargs[key]
+        for key in (
+            "bracket_height",
+            "text_offset",
+            "color",
+            "linewidth",
+            "fontsize",
+            "fontweight",
+        )
+        if key in kwargs
+    }
+
+    artists = draw_stat_annotation(
+        recording_axes._ax,
+        x1,
+        x2,
+        y=y,
+        text=text,
+        p_value=p_value,
+        style=style,
+        **styling,
+        **draw_kwargs,
+    )
+
+    if recording_axes._track and track:
+        recorder = recording_axes._recorder
+        call_id = id if id else recorder._generate_call_id("stat_annotation")
+        record_kwargs = {
+            "x1": x1,
+            "x2": x2,
+            "p_value": p_value,
+            "text": text,
+            "y": y,
+            "style": style,
+        }
+        record_kwargs.update(styling)
+        record_kwargs.update(draw_kwargs)
+        record_kwargs = {k: v for k, v in record_kwargs.items() if v is not None}
+
+        from .._recorder import CallRecord
+
+        record = CallRecord(
+            id=call_id,
+            function="stat_annotation",
+            args=[],
+            kwargs=record_kwargs,
+            ax_position=recording_axes._position,
+        )
+        ax_record = recorder.figure_record.get_or_create_axes(*recording_axes._position)
+        ax_record.add_decoration(record)
+
+    return artists
+
+
 def calculate_auto_y(
     ax: Axes,
     x1: float,

--- a/tests/figrecipe/_annotations/test__stat_result.py
+++ b/tests/figrecipe/_annotations/test__stat_result.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for ``StatResult`` — the six-stat display port."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+from figrecipe._annotations import StatResult
+
+
+def _complete_result() -> StatResult:
+    """A result carrying all six doctrine fields."""
+    return StatResult(
+        p_value=0.0004,
+        method="Pearson correlation",
+        statistic=5.1,
+        statistic_name="t",
+        dof=338,
+        effect_size=0.42,
+        effect_name="r",
+        ci=(0.21, 0.60),
+        n=340,
+        n_subjects=12,
+    )
+
+
+class TestMissingFields:
+    """The doctrine's completeness check."""
+
+    def test_complete_result_reports_nothing_missing(self):
+        # Arrange
+        result = _complete_result()
+        # Act
+        missing = result.missing_fields()
+        # Assert
+        assert missing == []
+
+    def test_bare_p_value_reports_all_five_others_missing(self):
+        # Arrange
+        result = StatResult(p_value=0.03)
+        # Act
+        missing = result.missing_fields()
+        # Assert
+        assert missing == ["n", "CI", "method", "effect size", "test statistic"]
+
+    def test_subject_count_alone_satisfies_sample_size(self):
+        # Arrange
+        result = StatResult(p_value=0.03, n_subjects=12)
+        # Act
+        missing = result.missing_fields()
+        # Assert
+        assert "n" not in missing
+
+
+class TestAnnotationRendering:
+    """The rendered mathtext string."""
+
+    def test_annotation_contains_every_doctrine_field(self):
+        # Arrange
+        result = _complete_result()
+        expected = ["12", "340", "Pearson correlation", "338", "5.10", "0.42", "95% CI"]
+        # Act
+        text = result.annotation()
+        # Assert
+        assert all(fragment in text for fragment in expected)
+
+    def test_statistical_symbols_render_in_italic(self):
+        # Arrange
+        result = _complete_result()
+        # Act
+        text = result.annotation()
+        # Assert
+        assert all(symbol in text for symbol in (r"$\it{p}$", r"$\it{t}$", r"$\it{r}$"))
+
+    def test_subject_and_sample_counts_stay_distinct(self):
+        # Arrange
+        result = _complete_result()
+        # Act
+        text = result.annotation()
+        # Assert
+        assert r"$\it{N}$ = 12" in text and r"$\it{n}$ = 340" in text
+
+    def test_tiny_p_value_collapses_below_precision(self):
+        # Arrange
+        result = StatResult(p_value=1e-9)
+        # Act
+        text = result.annotation(require_complete=False)
+        # Assert
+        assert r"$\it{p}$ < 0.001" in text
+
+    def test_large_sample_size_gets_comma_grouping(self):
+        # Arrange
+        result = StatResult(p_value=0.01, n=12340)
+        # Act
+        text = result.annotation(require_complete=False)
+        # Assert
+        assert "12,340" in text
+
+    def test_paired_dof_renders_two_values(self):
+        # Arrange
+        result = StatResult(
+            p_value=0.01, statistic=4.2, statistic_name="F", dof=(2, 57)
+        )
+        # Act
+        text = result.annotation(require_complete=False)
+        # Assert
+        assert r"$\it{F}$(2, 57) = 4.20" in text
+
+    def test_chi_square_uses_greek_symbol(self):
+        # Arrange
+        result = StatResult(p_value=0.01, statistic=9.1, statistic_name="chi2", dof=2)
+        # Act
+        text = result.annotation(require_complete=False)
+        # Assert
+        assert r"$\chi^2$(2) = 9.10" in text
+
+    def test_separator_is_configurable_for_wrapping(self):
+        # Arrange
+        result = _complete_result()
+        # Act
+        text = result.annotation(sep=",\n")
+        # Assert
+        assert "\n" in text
+
+    def test_stars_option_keeps_the_exact_p_value(self):
+        # Arrange: stars are a convenience, never a replacement for the number.
+        result = _complete_result()
+        # Act
+        text = result.annotation(stars=True)
+        # Assert
+        assert text.startswith("***\n") and r"$\it{p}$ < 0.001" in text
+
+    def test_incomplete_result_warns_instead_of_rendering_silently(self):
+        # Arrange
+        result = StatResult(p_value=0.03)
+        # Act
+        warns_on_incomplete = pytest.warns(UserWarning, match="missing required field")
+        # Assert
+        with warns_on_incomplete:
+            result.annotation()
+
+    def test_require_complete_false_suppresses_the_warning(self):
+        # Arrange
+        import warnings
+
+        result = StatResult(p_value=0.03)
+        # Act
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            result.annotation(require_complete=False)
+        # Assert
+        assert recorded == []
+
+
+class TestStars:
+    """p-value to significance stars."""
+
+    def test_highly_significant_p_gets_three_stars(self):
+        # Arrange
+        result = StatResult(p_value=0.0004)
+        # Act
+        stars = result.stars
+        # Assert
+        assert stars == "***"
+
+    def test_non_significant_p_is_marked_ns(self):
+        # Arrange
+        result = StatResult(p_value=0.4)
+        # Act
+        stars = result.stars
+        # Assert
+        assert stars == "n.s."
+
+
+class TestFromMapping:
+    """The adapter seam: a producer's result dict becomes a StatResult."""
+
+    def test_common_key_aliases_are_accepted(self):
+        # Arrange
+        mapping = {"pval": 0.03, "test": "Welch's t-test", "nobs": 60}
+        # Act
+        result = StatResult.from_mapping(mapping)
+        # Assert
+        assert (result.p_value, result.method, result.n) == (0.03, "Welch's t-test", 60)
+
+    def test_split_confidence_interval_keys_are_paired(self):
+        # Arrange
+        mapping = {"p": 0.01, "ci_lower": 0.1, "ci_upper": 1.1}
+        # Act
+        result = StatResult.from_mapping(mapping)
+        # Assert
+        assert result.ci == (0.1, 1.1)
+
+    def test_unrecognised_keys_are_preserved_in_extras(self):
+        # Arrange
+        mapping = {"p_value": 0.01, "alternative": "two-sided"}
+        # Act
+        result = StatResult.from_mapping(mapping)
+        # Assert
+        assert result.extras == {"alternative": "two-sided"}
+
+    def test_mapping_without_p_value_fails_loudly(self):
+        # Arrange
+        mapping = {"statistic": 2.4, "nobs": 60}
+        # Act
+        raises_on_missing_p = pytest.raises(KeyError, match="requires a p-value")
+        # Assert
+        with raises_on_missing_p:
+            StatResult.from_mapping(mapping)
+
+
+class TestAxesIntegration:
+    """``ax.add_stat_annotation(stat=...)`` on a recording axes."""
+
+    @pytest.fixture(autouse=True)
+    def reset_matplotlib(self):
+        plt.close("all")
+        yield
+        plt.close("all")
+
+    def test_stat_renders_full_annotation_by_default(self):
+        # Arrange
+        import figrecipe as fr
+
+        fig, ax = fr.subplots()
+        ax.bar([0, 1], [3, 5], id="bars")
+        # Act
+        artists = ax.add_stat_annotation(0, 1, stat=_complete_result(), y=6)
+        # Assert
+        assert "Pearson correlation" in artists[-1].get_text()
+
+    def test_explicit_stars_style_overrides_full_render(self):
+        # Arrange
+        import figrecipe as fr
+
+        fig, ax = fr.subplots()
+        ax.bar([0, 1], [3, 5], id="bars")
+        # Act
+        artists = ax.add_stat_annotation(
+            0, 1, stat=_complete_result(), y=6, style="stars"
+        )
+        # Assert
+        assert artists[-1].get_text() == "***"
+
+    def test_plain_p_value_call_still_shows_stars(self):
+        # Arrange
+        import figrecipe as fr
+
+        fig, ax = fr.subplots()
+        ax.bar([0, 1], [3, 5], id="bars")
+        # Act
+        artists = ax.add_stat_annotation(0, 1, p_value=0.0004, y=6)
+        # Assert
+        assert artists[-1].get_text() == "***"
+
+    def test_stat_annotation_survives_save_and_reproduce(self, tmp_path):
+        # Arrange
+        import figrecipe as fr
+
+        fig, ax = fr.subplots()
+        ax.bar([0, 1], [3, 5], id="bars")
+        ax.add_stat_annotation(0, 1, stat=_complete_result(), y=6, id="stat")
+        recipe = tmp_path / "stat.yaml"
+        fr.save(fig, recipe)
+        plt.close("all")
+        # Act
+        fig2, ax2 = fr.reproduce(recipe)
+        # Assert
+        assert any("Pearson correlation" in t.get_text() for t in ax2.texts)
+
+
+# EOF


### PR DESCRIPTION
## Why

0.31.0 shipped the six-stat annotation doctrine (every statistical annotation carries **n / CI / method / p / effect size / test statistic**, italic symbols, N distinct from n) and a lint for it — but left no way to actually *satisfy* it except hand-typing the mathtext:

```python
ax.add_stat_annotation(x1=0, x2=1, text=r"$\it{N}$=12, $\it{n}$=340, ...")
```

That is tedious, easy to typo, and — worst — **unverifiable**: a forgotten field looks exactly like a complete one. The `STX-FM017` lint structurally cannot help, because it only inspects literal strings and skips f-strings, which is how any real script builds this.

The doctrine's own "compliant example" was a hand-typed raw string. This PR replaces it with something that builds the string for you.

## What

`figrecipe.StatResult` — the **display-side port** for a completed statistical test.

figrecipe *displays* statistics; it never computes them. A producer (scitex-stats, scipy, a stored results table) fills the fields — via the constructor or `StatResult.from_mapping(result_dict)`, the adapter seam — and **neither package imports the other**. The only coupling is the field names.

```python
result = fr.StatResult(
    p_value=welch.pvalue, method="Welch's t-test",
    statistic=welch.statistic, statistic_name="t", dof=welch.df,
    effect_size=d, effect_name="d", ci=(0.85, 1.16),
    n=720, n_subjects=12, n_unit="windows", n_subjects_unit="patients",
)
ax.add_stat_annotation(0, 1, stat=result, stars=True)
result.missing_fields()   # -> []
```

- `.missing_fields()` names the doctrine fields a result cannot render — the check the lint can't do.
- An incomplete result **warns**, naming what is missing, rather than silently emitting a partial annotation (no silent fallback).
- Italic symbols, N-vs-n, Greek statistics (`chi2` → *χ²*), comma-grouped sample sizes, and Welch's fractional dof (`694.053` → `t(694.1)`) are handled — conventions become automatic instead of remembered.
- `stars=True` prepends significance stars — never as a *substitute* for the p-value, which is always rendered alongside.

## Refactor

`add_stat_annotation`'s recording half moves to `_wrappers/_stat_annotation.py::record_stat_annotation`, beside the drawing code it wraps. `_axes_methods.py` was over its line budget, and the method lived there only by accident of the mixin. A supplied `StatResult` resolves to plain text *before* recording, so recipes replay without needing the producer's result object.

## Verification

- 24 new tests (38 in the annotations suite), including a save → reproduce round-trip.
- `examples/12_six_stat_annotation.py` renders a worked figure in which **every number is computed and none is typed**.

## Found while building this

The SCITEX style strips ticks, tick labels and spines from **every** `imshow` — right for a photo, wrong for a heatmap whose axes carry physical meaning, and it contradicts the doctrine's own rule 2. It is also not overridable (the style is re-applied on save) and emits no warning. Carded separately; the example uses `pcolormesh` to sidestep it.