### PR TITLE
feat(annotations): per-figure-type hints for comparison placement and candidate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] - 2026-07-14
+
+### Added
+- **Per-figure-type annotation hints** (`figrecipe.hints_for`) — a small registry
+  answering two questions for a given plot type: *where does a comparison line
+  go*, and *which statistical methods are conventional for the kind of data this
+  plot shows*.
+
+  ```python
+  hint = fr.hints_for("scatter")
+  hint.geometry        # ComparisonGeometry.INLINE_TEXT — a bracket has nothing to span
+  hint.draws_bracket   # False
+  hint.methods         # ["Pearson correlation", "Spearman correlation", ...]
+  ```
+
+  Deliberately a skeleton: five entries, each added because a real figure needed
+  it. It grows an entry at a time as concrete cases turn up and is **not** a
+  pre-populated taxonomy of every plot type.
+
+  Two things it is not:
+  - It does not **compute**. Values still come from a producer via `StatResult`;
+    this only says where to *draw* the comparison and what is conventional.
+  - It does not **enforce**. `methods` is a hint for a human, not a whitelist —
+    whether a test suits a figure is a judgement about the *data* (paired?
+    normal? how many groups?), which the plot type only hints at. `hints_for`
+    returns `None` for an unknown type, meaning "the registry has nothing to
+    say", never "this figure is wrong". Nothing in figrecipe rejects a
+    `StatResult` because of this table.
+
 ## [0.32.1] - 2026-07-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.32.1"
+version = "0.33.0"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/__init__.py
+++ b/src/figrecipe/__init__.py
@@ -174,6 +174,9 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     # ._diagram
     "Diagram": ("._diagram", "Diagram"),
     "StatResult": ("._annotations", "StatResult"),
+    "hints_for": ("._annotations", "hints_for"),
+    "known_figure_types": ("._annotations", "known_figure_types"),
+    "ComparisonGeometry": ("._annotations", "ComparisonGeometry"),
     "_Graphviz": ("._diagram._graphviz.graphviz", "Graphviz"),
     "_Mermaid": ("._diagram._mermaid.mermaid", "Mermaid"),
     # ._graph._presets
