### PR TITLE
fix(styles): keep imshow axis suppression reversible so heatmaps keep their ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.1] - 2026-07-14
+
+### Fixed
+- **A heatmap no longer loses its tick numbers with no way to get them back.**
+  The SCITEX style suppresses axis chrome on `imshow` — correct for a picture,
+  where ticks are noise, but the same call also draws heatmaps and spectrograms
+  whose x/y axes carry physical meaning (time, frequency) and must stay readable.
+
+  The suppression cleared the ticks with `set_xticks([])` **and**
+  `set_xticklabels([])`. The second call was not merely redundant: it pinned a
+  `NullFormatter` on the axis, so every tick the caller set *afterwards* rendered
+  blank. A `ax.set_xticks([0, 0.5, 1.0])` after the `imshow` therefore produced
+  tick marks with no numbers — silently, with no warning, and with no way to
+  override it. That contradicts the readable-heatmap rule in figrecipe's own
+  six-stat doctrine skill, and it violated the no-silent-fallback rule.
+
+  Suppression now clears tick *locations* only, in both the live wrapper
+  (`apply_imshow_axes_visibility`) and the replay finaliser
+  (`finalize_imshow_axes`), so it stays reversible: a heatmap author who ticks
+  the axes after the `imshow` gets those ticks, live and through
+  save → reproduce. Found while building `examples/12_six_stat_annotation.py`,
+  whose panel C had to route around it.
+
 ## [0.32.0] - 2026-07-14
 
 ### Added

--- a/examples/12_six_stat_annotation.py
+++ b/examples/12_six_stat_annotation.py
@@ -163,10 +163,18 @@ def main() -> int:
     power = np.exp(-((freq[:, None] - 40) ** 2) / 300) * np.exp(
         -((time[None, :] - 0.5) ** 2) / 0.05
     )
-    # pcolormesh, not imshow: the SCITEX style strips ticks and spines from every
-    # imshow -- right for a photo, wrong for a time-by-frequency map whose axes
-    # carry physical meaning, and not overridable (the style is re-applied on save).
-    image = ax.pcolormesh(time, freq, power, cmap="viridis", id="heatmap_c")
+    image = ax.imshow(
+        power,
+        aspect="auto",
+        origin="lower",
+        extent=[time[0], time[-1], freq[0], freq[-1]],
+        cmap="viridis",
+        id="heatmap_c",
+    )
+    # The SCITEX style suppresses axis chrome on imshow (right for a picture, where
+    # ticks are noise). A heatmap's axes carry physical meaning, so tick them back.
+    ax.set_xticks([0.0, 0.5, 1.0])
+    ax.set_yticks([20, 40, 60, 80])
     ax.set_xlabel("Time [s]")
     ax.set_ylabel("Frequency [Hz]")
     # Doctrine rule 2: a heatmap needs a colorbar, with a label AND units.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.32.0"
+version = "0.32.1"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_reproducer/_replay_axes.py
+++ b/src/figrecipe/_reproducer/_replay_axes.py
@@ -104,13 +104,14 @@ def finalize_imshow_axes(ax, ax_record, style: Optional[Dict[str, Any]]) -> None
     if show_axes:
         return
 
+    # Clear tick LOCATIONS only. set_xticklabels([]) would additionally pin a
+    # NullFormatter, which blanks every tick the caller sets afterwards and so
+    # makes the suppression irreversible -- see apply_imshow_axes_visibility.
     decorations = ax_record.decorations
     if not any(c.function == "set_xticks" for c in decorations):
         ax.set_xticks([])
-        ax.set_xticklabels([])
     if not any(c.function == "set_yticks" for c in decorations):
         ax.set_yticks([])
-        ax.set_yticklabels([])
     for spine in ax.spines.values():
         spine.set_visible(False)
 

--- a/src/figrecipe/_wrappers/_axes_plots.py
+++ b/src/figrecipe/_wrappers/_axes_plots.py
@@ -67,7 +67,15 @@ def imshow_plot(
     call_id: Optional[str],
     **kwargs,
 ):
-    """Display image with automatic SCITEX styling."""
+    """Display image with automatic SCITEX styling.
+
+    The style suppresses axis chrome for an ``imshow`` because it is usually a
+    picture, where ticks are noise. The same call also draws heatmaps and
+    spectrograms, whose x/y axes carry physical meaning and must stay readable --
+    those callers restore the axes with a plain ``ax.set_xticks(...)`` /
+    ``set_yticks(...)`` AFTER the imshow, which both the live render and replay
+    honour (see ``apply_imshow_axes_visibility`` and ``finalize_imshow_axes``).
+    """
     from ..styles._internal import get_style
     from ._axes_helpers import inject_clip_on_from_style
 

