### PR TITLE
fix(pre-commit): remove the pytest-testmon hook — it never ran a single test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,37 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: local
-    hooks:
-      - id: pytest-testmon
-        name: pytest-testmon
-        entry: python -m pytest --testmon -x -q --tb=short --ignore=tests/figrecipe/_editor --ignore=tests/figrecipe/test_pixel_perfect.py --ignore=tests/develop/test_audit.py --ignore=tests/figrecipe/_mcp/test__resources.py
-        language: system
-        types: [python]
-        pass_filenames: false
-        stages: [pre-commit]
+  # Incremental testing (pytest-testmon) — REMOVED from the commit path.
+  #
+  # This hook never worked, and could not work:
+  #
+  #   * `pytest-testmon` is not a dependency of figrecipe. It is absent from
+  #     [project.optional-dependencies].dev and is not pulled in transitively
+  #     (scitex-dev does not require it). So in a correctly provisioned env
+  #     (`pip install -e .[dev]`) the hook died instantly with
+  #     `error: unrecognized arguments: --testmon` (exit 4) — it never ran a
+  #     single test. In the agent container it died even earlier, on
+  #     `ModuleNotFoundError: No module named 'matplotlib'` (exit 4), because
+  #     `python` there resolves to the sac venv, not figrecipe's env.
+  #     Every commit staging a .py file was blocked by a hook that had never
+  #     executed a test.
+  #
+  #   * Where testmon *is* installed by hand, a COLD run of the ~2460-test
+  #     suite costs ~2h. A fresh git worktree is always cold, and agents work
+  #     in fresh worktrees, so "cold" is the normal case, not the exception.
+  #     A pre-commit hook must be bounded and fast; a 2460-test suite in the
+  #     commit path is an unbounded stall. Even a perfectly warmed testmon
+  #     cache re-enters that cold path whenever its environment fingerprint
+  #     changes (testmon keys its DB on the FULL installed-distribution set
+  #     plus the exact python micro version), which an unpinned `uv pip
+  #     install -e .` re-resolves on every container boot.
+  #
+  # Full verification lives in CI, where it belongs: the self-hosted
+  # (Spartan CPU) pytest matrix runs the complete suite on py3.11/3.12/3.13
+  # for every push and PR to main/develop
+  # (.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml).
+  #
+  # Run the suite locally whenever you want:  pytest -n auto
+  #
+  # scitex-cloud, scitex-code, scitex-hub, scitex-python and scitex_repo all
+  # removed this same hook from their commit paths for the same reason.


### PR DESCRIPTION
## The hook never ran a single test

figrecipe was the **only** repo left with a live `pytest-testmon` pre-commit hook. It was reported as a "cold cache" problem. It is not — the cache was a symptom. The hook could not work at all.

**`pytest-testmon` is not a dependency of figrecipe.** It is absent from `[project.optional-dependencies].dev`, and it is not pulled in transitively (`scitex-dev` does not require it). So there is no correctly-provisioned figrecipe environment in which the hook's entry can even parse its own arguments.

### Measured on this commit

| environment | result |
|---|---|
| `pip install -e .[dev]` (py3.11, matplotlib + figrecipe + test runner all present) | `error: unrecognized arguments: --testmon` — **exit 4**, 118s |
| agent container, ambient env (`python` = the sac venv) | `ModuleNotFoundError: No module named 'matplotlib'` — **exit 4**, 13s |

Every commit staging a `.py` file was blocked by a hook that had never executed a test.

Corroborating evidence: the warm-cache dir has been **empty since Jul 1**, and **not one of figrecipe's 12 worktrees contains a `.testmondata`** — because testmon has never completed a run here.

### The prescribed fix does not fix it

Re-pointing the hook at scitex-dev's warm-cache wrapper (`scitex-dev-testmon`) fails **identically**:

```
entry: scitex-dev-testmon  ->  exit 4, 22s
ModuleNotFoundError: No module named 'matplotlib'
wrapper's python3 = /opt/venv-sac/bin/python3
```

