### PR TITLE
fix(colors): str2bgra() silently ignored its alpha argument

### DIFF
--- a/src/figrecipe/colors/_colors.py
+++ b/src/figrecipe/colors/_colors.py
@@ -92,7 +92,7 @@ def str2bgr(c):
 
 
 def str2bgra(c, alpha=1.0):
-    return rgba2bgra(str2rgba(c))
+    return rgba2bgra(str2rgba(c, alpha=alpha))
 
 
 def bgr2bgra(bgra, alpha=1.0, round=2):

--- a/tests/figrecipe/colors/test__colors.py
+++ b/tests/figrecipe/colors/test__colors.py
@@ -4,7 +4,6 @@ Auto-generated subpackage mirror placeholder; replace with real tests
 as the module matures. Satisfies the src<->tests mirror audit rule.
 """
 
-
 import pytest
 
 
@@ -13,8 +12,38 @@ def test_import_colors__colors_module():
     # Arrange
     # Act
     # Assert
-    module_path = 'figrecipe.colors._colors'
+    module_path = "figrecipe.colors._colors"
     # Act
     mod = pytest.importorskip(module_path)
     # Assert
     assert mod.__name__ == module_path
+
+
+def test_str2bgra_honours_alpha():
+    # Arrange
+    mod = pytest.importorskip("figrecipe.colors._colors")
+    alpha = 0.3
+    # Act
+    bgra = mod.str2bgra("blue", alpha=alpha)
+    # Assert
+    assert bgra[-1] == alpha
+
+
+def test_str2bgra_defaults_to_opaque():
+    # Arrange
+    mod = pytest.importorskip("figrecipe.colors._colors")
+    # Act
+    bgra = mod.str2bgra("blue")
+    # Assert
+    assert bgra[-1] == 1.0
+
+
+def test_str2bgra_channels_are_reversed_str2rgba():
+    # Arrange
+    mod = pytest.importorskip("figrecipe.colors._colors")
+    alpha = 0.3
+    # Act
+    rgba = mod.str2rgba("blue", alpha=alpha)
+    bgra = mod.str2bgra("blue", alpha=alpha)
+    # Assert
+    assert bgra == [rgba[2], rgba[1], rgba[0], alpha]


### PR DESCRIPTION
## The bug

`str2bgra()` accepted an `alpha` argument and then discarded it, so the returned alpha channel was **always 1.0** regardless of what the caller passed.

```python
def str2bgra(c, alpha=1.0):
    return rgba2bgra(str2rgba(c))   # alpha never forwarded
```

## Why this looks unintended rather than deliberate

- `str2rgba(c, alpha=1.0)` (same file, L21-24) *does* honour the parameter.
- The deprecated wrapper `to_rgba` (L177) calls `str2rgba(c, alpha=alpha)` — the intended shape.

## The fix

One line: forward `alpha` through. Blast radius is zero — `str2bgra` is referenced only at its own definition and is not re-exported from `colors/__init__.py`.

## Verification (run in both directions)

- **Before the fix:** 2 failed, 5 passed — `assert 1.0 == 0.3`
- **After the fix:** 7 passed; the whole `tests/figrecipe/colors/` suite is green

Three regression tests added: alpha is honoured, the default stays opaque, and channel order is pinned against `str2rgba` so a later change cannot silently swap B and R.

## Note for maintainers

This repo's `.venv` is broken inside the agent container (`bin/python3.11` is a dangling symlink; only 3.12 is present), so the tests had to be run through a throwaway 3.12 venv. Reported separately — it is independent of this change.

Found while surveying the codebase for newcomer-friendly issues.