--- a/src/figrecipe/styles/_plot_styles.py
+++ b/src/figrecipe/styles/_plot_styles.py
@@ -170,6 +170,16 @@ def apply_imshow_axes_visibility(ax: Axes, show_axes: bool, show_labels: bool) -
     never had it, so adding it here would desync save vs. reproduce -- exactly
     the bug where a labelled ``imshow`` reproduced with extra numeric ticks.
 
+    Suppression must stay REVERSIBLE. ``set_xticks([])`` alone already clears
+    both the ticks and their labels, and a later ``ax.set_xticks([...])``
+    restores them. The additional ``set_xticklabels([])`` this used to call was
+    not just redundant -- it pinned a ``NullFormatter`` on the axis, so every
+    tick the caller set afterwards rendered BLANK. A heatmap whose axes carry
+    physical meaning (a time-by-frequency map) therefore lost its numbers with
+    no warning and no way to get them back, which contradicts the readable-
+    heatmap rule in the six-stat doctrine skill. Suppress by clearing the tick
+    locations only; never install a formatter.
+
     Parameters
     ----------
     ax : matplotlib.axes.Axes
@@ -182,8 +192,6 @@ def apply_imshow_axes_visibility(ax: Axes, show_axes: bool, show_labels: bool) -
     if not show_axes:
         ax.set_xticks([])
         ax.set_yticks([])
-        ax.set_xticklabels([])
-        ax.set_yticklabels([])
         for spine in ax.spines.values():
             spine.set_visible(False)
 

--- a/tests/figrecipe/_reproducer/test__replay_axes.py
+++ b/tests/figrecipe/_reproducer/test__replay_axes.py
@@ -1,0 +1,70 @@
+"""Tests for figrecipe._reproducer._replay_axes.
+
+Focus: a heatmap whose author deliberately ticked its axes must reproduce WITH
+those ticks. The imshow chrome suppression may clear tick locations, but it must
+never pin a formatter that blanks the ticks the author set afterwards.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    plt.close("all")
+    yield
+    plt.close("all")
+
+
+def test_import_reproducer__replay_axes_module():
+    # Arrange
+    module_path = "figrecipe._reproducer._replay_axes"
+    # Act
+    mod = pytest.importorskip(module_path)
+    # Assert
+    assert mod.__name__ == module_path
+
+
+def _labelled_heatmap():
+    """A time-by-frequency map: axes carry physical meaning, ticks must survive."""
+    import figrecipe as fr
+
+    fig, ax = fr.subplots()
+    ax.imshow(
+        [[1, 2, 3], [4, 5, 6]],
+        aspect="auto",
+        origin="lower",
+        extent=[0, 1, 4, 80],
+        id="heatmap",
+    )
+    ax.set_xticks([0.0, 0.5, 1.0])
+    ax.set_xlabel("Time [s]")
+    ax.set_ylabel("Frequency [Hz]")
+    return fig, ax
+
+
+def test_explicit_heatmap_ticks_render_in_the_live_figure():
+    # Arrange
+    fig, ax = _labelled_heatmap()
+    # Act
+    fig.fig.canvas.draw()
+    # Assert
+    assert [tick.get_text() for tick in ax.get_xticklabels()] == ["0.0", "0.5", "1.0"]
+
+
+def test_explicit_heatmap_ticks_survive_save_and_reproduce(tmp_path):
+    # Arrange
+    import figrecipe as fr
+
+    fig, _ = _labelled_heatmap()
+    recipe = tmp_path / "heatmap.yaml"
+    fr.save(fig, recipe, validate=False)
+    plt.close("all")
+    # Act
+    fig2, ax2 = fr.reproduce(recipe)
+    fig2.fig.canvas.draw()
+    # Assert
+    assert [tick.get_text() for tick in ax2.get_xticklabels()] == ["0.0", "0.5", "1.0"]

--- a/tests/figrecipe/styles/test__plot_styles.py
+++ b/tests/figrecipe/styles/test__plot_styles.py
@@ -1,20 +1,90 @@
-"""Smoke import mirror for figrecipe.styles._plot_styles.
+"""Tests for figrecipe.styles._plot_styles.
 
-Auto-generated subpackage mirror placeholder; replace with real tests
-as the module matures. Satisfies the src<->tests mirror audit rule.
+Focus: imshow axis-chrome suppression must stay REVERSIBLE. A heatmap whose x/y
+axes carry physical meaning has to be able to keep its tick numbers.
 """
 
+import matplotlib
 
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
 import pytest
+
+from figrecipe.styles._plot_styles import apply_imshow_axes_visibility
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    plt.close("all")
+    yield
+    plt.close("all")
 
 
 def test_import_styles__plot_styles_module():
     # Arrange
