### PR TITLE
fix(styles): make tick suppression reversible everywhere, and never discard author ticks in silence

### DIFF
--- a/src/figrecipe/_skills/figrecipe/28_never-silently-discard.md
+++ b/src/figrecipe/_skills/figrecipe/28_never-silently-discard.md
@@ -1,0 +1,98 @@
+# Never silently discard what the author set
+
+A styler that drops a property the author explicitly set — without saying so —
+produces a figure that is **wrong in the picture and right in every assertion**.
+That is not a theoretical risk. It shipped a comodulogram to human review with
+its frequency axis blank.
+
+## The incident
+
+`apply_imshow_axes_visibility` suppressed heatmap chrome with:
+
+```python
+ax.set_xticks([])
+ax.set_xticklabels([])   # <- the bug
+```
+
+`set_xticklabels([])` pins a **`NullFormatter`** on the axis. A formatter lives
+on the *axis*, not on the handle you reach it through, so **every tick set
+afterwards renders blank** — through the figrecipe wrapper, through the raw
+`ax._ax`, through an explicit `set_xticklabels(...)`. There was **no code
+workaround**; only upgrading fixed it.
+
+What made it dangerous was not the blanking. It was the silence:
+
+```python
+ax.set_xticks([0, 1])
+ax.get_xticks()          # [0, 1]   <- the author's own values. Looks correct.
+# ...but the drawn labels are ['', '']
+```
+
+Every object-level assertion passed. The figure reached print with no numbers on
+an axis whose numbers *were the content*. Which frequencies couple **is** the
+finding in a comodulogram.
+
+## The rules
+
+**1. Suppress reversibly.** Clear tick *locations*; never install a formatter.
+
+```python
+# GOOD - reversible; a later set_xticks() renders
+ax.set_xticks([])
+
+# BAD - pins a NullFormatter; nothing can undo it
+ax.set_xticks([])
+ax.set_xticklabels([])
+```
+
+To hide labels while *keeping* tick marks, toggle visibility — it is a flag, not
+a formatter, so it can be turned back on:
+
+```python
+ax.tick_params(labelbottom=False)   # reversible
+ax.tick_params(labelbottom=True)    # genuinely restores
+```
+
+**2. If you must discard an explicit choice, say so.** A `FixedLocator` is
+matplotlib's fingerprint of an author's `set_xticks(...)`. Overriding one is a
+decision the author did not make — warn, and name the axis and the escape hatch.
+
+**3. Assert on what RENDERS, not on the object graph.** This is the rule that
+actually protects people. An axis-object assertion is *structurally blind* to
+this class of corruption, because the object state is exactly what was asked for.
+
+```python
+# BLIND - passed throughout the incident
+assert list(ax.get_xticks()) == [0, 1]
+
+# SEES IT - reads the drawn text
+ax.figure.canvas.draw()
+assert [t.get_text() for t in ax.get_xticklabels()] == ["0", "1"]
+```
+
+## A silent failure also hides whatever is behind it
+
+This is the part most people miss. The blank labels were not just *a* bug — they
+were a **mask over two more**, both found the moment the labels rendered:
+
+- A **layout** bug: with numbers finally drawn, the colorbar was seen colliding
+  with the xlabel. The silence had concealed a real defect in the figure code.
+- A **wrong computation**: the family-center tick positions had been computed
+  assuming contiguous feature families, but the features were *interleaved*, so
+  every label collapsed onto the axis centre. The labels were never merely
+  missing — they were **nonsense**, and nobody could tell while they were blank.
+
+So a silent failure is not one bug, it is a bug plus everything it conceals. The
+drawn-label assertion catches the *renderer*; only looking at the pixels caught
+the *computation behind it*. Both layers needed the pixels.
+
+## Where this generalises
+
+Any figrecipe path that can silently diverge from an explicit instruction owes
+the author a warning: stylers that override, recorders that cannot faithfully
+replay something drawn, solvers that quietly fall back. A figure that looks
+plausible and is wrong is worse than one that fails — the failure gets fixed;
+the plausible one gets published, and takes its hidden defects with it.
+
+See also: `05_styles.md`, `27_six-stat-annotation-doctrine.md` (readable
+heatmaps), `25_figure-prep-checklist.md`.

