### PR TITLE
chore(django): adopt scitex-ui's native favicon; drop figrecipe's duplicate override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.1] - 2026-07-14
+
+### Changed
+- **Adopt scitex-ui's native favicon support; drop figrecipe's interim override.**
+  figrecipe prototyped a `favicon_href` context var and scitex-ui adopted it as
+  the shared contract (scitex-ui#65, released in 0.6.4), where
+  `standalone_shell.html` now renders the `<link rel="icon">` itself, in `<head>`.
+  figrecipe's own `standalone.html` was still emitting that link from its
+  `extra_css` block — written before 0.6.4 existed — which on 0.6.4 produces a
+  **duplicate** `<link rel="icon">` rather than the only one (the parent renders
+  its copy outside the `extra_css` block, so the override never replaced it).
+
+  Removed the override and raised the `scitex-ui` floor `>=0.1.0` → `>=0.6.4`, so
+  the parent template that renders the favicon is guaranteed present. `views.py`
+  already passed `favicon_href` in the render context and is unchanged — the tab
+  icon still brands per `FIGRECIPE_FAVICON_COLOR`.
+
 ## [0.34.0] - 2026-07-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.34.0"
+version = "0.34.1"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"
@@ -60,7 +60,7 @@ dev = [
     # Mirror runtime extras so `pip install -e .[dev]` runs the full suite.
     # Tests import these unguarded; PS210 audit invariants.
     "scitex-app>=0.3.0",
-    "scitex-ui>=0.1.0",
+    "scitex-ui>=0.6.4",
     "scitex-logging",
     "scitex-pd",
     "scitex-stats",
@@ -84,7 +84,7 @@ seaborn = [
 ]
 scitex = [
     "scitex-app>=0.3.0",
-    "scitex-ui>=0.1.0",
+    "scitex-ui>=0.6.4",
     "scitex-logging",
     "scitex-pd",
     "scitex-stats",
@@ -98,7 +98,7 @@ app = [
     "django>=4.2.0",
     "Pillow>=9.0.0",
     "scitex-app>=0.3.0",
-    "scitex-ui>=0.1.0",
+    "scitex-ui>=0.6.4",
 ]
 desktop = [
     "django>=4.2.0",

--- a/src/figrecipe/_django/templates/figrecipe/standalone.html
+++ b/src/figrecipe/_django/templates/figrecipe/standalone.html
@@ -1,7 +1,6 @@
 {% extends "scitex_ui/standalone_shell.html" %}
 {% load static %}
 {% block extra_css %}
-    {% if favicon_href %}<link rel="icon" href="{{ favicon_href }}">{% endif %}
     <link rel="stylesheet"
           crossorigin
           href="{% static 'figrecipe/assets/index.css' %}">

--- a/tests/figrecipe/_django/test_standalone_template.py
+++ b/tests/figrecipe/_django/test_standalone_template.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for figrecipe's standalone.html shell template.
+
+figrecipe prototyped the ``favicon_href`` context var and scitex-ui adopted it as
+the shared contract (0.6.4), where ``standalone_shell.html`` renders the
+``<link rel="icon">`` itself. figrecipe's own override was removed; these tests
+pin that the favicon still renders — exactly ONCE, not zero times (override
+removed and parent doesn't render it) and not twice (both render it).
+"""
+
+import os
+
+import django
+import pytest
+
+
+@pytest.fixture(scope="module")
+def _django_ready():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "figrecipe._django.settings")
+    django.setup()
+
+
+def _render(_django_ready, **context):
+    from django.template.loader import render_to_string
+
+    return render_to_string("figrecipe/standalone.html", context)
+
+
+def test_favicon_renders_exactly_once(_django_ready):
+    # Arrange: the parent shell renders the icon link in <head>, outside the
+    # extra_css block, so a figrecipe override would DUPLICATE it, not replace it.
+    href = "data:image/svg+xml,<svg/>"
+    # Act
+    html = _render(_django_ready, favicon_href=href, working_dir="/tmp")
+    # Assert
+    assert html.count('rel="icon"') == 1
+
+
+def test_favicon_href_reaches_the_markup(_django_ready):
+    # Arrange
+    href = "data:image/svg+xml,<svg/>"
+    # Act
+    html = _render(_django_ready, favicon_href=href, working_dir="/tmp")
+    # Assert
+    assert "data:image/svg+xml" in html
+
+
+def test_no_icon_link_when_no_favicon_supplied(_django_ready):
+    # Arrange: an unbranded tab is the documented default.
+    # Act
+    html = _render(_django_ready, working_dir="/tmp")
+    # Assert
+    assert 'rel="icon"' not in html
+
+
+def test_app_stylesheet_survives_the_override_removal(_django_ready):
+    # Arrange: the extra_css block still carries figrecipe's own stylesheet — only
+    # the duplicate favicon link was removed from it.
+    # Act
+    html = _render(_django_ready, working_dir="/tmp")
+    # Assert
+    assert "index.css" in html
+
+
+# EOF


### PR DESCRIPTION
figrecipe prototyped the `favicon_href` context var and scitex-ui adopted it as the shared contract (scitex-ui#65, released in **0.6.4**), where `standalone_shell.html` now renders the `<link rel="icon">` itself — in `<head>`.

figrecipe's own `standalone.html` was still emitting that link from its `extra_css` block, written before 0.6.4 existed.

**The parent renders its copy *outside* the `extra_css` block, so the override never replaced it.** On scitex-ui 0.6.4 the page therefore carried **two** `<link rel="icon">` tags, not one.

## Change

- Removed the override from `standalone.html` (its own stylesheet stays).
- Raised the `scitex-ui` floor `>=0.1.0` → `>=0.6.4`, so the parent that renders the favicon is *guaranteed* present rather than merely likely.
- `views.py` already passed `favicon_href` and is unchanged — the tab still brands per `FIGRECIPE_FAVICON_COLOR`.

## Verification

By **rendering the template**, not reading it. The risk in deleting an override is deleting the only thing that rendered the icon, so the test pins all three failure modes:

- exactly **one** `rel="icon"` — not zero (override gone *and* parent silent), not two (both render);
- the `href` actually reaches the markup;
- figrecipe's own stylesheet survives in the `extra_css` block.

4 tests.