@@ -316,6 +319,10 @@ __all__ = [
     "Diagram",
     # Statistics display port (six-stat annotation doctrine)
     "StatResult",
+    # Per-figure-type annotation hints (advisory; never enforced)
+    "hints_for",
+    "known_figure_types",
+    "ComparisonGeometry",
     # Color utilities
     "colors",
     "color",

--- a/src/figrecipe/_annotations/__init__.py
+++ b/src/figrecipe/_annotations/__init__.py
@@ -39,6 +39,12 @@ Submodules
 """
 
 from ._auto_placement import auto_y_position
+from ._figure_type_hints import (
+    ComparisonGeometry,
+    FigureTypeHint,
+    hints_for,
+    known_figure_types,
+)
 from ._stat_bracket import (
     add_stat_bracket,
     list_stat_brackets,
@@ -62,6 +68,11 @@ __all__ = [
     "auto_y_position",
     # Display port for a computed test result (six-stat doctrine)
     "StatResult",
+    # Per-figure-type annotation hints (advisory; never enforced)
+    "ComparisonGeometry",
+    "FigureTypeHint",
+    "hints_for",
+    "known_figure_types",
 ]
 
 # EOF

--- a/src/figrecipe/_annotations/_figure_type_hints.py
+++ b/src/figrecipe/_annotations/_figure_type_hints.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Per-figure-type hints: where a comparison line goes, and which tests fit.
+
+A skeleton, deliberately. Four entries, added because a real figure needed each
+one. The registry grows an entry at a time as concrete cases turn up -- it is NOT
+a pre-populated taxonomy of every plot type, and it should not become one.
+
+Two things this is NOT:
+
+- It does not COMPUTE anything. figrecipe displays statistics; the values come
+  from a producer (scitex-stats, scipy, ...) and arrive as a
+  :class:`~figrecipe._annotations._stat_result.StatResult`. This module only says
+  where to *draw* the comparison and which tests are *conventional* for the shape
+  of data a given plot type shows.
+- It does not ENFORCE anything. ``methods`` is a list of hints for a human, not a
+  whitelist: whether a statistical method suits a figure is a judgement about the
+  DATA (paired? normal? how many groups?), which the plot type only hints at. A
+  bar chart can legitimately carry a test not listed here. Nothing in figrecipe
+  rejects a StatResult because of this table, and nothing should.
+"""
+
+from __future__ import annotations
+
+__all__ = ["ComparisonGeometry", "FigureTypeHint", "hints_for", "known_figure_types"]
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+
+class ComparisonGeometry(str, Enum):
+    """How a comparison between two conditions is drawn on this figure type."""
+
+    BRACKET_ABOVE = "bracket_above"
+    """A horizontal bracket spanning the two categories, above the data.
+
+    The default for categorical plots (bar, box, violin): the x positions are
+    discrete, so a bracket has two unambiguous endpoints to span.
+    """
+
+    INLINE_TEXT = "inline_text"
+    """No bracket -- the statistic is written as text in the plot area.
+
+    For plots with no discrete categories to span (a scatter, a correlation): the
+    comparison is not *between two x positions*, it is a property of the whole
+    cloud, so a bracket would point at nothing.
+    """
+
+    COLORBAR_ANNOTATION = "colorbar_annotation"
+    """Significance is carried by the image itself (e.g. a mask or contour).
+
+    A heatmap has no free space to run a bracket through, and a cell-by-cell test
+    produces one statistic per cell, not one per pair -- so significance is shown
+    by marking the cells, with the method and correction named in the caption.
+    """
+
+
+@dataclass(frozen=True)
+class FigureTypeHint:
+    """Hints for annotating one figure type.
+
+    Parameters
+    ----------
+    figure_type : str
+        The plotting call this describes (``"bar"``, ``"scatter"``, ...).
+    geometry : ComparisonGeometry
+        How to draw a comparison on this figure type.
+    methods : list of str
+        Statistical methods CONVENTIONALLY used for the kind of data this plot
+        shows. A hint for a human, never a whitelist -- see the module docstring.
+    note : str
+        One line on the judgement the caller still has to make themselves.
+    """
+
+    figure_type: str
+    geometry: ComparisonGeometry
+    methods: List[str] = field(default_factory=list)
+    note: str = ""
+
+    @property
+    def draws_bracket(self) -> bool:
+        """Whether a comparison on this figure type is drawn as a bracket."""
+        return self.geometry is ComparisonGeometry.BRACKET_ABOVE
+
+
+# Grown one entry at a time, each from a figure that actually needed it.
+_HINTS: Dict[str, FigureTypeHint] = {
+    "bar": FigureTypeHint(
+        figure_type="bar",
+        geometry=ComparisonGeometry.BRACKET_ABOVE,
+        methods=["Welch's t-test", "Mann-Whitney U", "one-way ANOVA"],
+        note=(
+            "Which test depends on the data, not the plot: paired or independent, "
+            "normal or not, two groups or more. The bar chart cannot tell you."
+        ),
+    ),
+    "box": FigureTypeHint(
+        figure_type="box",
+        geometry=ComparisonGeometry.BRACKET_ABOVE,
+        methods=["Mann-Whitney U", "Wilcoxon signed-rank", "Kruskal-Wallis"],
+        note=(
+            "A box plot shows a distribution's shape, so it is usually reached for "
+            "when a rank-based test is appropriate -- but that is a convention, not "
+            "a rule."
+        ),
+    ),
+    "violin": FigureTypeHint(
+        figure_type="violin",
+        geometry=ComparisonGeometry.BRACKET_ABOVE,
+        methods=["Mann-Whitney U", "Kruskal-Wallis"],
+        note="As for a box plot: the shape is shown, so the test is usually rank-based.",
+    ),
+    "scatter": FigureTypeHint(
+        figure_type="scatter",
+        geometry=ComparisonGeometry.INLINE_TEXT,
+        methods=["Pearson correlation", "Spearman correlation", "linear regression"],
+        note=(
+            "There are no discrete categories to span, so a bracket has nothing to "
+            "point at. Write the statistic inline instead."
+        ),
+    ),
+    "imshow": FigureTypeHint(
+        figure_type="imshow",
+        geometry=ComparisonGeometry.COLORBAR_ANNOTATION,
+        methods=["cluster-based permutation", "FDR-corrected mass-univariate"],
+        note=(
+            "One statistic per cell, not one per pair -- mark the significant cells "
+            "and name the multiple-comparison correction in the caption."
+        ),
+    ),
+}
+
+# Plot calls that are the same shape as an entry above.
+_ALIASES: Tuple[Tuple[str, str], ...] = (
+    ("barh", "bar"),
+    ("boxplot", "box"),
+    ("violinplot", "violin"),
+    ("pcolormesh", "imshow"),
+    ("matshow", "imshow"),
+)
+
+
+def known_figure_types() -> List[str]:
+    """Figure types the registry has an entry for, aliases included."""
+    return sorted(set(_HINTS) | {alias for alias, _ in _ALIASES})
+
+
+def hints_for(figure_type: str) -> Optional[FigureTypeHint]:
+    """Return the hint for ``figure_type``, or None when there is no entry yet.
+
+    None means "the registry has nothing to say", NOT "this figure type is wrong".
+    Most plot types have no entry -- the table is a short list of cases that came
+    up, not a closed world. Callers must treat None as silence.
+    """
+    key = figure_type.lower()
+    for alias, target in _ALIASES:
+        if key == alias:
+            key = target
+            break
+    return _HINTS.get(key)
+
+
+# EOF

--- a/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
+++ b/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
@@ -100,6 +100,16 @@ ax.add_stat_annotation(x1=0, x2=1, text="p=0.03")  # STX-FM017: missing n, CI, m
 
 Working example: `examples/12_six_stat_annotation.py`.
 
+### Where the comparison goes
+
+`fr.hints_for("<plot type>")` answers where a comparison line belongs and which
+tests are conventional for that plot's data — a bracket spans two categories on
+a bar/box/violin; a scatter has no categories to span, so the statistic is
+written inline; a heatmap marks significant cells instead. It is ADVISORY:
+`methods` is a hint for a human, not a whitelist (whether a test suits a figure
+is a judgement about the *data*), and `None` means the registry has nothing to
+say, never that the figure is wrong.
+
 ## Rule 2 — heatmap colorbar requirement
 
 Any 2D heatmap (an `imshow`-style plot of a 2D array — `imshow`, `matshow`,

--- a/tests/figrecipe/_annotations/test__figure_type_hints.py
+++ b/tests/figrecipe/_annotations/test__figure_type_hints.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the per-figure-type annotation hints."""
+
+import pytest
+
+from figrecipe._annotations._figure_type_hints import (
+    ComparisonGeometry,
+    hints_for,
+    known_figure_types,
+)
+
+
+class TestLookup:
+    """Resolving a figure type to its hint."""
+
+    def test_bar_chart_has_a_hint(self):
+        # Arrange
+        figure_type = "bar"
+        # Act
+        hint = hints_for(figure_type)
+        # Assert
+        assert hint.figure_type == "bar"
+
+    def test_lookup_is_case_insensitive(self):
+        # Arrange
+        figure_type = "BoxPlot"
+        # Act
+        hint = hints_for(figure_type)
+        # Assert
+        assert hint.figure_type == "box"
+
+    def test_alias_resolves_to_its_target_entry(self):
+        # Arrange: pcolormesh draws the same shape of thing as imshow.
+        figure_type = "pcolormesh"
+        # Act
+        hint = hints_for(figure_type)
+        # Assert
+        assert hint.figure_type == "imshow"
+
+    def test_unknown_figure_type_returns_none_not_an_error(self):
+        # Arrange: the registry is a short list of cases that came up, not a closed
+        # world. Silence is the correct answer for anything not in it.
+        figure_type = "streamplot"
+        # Act
+        hint = hints_for(figure_type)
+        # Assert
+        assert hint is None
+
+    def test_known_types_include_the_aliases(self):
+        # Arrange
+        expected = {"bar", "box", "violin", "scatter", "imshow", "pcolormesh", "barh"}
+        # Act
+        known = set(known_figure_types())
+        # Assert
+        assert expected <= known
+
+
+class TestComparisonGeometry:
+    """Where a comparison line goes, per figure type."""
+
+    def test_categorical_plot_uses_a_bracket(self):
+        # Arrange: discrete x positions give a bracket two endpoints to span.
+        hint = hints_for("bar")
+        # Act
+        geometry = hint.geometry
+        # Assert
+        assert geometry is ComparisonGeometry.BRACKET_ABOVE
+
+    def test_scatter_writes_inline_instead_of_bracketing(self):
+        # Arrange: a correlation is a property of the whole cloud, so a bracket
+        # would have nothing to point at.
+        hint = hints_for("scatter")
+        # Act
+        geometry = hint.geometry
+        # Assert
+        assert geometry is ComparisonGeometry.INLINE_TEXT
+
+    def test_heatmap_marks_cells_rather_than_bracketing(self):
+        # Arrange: one statistic per cell, not one per pair.
+        hint = hints_for("imshow")
+        # Act
+        geometry = hint.geometry
+        # Assert
+        assert geometry is ComparisonGeometry.COLORBAR_ANNOTATION
+
+    def test_draws_bracket_is_true_only_for_bracket_geometry(self):
+        # Arrange
+        categorical, continuous = hints_for("violin"), hints_for("scatter")
+        # Act
+        flags = (categorical.draws_bracket, continuous.draws_bracket)
+        # Assert
+        assert flags == (True, False)
+
+
+class TestMethodHints:
+    """The candidate-method list is advisory, never a whitelist."""
+
+    def test_scatter_suggests_correlation_methods(self):
+        # Arrange
+        hint = hints_for("scatter")
+        # Act
+        methods = hint.methods
+        # Assert
+        assert "Pearson correlation" in methods
+
+    def test_every_entry_carries_a_note_on_the_remaining_judgement(self):
+        # Arrange: the plot type hints at the data's shape but cannot decide the
+        # test, so each entry must say what the caller still has to decide.
+        entries = [hints_for(name) for name in known_figure_types()]
+        # Act
+        noteless = [entry.figure_type for entry in entries if not entry.note]
+        # Assert
+        assert noteless == []
+
+    def test_hints_are_immutable(self):
+        # Arrange: a shared registry entry must not be mutable by one caller.
+        hint = hints_for("bar")
+        # Act
+        rejects_mutation = pytest.raises(AttributeError)
+        # Assert
+        with rejects_mutation:
+            hint.figure_type = "box"
+
+
+# EOF


### PR DESCRIPTION
## What

A small registry answering two questions for a given plot type: **where does a comparison line go**, and **which statistical methods are conventional** for the kind of data that plot shows.

```python
hint = fr.hints_for("scatter")
hint.geometry        # ComparisonGeometry.INLINE_TEXT — a bracket has nothing to span
hint.draws_bracket   # False
hint.methods         # ["Pearson correlation", "Spearman correlation", ...]
```

## Deliberately a skeleton

Five entries, each added because a real figure needed it. It grows an entry at a time as concrete cases turn up — it is **not** a pre-populated taxonomy of every plot type, and it should not become one.

## Two things it is NOT

- **It does not compute.** figrecipe displays statistics; values still arrive from a producer (scitex-stats, scipy) via `StatResult`. This module only says where to *draw* the comparison and what is conventional.
- **It does not enforce.** `methods` is a hint for a human, not a whitelist. Whether a test suits a figure is a judgement about the **data** — paired? normal? how many groups? — which the plot type only *hints* at. `hints_for` returns `None` for an unknown type, meaning "the registry has nothing to say", never "this figure is wrong". Nothing in figrecipe rejects a `StatResult` because of this table, and nothing should.

## The geometry distinction is the load-bearing part

- **bar / box / violin** → `BRACKET_ABOVE`. Discrete x positions give a bracket two unambiguous endpoints to span.
- **scatter** → `INLINE_TEXT`. A correlation is a property of the whole cloud, not a comparison *between two x positions* — a bracket would point at nothing.
- **imshow / pcolormesh** → `COLORBAR_ANNOTATION`. One statistic per *cell*, not one per pair, so significance is marked on the cells with the multiple-comparison correction named in the caption.

## Tests

12, covering lookup (including aliases and the case-insensitive path), the `None`-means-silence contract, each geometry, and immutability of the shared registry entries.