--- a/src/figrecipe/_skills/figrecipe/28_never-silently-discard.md
+++ b/src/figrecipe/_skills/figrecipe/28_never-silently-discard.md
@@ -1,3 +1,10 @@
+---
+description: |
+  [TOPIC] Never silently discard what the author set — suppress reversibly, assert on rendered pixels
+  [DETAILS] Incident doctrine (2026-07-14): a styler that drops a property the author explicitly set, without warning, produces a figure that is wrong in the picture and right in every assertion. `set_xticklabels([])` pins a NullFormatter on the AXIS, so every tick set afterwards renders blank through any handle — and `get_xticks()` keeps returning the author's own values. Three comodulograms shipped to human review with no frequency numbers. Suppress by clearing tick LOCATIONS (reversible) or toggling visibility via tick_params — never install a formatter. Warn when discarding an author-pinned choice. Assert on RENDERED label text, because an object-level assertion is structurally blind to this class of corruption. A silent failure also HIDES whatever is behind it.
+tags: [figrecipe-never-silently-discard, figrecipe-fail-loud, figrecipe-tick-suppression, figrecipe-rendered-assertions, figrecipe]
+---
+
 # Never silently discard what the author set
 
 A styler that drops a property the author explicitly set — without saying so —

--- a/src/figrecipe/_skills/figrecipe/SKILL.md
+++ b/src/figrecipe/_skills/figrecipe/SKILL.md
@@ -63,6 +63,7 @@ This package does not ship as a submodule of the `scitex` umbrella.
 * [24_l-shaped-scale-bar](24_l-shaped-scale-bar.md) — L-shaped scale-bar convention for representative signal-trace panels (hide axes; lower-left time + amplitude bars sharing a corner); worked-example leaf for playbook rule 7
 * [25_figure-prep-checklist](25_figure-prep-checklist.md) — pre-render merge-gate checklist + anti-patterns companion to the playbook (21)
 * [27_six-stat-annotation-doctrine](27_six-stat-annotation-doctrine.md) — every stat annotation carries n/CI/method/p/effect/statistic (italic symbols, N-vs-n), and every 2D heatmap ships a labelled colorbar; worked-example leaf for playbook rule 8, checked by STX-FM017/STX-FM018
+* [28_never-silently-discard](28_never-silently-discard.md) — never drop a property the author explicitly set without warning; suppress reversibly (locations, never a formatter) and assert on the RENDERED output, because an object-level assertion is blind to this corruption (it shipped a blank-axis comodulogram to review)
 
 ## At a glance
 

