### PR TITLE
docs(pre-commit): correct an unverified figure, and name the real defect

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,15 +30,21 @@ repos:
   #     Every commit staging a .py file was blocked by a hook that had never
   #     executed a test.
   #
-  #   * Where testmon *is* installed by hand, a COLD run of the ~2460-test
-  #     suite costs ~2h. A fresh git worktree is always cold, and agents work
-  #     in fresh worktrees, so "cold" is the normal case, not the exception.
-  #     A pre-commit hook must be bounded and fast; a 2460-test suite in the
-  #     commit path is an unbounded stall. Even a perfectly warmed testmon
-  #     cache re-enters that cold path whenever its environment fingerprint
-  #     changes (testmon keys its DB on the FULL installed-distribution set
-  #     plus the exact python micro version), which an unpinned `uv pip
-  #     install -e .` re-resolves on every container boot.
+  #   * `language: system` means the entry runs whatever `python` is on the
+  #     ambient PATH, which differs per agent and per container. So the SAME
+  #     hook behaved differently across the fleet: where testmon happened to
+  #     be installed by hand it ran the suite (cold, i.e. slowly); where it
+  #     was not, it blocked the commit instantly. An undeclared dependency
+  #     behind a `language: system` hook is nondeterministic by construction.
+  #     That, not the cache, was the defect.
+  #
+  #   * A cold run is unbounded in the commit path. (Measured here: a
+  #     189-test slice, run cold under testmon on a loaded host, was
+  #     OOM-killed after 17 min without finishing. The full suite is ~2460
+  #     tests. No trustworthy figure exists for a full cold run, and none is
+  #     needed — a suite this size does not belong in a commit hook.)
+  #     A fresh git worktree is always cold, and agents work in fresh
+  #     worktrees, so "cold" is the normal case, not the exception.
   #
   # Full verification lives in CI, where it belongs: the self-hosted
   # (Spartan CPU) pytest matrix runs the complete suite on py3.11/3.12/3.13


### PR DESCRIPTION
Comment-only follow-up to #306. No behaviour change; the hook stays removed.

Two corrections to the note #306 left in `.pre-commit-config.yaml`.

### 1. It asserted a number I never measured

The note said a cold run "costs ~2h". I did not measure that. It came off a task card and I repeated it as fact — exactly the trap of trusting card text.

Replaced with what was actually measured: a **189-test slice**, run cold under testmon on a loaded host, was **OOM-killed after 17 min without finishing**. The full suite is ~2460 tests. No trustworthy figure exists for a full cold run — and none is needed to justify the removal.

### 2. It buried the real defect

The removal was right, but the note framed it around the warm cache. The actual defect is sharper:

> `language: system` runs the entry against whatever `python` is on the **ambient PATH**, which differs per agent and per container.

So the *same* hook did different things across the fleet:

- where `pytest-testmon` happened to be hand-installed → it ran the suite, cold and slow;
- where it was not (the normal case, since it is **not a declared dependency**) → it blocked the commit instantly, having run **zero** tests.

**An undeclared dependency behind a `language: system` hook is nondeterministic by construction.** That is the bug. The cache was a symptom, and chasing it was chasing the wrong thing.

### Fleet sweep for the same shape

Every `language: system` hook across `~/proj/*` was checked for a tool that is not a declared dependency:

- **figrecipe** → `--testmon`, undeclared. Fixed by #306. (The only repo passing an undeclared *plugin flag* — the silent variant, since pytest itself is present so the hook looks healthy right up until `unrecognized arguments`.)
- **davinci-resolve-mcp** → hook `python -m pytest tests/`, `language: system`, but `pytest` appears in its `pyproject.toml` only as `[tool.pytest.ini_options]` (a config section) — never as a dependency, and not in `requirements.txt` either. Same class; it only works today because pytest happens to be ambient. Reported to that repo's owner, not changed here.
- emacs_mcp_server, pip-project-template, priority-config, pyposter, semantic-graph all invoke pytest from a `language: system` hook but **do** declare it — not this bug (though they do run their whole suite at commit, which is a separate design question).
