### PR TITLE
docs(skills): the heatmap rule must cover the heatmap's OWN axes, not just its colorbar

### DIFF
--- a/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
+++ b/src/figrecipe/_skills/figrecipe/27_six-stat-annotation-doctrine.md
@@ -126,6 +126,20 @@ colorbar leaves the reader unable to read any absolute value off the
 image; a colorbar with no label/units leaves them unable to interpret
 what they *can* read.
 
+**The heatmap's OWN axes must stay readable too.** The colorbar says what the
+colors mean; the axes say *where on the map* you are. When they carry a
+physical quantity (a time-by-frequency map, a comodulogram) the numbers on
+them **are the finding** — and three comodulograms once shipped to review
+labelled `(Hz)` with no frequency numbers at all. The colorbar was perfect;
+Rule 2 as written would not have caught it. So:
+
+- a meaningful heatmap axis needs **tick numbers**, not just a title;
+- set `imshow_show_axes=True` (figrecipe hides imshow chrome by default —
+  right for an image, wrong for a map);
+- verify on the **rendered** tick text, never `get_xticks()`, which returns
+  what you asked for even when nothing was drawn. See
+  [28_never-silently-discard](28_never-silently-discard.md).
+
 ### Compliant example
 
 ```python


### PR DESCRIPTION
## The gap

Rule 2 of the six-stat doctrine required a heatmap to carry a colorbar with tick labels, an axis label, and units. It said **nothing about the axes of the heatmap itself**.

That is exactly the gap that let three comodulograms ship to human review labelled `(Hz)` with **no frequency numbers on either axis**. Their colorbars were perfect — so the rule as written would have passed the figure.

## The addition

The colorbar says what the *colors* mean; the axes say *where on the map* you are. When a heatmap axis carries a physical quantity, the numbers on it **are the finding**.

- A meaningful heatmap axis needs **tick numbers**, not just an axis title.
- Use `imshow_show_axes=True` — figrecipe hides imshow chrome by default, which is right for an *image* and wrong for a *map*.
- Verify on the **rendered** tick text, never `get_xticks()`, which returns what you asked for even when nothing was drawn.

Cross-links to the new `28_never-silently-discard` leaf (shipped in #308), which documents the mechanism.

Docs only. Leaf stays within the SK-401 budget (197 lines / 9915 bytes, limits 200 / 10240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)