--- a/src/figrecipe/styles/_axis_helpers/_spines.py
+++ b/src/figrecipe/styles/_axis_helpers/_spines.py
@@ -78,10 +78,14 @@ def hide_spines(
                 ax.yaxis.set_ticks_position("none")
 
         if labels:
+            # tick_params toggles label VISIBILITY; set_xticklabels([]) would
+            # pin a NullFormatter on the axis instead, so a caller who later
+            # set ticks would draw blanks and could never get them back.
+            # show_spines() below restores these with labelbottom=True.
             if target == "bottom":
-                ax.set_xticklabels([])
+                ax.tick_params(labelbottom=False)
             elif target == "left":
-                ax.set_yticklabels([])
+                ax.tick_params(labelleft=False)
 
     return ax
 
@@ -164,15 +168,16 @@ def show_spines(
         elif left and right:
             ax.yaxis.set_ticks_position("both")
 
-    # Restore labels if requested
+    # Restore labels if requested. Re-setting the tick LOCATIONS is not enough
+    # to bring labels back: hide_spines turns label visibility OFF, and only
+    # turning it back ON shows them again. (It used to blank labels with
+    # set_xticklabels([]), which pinned a NullFormatter that no amount of
+    # set_xticks could undo -- so this restore path never actually worked.)
     if labels and restore_defaults:
-        current_xticks = ax.get_xticks()
-        current_yticks = ax.get_yticks()
-
-        if len(current_xticks) > 0 and (bottom or top):
-            ax.set_xticks(current_xticks)
-        if len(current_yticks) > 0 and (left or right):
-            ax.set_yticks(current_yticks)
+        if bottom or top:
+            ax.tick_params(labelbottom=bottom, labeltop=top)
+        if left or right:
+            ax.tick_params(labelleft=left, labelright=right)
 
     return ax
 

--- a/src/figrecipe/styles/_finalize.py
+++ b/src/figrecipe/styles/_finalize.py
@@ -124,10 +124,11 @@ def finalize_special_plots(ax: Axes, style: Dict[str, Any] = None) -> None:
             text.set_fontfamily(font_family)
 
         if not show_axes:
+            # Clear tick LOCATIONS only. set_xticklabels([]) would additionally
+            # pin a NullFormatter on the axis, permanently blanking any tick the
+            # author sets later -- the irreversible-suppression bug.
             ax.set_xticks([])
             ax.set_yticks([])
-            ax.set_xticklabels([])
-            ax.set_yticklabels([])
             ax.set_xlabel("")
             ax.set_ylabel("")
             for spine in ax.spines.values():
@@ -156,12 +157,13 @@ def finalize_special_plots(ax: Axes, style: Dict[str, Any] = None) -> None:
         if not is_specgram:
             show_axes = style.get("imshow_show_axes", False)
             if not show_axes:
+                # Clear tick LOCATIONS only -- set_xticklabels([]) would pin a
+                # NullFormatter, so an author who set ticks after save (or on
+                # replay) would draw blanks with no way to recover them.
                 if not x_is_fixed:
                     ax.set_xticks([])
-                    ax.set_xticklabels([])
                 if not y_is_fixed:
                     ax.set_yticks([])
-                    ax.set_yticklabels([])
                 if not x_is_fixed and not y_is_fixed:
                     for spine in ax.spines.values():
                         spine.set_visible(False)

--- a/src/figrecipe/styles/_plot_styles.py
+++ b/src/figrecipe/styles/_plot_styles.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Plot-specific style application for figrecipe."""
 
+import warnings
 from typing import Any, Dict
 
 from matplotlib.axes import Axes
@@ -151,10 +152,11 @@ def apply_pie_style(ax: Axes, style: Dict[str, Any]) -> None:
         text.set_fontfamily(font_family)
 
     if not show_axes:
+        # set_xticks([]) alone clears ticks AND labels, reversibly. Adding
+        # set_xticklabels([]) would pin a NullFormatter on the axis and blank
+        # every tick set afterwards -- see apply_imshow_axes_visibility below.
         ax.set_xticks([])
         ax.set_yticks([])
-        ax.set_xticklabels([])
-        ax.set_yticklabels([])
         for spine in ax.spines.values():
             spine.set_visible(False)
 
@@ -190,6 +192,7 @@ def apply_imshow_axes_visibility(ax: Axes, show_axes: bool, show_labels: bool) -
         If False, clear the x/y axis labels.
     """
     if not show_axes:
+        _warn_if_discarding_author_ticks(ax)
         ax.set_xticks([])
         ax.set_yticks([])
         for spine in ax.spines.values():
@@ -198,6 +201,37 @@ def apply_imshow_axes_visibility(ax: Axes, show_axes: bool, show_labels: bool) -
     if not show_labels:
         ax.set_xlabel("")
         ax.set_ylabel("")
+
+
+def _warn_if_discarding_author_ticks(ax: Axes) -> None:
+    """Warn before suppression throws away ticks the author explicitly pinned.
+
+    A styler that silently drops what an author asked for produces a figure that
+    is wrong in the picture but right in every object-level assertion -- which is
+    how a heatmap once reached human review with its frequency axis blank. If we
+    are about to discard an explicit choice, say which axis and how to keep it.
+
+    A ``FixedLocator`` is matplotlib's fingerprint of an explicit
+    ``set_xticks(...)``; the default locator is a computed one.
+    """
+    from matplotlib.ticker import FixedLocator
+
+    pinned = [
+        name
+        for name, axis in (("x", ax.xaxis), ("y", ax.yaxis))
+        if isinstance(axis.get_major_locator(), FixedLocator)
+    ]
+    if not pinned:
+        return
+
+    warnings.warn(
+        f"figrecipe: imshow styling is hiding the {'/'.join(pinned)} tick(s) you "
+        "set explicitly, because imshow_show_axes is False. If these axes carry "
+        "physical meaning (a time-by-frequency map), the numbers are the content "
+        "-- keep them with imshow_show_axes=True in your style.",
+        UserWarning,
+        stacklevel=3,
+    )
 
 
 def apply_matrix_style(ax: Axes, style: Dict[str, Any]) -> None:

--- a/tests/figrecipe/styles/test__tick_suppression_is_reversible.py
+++ b/tests/figrecipe/styles/test__tick_suppression_is_reversible.py
@@ -67,7 +67,8 @@ def test_suppressing_explicit_ticks_warns_the_author(heatmap):
     # Arrange: the author explicitly asked for these ticks; the style says hide.
     # Discarding that silently is the defect -- name it.
     heatmap.set_xticks([0, 1])
-    # Act + Assert
+    # Act
+    # Assert
     with pytest.warns(UserWarning, match="tick"):
         apply_imshow_axes_visibility(heatmap, show_axes=False, show_labels=False)
 

--- a/tests/figrecipe/styles/test__tick_suppression_is_reversible.py
+++ b/tests/figrecipe/styles/test__tick_suppression_is_reversible.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tick suppression must be REVERSIBLE, and must be checked on the PIXELS.
+
+``set_xticklabels([])`` pins a ``NullFormatter`` on the *axis*, so every tick the
+author sets AFTERWARDS renders blank -- through any handle, because the formatter
+lives on the axis, not on the handle. A heatmap therefore shipped to human review
+with its frequency numbers gone.
+
+It survived review because it survived the TESTS: ``get_xticks()`` kept returning
+exactly what the author asked for. Only the drawn text was empty. So every
+assertion here reads the RENDERED label text -- an object-level assertion is
+structurally blind to this class of corruption.
+"""
+
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+from figrecipe.styles._axis_helpers._spines import (  # noqa: E402
+    hide_spines,
+    show_spines,
+)
+from figrecipe.styles._plot_styles import apply_imshow_axes_visibility  # noqa: E402
+
+
+def _drawn_xlabels(ax):
+    """The tick label text actually RENDERED -- not what get_xticks() claims."""
+    ax.figure.canvas.draw()
+    return [t.get_text() for t in ax.get_xticklabels() if t.get_visible()]
+
+
+@pytest.fixture
+def heatmap():
+    fig, ax = plt.subplots()
+    ax.imshow([[1, 2], [3, 4]])
+    yield ax
+    plt.close(fig)
+
+
+def test_author_ticks_render_after_imshow_suppression(heatmap):
+    # Arrange: the styler hides the chrome, then the author pins real ticks --
+    # the exact order that produced a blank-axis comodulogram.
+    apply_imshow_axes_visibility(heatmap, show_axes=False, show_labels=False)
+    # Act
+    heatmap.set_xticks([0, 1])
+    # Assert: the NUMBERS are on the page, not merely in get_xticks().
+    assert _drawn_xlabels(heatmap) == ["0", "1"]
+
+
+def test_imshow_suppression_leaves_no_null_formatter(heatmap):
+    # Arrange: a NullFormatter is the mechanism -- pin it and nothing can undo it.
+    from matplotlib.ticker import NullFormatter
+
+    # Act
+    apply_imshow_axes_visibility(heatmap, show_axes=False, show_labels=False)
+    # Assert
+    assert not isinstance(heatmap.xaxis.get_major_formatter(), NullFormatter)
+
+
+def test_suppressing_explicit_ticks_warns_the_author(heatmap):
+    # Arrange: the author explicitly asked for these ticks; the style says hide.
+    # Discarding that silently is the defect -- name it.
+    heatmap.set_xticks([0, 1])
+    # Act + Assert
+    with pytest.warns(UserWarning, match="tick"):
+        apply_imshow_axes_visibility(heatmap, show_axes=False, show_labels=False)
+
+
+def test_default_ticks_are_suppressed_without_warning(heatmap):
+    # Arrange: nothing was author-set, so hiding the chrome discards no choice
+    # and must stay quiet -- a warning on every heatmap would be noise.
+    # Act
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        apply_imshow_axes_visibility(heatmap, show_axes=False, show_labels=False)
+    # Assert
+    assert not [w for w in caught if "tick" in str(w.message)]
+
+
+def test_hidden_spine_labels_come_back_on_show(heatmap):
+    # Arrange: hide_spines(labels=True) then show_spines(labels=True) is the
+    # documented round trip. It could never work against a pinned NullFormatter,
+    # because show_spines restores by re-setting tick LOCATIONS and a formatter
+    # outranks those. (hide_spines defaults to bottom=False, so name the axis.)
+    heatmap.set_xticks([0, 1])
+    hide_spines(heatmap, bottom=True, labels=True)
+    # Act
+    show_spines(heatmap, top=False, right=False, labels=True)
+    # Assert
+    assert _drawn_xlabels(heatmap) == ["0", "1"]
+
+
+def test_hide_spines_actually_hides_the_labels(heatmap):
+    # Arrange: the round trip above must not be vacuous -- hiding has to hide,
+    # or "restored" would prove nothing.
+    heatmap.set_xticks([0, 1])
+    # Act
+    hide_spines(heatmap, bottom=True, labels=True)
+    # Assert
+    assert _drawn_xlabels(heatmap) == []
+
+
+# EOF


### PR DESCRIPTION
## Why this matters

This bug **corrupted a real main-text figure**. Three comodulograms shipped through human review with axis titles and **no frequency numbers** — and which frequencies couple *is* the content of a comodulogram.

0.32.1 removed the irreversible `set_xticklabels([])` from **one** styler. It was still live in **four** others, so the bug was never really gone:

- `_plot_styles.apply_pie_style`
- `_finalize.finalize_special_plots` (pie)
- `_finalize.finalize_special_plots` (imshow — a **second** imshow suppressor)
- `_axis_helpers/_spines.hide_spines(labels=True)`

## The mechanism

`set_xticklabels([])` pins a **NullFormatter on the axis**. A formatter outranks whatever handle you reach the axis through, so every tick set afterwards renders blank — through the wrapper, through the raw `ax._ax`, through an explicit `set_xticklabels()`. **There is no code workaround**; only upgrading fixes it.

Clearing tick *locations* is reversible and sufficient. `hide_spines` now toggles label *visibility* — a flag, not a formatter — which also repairs `show_spines`, whose advertised label-restore **never worked**: it restores by re-setting tick locations, and locations cannot undo a pinned formatter.

## Fail loud

When imshow styling is about to hide ticks the author explicitly pinned, it now **warns and names the axis**. Silence is what let a wrong figure pass every check:

```python
ax.set_xticks([0, 1])
ax.get_xticks()   # [0, 1]  <- the author's own values. Looks correct.
# ...but the drawn labels are ['', '']
```

## Tests assert on RENDERED output

Not on `get_xticks()`. That distinction is the whole point — an object-level assertion is **structurally blind** to this corruption, because the object state is exactly what was asked for. Verified the new tests fail on the pre-fix code.

## The lesson, written into the skill

New leaf `28_never-silently-discard`. A silent failure is not one bug — it is a bug **plus everything it hides**. These blank labels were concealing *two* more: a colorbar/xlabel collision, and a genuinely wrong tick computation (family centers derived assuming contiguous features that were actually interleaved). The labels were not missing — they were **nonsense**, and nobody could see it while they were blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)