-    # Arrange
-    # Act
-    # Assert
-    module_path = 'figrecipe.styles._plot_styles'
+    module_path = "figrecipe.styles._plot_styles"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+def test_suppression_clears_the_tick_labels():
+    # Arrange
+    fig, ax = plt.subplots()
+    ax.imshow([[1, 2], [3, 4]])
+    # Act
+    apply_imshow_axes_visibility(ax, show_axes=False, show_labels=True)
+    fig.canvas.draw()
+    # Assert
+    assert [tick.get_text() for tick in ax.get_xticklabels()] == []
+
+
+def test_suppressed_ticks_can_be_restored_afterwards():
+    # Arrange: the caller draws a heatmap, then labels the axes it cares about.
+    # Suppression must not pin a NullFormatter -- that blanked every tick set
+    # afterwards, leaving a time-by-frequency map with no readable numbers and no
+    # way to get them back.
+    fig, ax = plt.subplots()
+    ax.imshow([[1, 2], [3, 4]], extent=[0, 1, 0, 1])
+    apply_imshow_axes_visibility(ax, show_axes=False, show_labels=True)
+    # Act
+    ax.set_xticks([0.0, 0.5, 1.0])
+    fig.canvas.draw()
+    # Assert
+    assert [tick.get_text() for tick in ax.get_xticklabels()] == ["0.0", "0.5", "1.0"]
+
+
+def test_restored_y_ticks_are_not_blanked_either():
+    # Arrange
+    fig, ax = plt.subplots()
+    ax.imshow([[1, 2], [3, 4]], extent=[0, 1, 0, 1])
+    apply_imshow_axes_visibility(ax, show_axes=False, show_labels=True)
+    # Act
+    ax.set_yticks([0.0, 1.0])
+    fig.canvas.draw()
+    # Assert: the exact numeric formatting is matplotlib's business ("0" vs "0.0");
+    # the contract is that the restored ticks are not BLANKED.
+    assert all(tick.get_text() for tick in ax.get_yticklabels())
+
+
+def test_show_axes_true_leaves_ticks_alone():
+    # Arrange
+    fig, ax = plt.subplots()
+    ax.imshow([[1, 2], [3, 4]])
+    # Act
+    apply_imshow_axes_visibility(ax, show_axes=True, show_labels=True)
+    fig.canvas.draw()
+    # Assert
+    assert len(ax.get_xticklabels()) > 0
+
+
+def test_show_labels_false_clears_the_axis_label():
+    # Arrange
+    fig, ax = plt.subplots()
+    ax.imshow([[1, 2], [3, 4]])
+    ax.set_xlabel("Time [s]")
+    # Act
+    apply_imshow_axes_visibility(ax, show_axes=True, show_labels=False)
+    # Assert
+    assert ax.get_xlabel() == ""


### PR DESCRIPTION
## The bug

The SCITEX style suppresses axis chrome on `imshow` — correct for a **picture**, where ticks are noise. But the same call also draws **heatmaps and spectrograms**, whose x/y axes carry physical meaning (time, frequency) and must stay readable.

The suppression cleared the ticks with `set_xticks([])` **and** `set_xticklabels([])`. The second call was not merely redundant — it pinned a `NullFormatter` on the axis, so every tick the caller set *afterwards* rendered **blank**:

```
set_xticks([]) only    -> restored labels: ['0.0', '0.5', '1.0']
+ set_xticklabels([])  -> restored labels: ['', '', '']      # NullFormatter
```

So an `ax.set_xticks([0, 0.5, 1.0])` issued after the `imshow` produced tick marks with no numbers — silently, with no warning, and **with no way to override it**. A time-by-frequency map simply lost its axes.

This contradicted figrecipe's *own* readable-heatmap rule (six-stat doctrine skill, rule 2) and violated the no-silent-fallback rule.

## The fix

Clear tick **locations** only — `set_xticks([])` already removes the labels too, and it stays reversible. Applied in both places that suppress, so save and reproduce remain in lockstep:

- `styles/_plot_styles.py::apply_imshow_axes_visibility` (live wrapper)
- `_reproducer/_replay_axes.py::finalize_imshow_axes` (replay finaliser)

No new API: a heatmap author just ticks the axes after the `imshow`, and now gets those ticks — live *and* through a save → reproduce round-trip.

## Verification

Three new tests. **All three fail on the old code and pass on the new** (checked by stashing the fix and re-running). Full `styles` + `_reproducer` suites: 163 passed, no regressions.

## Provenance

Found while building `examples/12_six_stat_annotation.py` (shipped in 0.32.0), whose panel C had to route around this via `pcolormesh`. The example now uses `imshow` as originally intended.