The wrapper invokes the test runner through a bare `python3` off `PATH`, which resolves to the sac venv — no testmon, none of figrecipe's deps. (For the record: the wrapper is referenced by **zero** repos, and scitex-dev does not dogfood it in its own `.pre-commit-config.yaml`.)

### In fairness: the warm-cache mechanism itself is sound

I wired it up properly (py3.11 + testmon + full deps, `python3` forced to the right interpreter) and measured it end to end. It works:

| run | wall | pytest phase |
|---|---|---|
| 1. cold (empty cache) | 24s | `4 passed in 8.45s` → cache written back |
| 2. warm (same worktree) | 23s | `no tests ran in 0.12s` |
| 3. **fresh worktree** (no `.testmondata` of its own) | 30s | `no tests ran in 1.04s` |

Run 3 seeded from the shared cache and re-ran **zero** tests: the impact graph survives the worktree boundary, and the environment fingerprint matched (`py3.11.15 / 43a70d2d871070c3` in both worktrees). So the seed/write-back design is not the problem, and this PR is **not** a claim that the cache is impossible.

### Why it is still the wrong tool for the commit path

Four measured reasons, any one of which is fatal in practice:

1. **testmon isn't installed** (above). Until that changes, the cache is irrelevant — the hook exits 4.
2. **The cold run must survive to seed the cache.** On a 189-test slice under real load, the cold run was **OOM-killed at 1018s**, and `run_testmon.sh` only persists on `rc < 2`:
   ```bash
   if [[ -f "$LOCAL_FILE" && "$rc" -lt 2 ]]; then   # a killed run is 137 -> SKIPPED
   ```
   So it cached **nothing**, and the next run is cold again — self-perpetuating. The real suite is ~2460 tests / ~2h cold, i.e. exactly the run that gets killed on a busy shared host. This is the most likely reason the cache dir has sat empty since Jul 1.
3. **The cache is not persistent or shared.** `$SCITEX_TESTMON_CACHE_ROOT` resolves under the container's `$HOME` (`/home/agent`), which lands in the container's **overlay upper**, not a shared host path — per-agent, and wiped on image rebuild. Every agent would pay the 2h warm-up separately, repeatedly.
4. **Fingerprint churn silently re-triggers the cold path.** testmon keys its DB on the **entire installed-distribution set** plus the **exact python micro version**; an unpinned editable install re-resolves that on every container boot. A 2h stall can reappear in the commit path at any time, with no warning.

Making this work in production is a 4-part change across figrecipe + scitex-dev + the sac agent spec, plus a protected one-off cold warm-up on a persistent shared cache — to buy faster local feedback that CI already provides. A 2460-test suite does not belong in the commit path; a pre-commit hook must be bounded.

If you'd rather have the cache than the removal, say so and I'll do that instead — it is achievable, just not free.

## What this PR does

Removes the `pytest-testmon` hook from the commit path, with the reasoning recorded inline in `.pre-commit-config.yaml`.

- **Verification is unchanged.** The self-hosted (Spartan CPU) test matrix already runs the complete suite on py3.11 / 3.12 / 3.13 for every push and PR to `main`/`develop` (`.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml`). Nothing that CI caught before is missed now — the hook caught nothing, because it never ran.
- **Commit-time cost after this change: 57s** for *all* remaining hooks across `--all-files`; a normal commit touches only staged files and finishes in seconds.
- `scitex-cloud`, `scitex-code`, `scitex-hub`, `scitex-python` and `scitex_repo` all removed this same hook from their commit paths already. This is the last one.

Locally: run the suite whenever you want with `-n auto`.

## Note for the figrecipe owner

Only `.pre-commit-config.yaml` changes; no source touched. None of the 6 open figrecipe PRs touch this file, so there is no in-flight conflict.

Separately, and **not** addressed here: `pre-commit run --all-files` reformats **428 files** on `develop` (pre-existing `ruff-format` drift). Worth a dedicated PR — happy to take it if you want.
