### PR TITLE
docs: update stale ywatanabe1989 org references to scitex-ai

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://github.com/ywatanabe1989/figrecipe#readme
+    url: https://github.com/scitex-ai/figrecipe#readme
     about: Check the README for usage examples and API reference

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -61,11 +61,11 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/cla.json"
-          path-to-document: "https://github.com/ywatanabe1989/figrecipe/blob/main/CLA.md"
+          path-to-document: "https://github.com/scitex-ai/figrecipe/blob/main/CLA.md"
           branch: "cla-signatures"
           allowlist: bot*,ywatanabe1989
           custom-allsigned-prcomment: |
             Thank you for signing the SciTeX CLA. Your contribution can now be reviewed.
           custom-notsigned-prcomment: |
-            Please sign the [SciTeX CLA](https://github.com/ywatanabe1989/figrecipe/blob/main/CLA.md) before your contribution can be merged.
+            Please sign the [SciTeX CLA](https://github.com/scitex-ai/figrecipe/blob/main/CLA.md) before your contribution can be merged.
             Comment `I have read and agree to the SciTeX CLA.` to sign.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ See [CLA.md](CLA.md) for full details.
 
 ## Reporting Issues
 
-- Search [existing issues](https://github.com/ywatanabe1989/figrecipe/issues)
+- Search [existing issues](https://github.com/scitex-ai/figrecipe/issues)
   before opening a new one.
 - Include a minimal reproducible example when reporting bugs.
 - Specify your Python version, OS, and `scitex` version.
@@ -24,7 +24,7 @@ See [CLA.md](CLA.md) for full details.
 ## Development Setup
 
 ```bash
-git clone git@github.com:ywatanabe1989/figrecipe.git
+git clone git@github.com:scitex-ai/figrecipe.git
 cd figrecipe
 pip install -e ".[dev]"
 ```

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 <p align="center">
   <a href="https://badge.fury.io/py/figrecipe"><img src="https://badge.fury.io/py/figrecipe.svg" alt="PyPI version"></a>
   <a href="https://figrecipe.readthedocs.io/"><img src="https://readthedocs.org/projects/figrecipe/badge/?version=latest" alt="Documentation"></a>
-  <a href="https://github.com/ywatanabe1989/figrecipe/actions/workflows/test.yml"><img src="https://github.com/ywatanabe1989/figrecipe/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
-  <a href="https://codecov.io/gh/ywatanabe1989/figrecipe"><img src="https://img.shields.io/codecov/c/github/ywatanabe1989/figrecipe" alt="coverage"></a>
+  <a href="https://github.com/scitex-ai/figrecipe/actions/workflows/test.yml"><img src="https://github.com/scitex-ai/figrecipe/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
+  <a href="https://codecov.io/gh/scitex-ai/figrecipe"><img src="https://img.shields.io/codecov/c/github/scitex-ai/figrecipe" alt="coverage"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
 </p>
 

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -113,7 +113,7 @@ html_favicon = None  # Add path to favicon if available
 # Show "Edit on GitHub" links
 html_context = {
     "display_github": True,
-    "github_user": "ywatanabe1989",
+    "github_user": "scitex-ai",
     "github_repo": "figrecipe",
     "github_version": "main",
     "conf_py_path": "/docs/sphinx/",

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -48,7 +48,7 @@ For development:
 
 .. code-block:: bash
 
-    git clone https://github.com/ywatanabe1989/figrecipe.git
+    git clone https://github.com/scitex-ai/figrecipe.git
     cd figrecipe
     pip install -e ".[all,dev]"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,10 +157,10 @@ figure = "figrecipe._quality._linter_plugin:get_plugin"
 mcp_parity_exempt = true
 
 [project.urls]
-Homepage = "https://github.com/ywatanabe1989/figrecipe"
+Homepage = "https://github.com/scitex-ai/figrecipe"
 Documentation = "https://figrecipe.readthedocs.io"
-Repository = "https://github.com/ywatanabe1989/figrecipe.git"
-Issues = "https://github.com/ywatanabe1989/figrecipe/issues"
+Repository = "https://github.com/scitex-ai/figrecipe.git"
+Issues = "https://github.com/scitex-ai/figrecipe/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/figrecipe"]

--- a/scripts/containers/Dockerfile
+++ b/scripts/containers/Dockerfile
@@ -49,5 +49,5 @@ ARG BUILD_DATE
 ARG VCS_REF
 LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.vcs-ref=$VCS_REF
-LABEL org.label-schema.vcs-url="https://github.com/ywatanabe1989/figrecipe"
+LABEL org.label-schema.vcs-url="https://github.com/scitex-ai/figrecipe"
 LABEL org.label-schema.schema-version="1.0"

--- a/src/figrecipe/_skills/figrecipe/01_installation.md
+++ b/src/figrecipe/_skills/figrecipe/01_installation.md
@@ -48,7 +48,7 @@ figrecipe --help
 ## Editable install (development)
 
 ```bash
-git clone https://github.com/ywatanabe1989/figrecipe
+git clone https://github.com/scitex-ai/figrecipe
 cd figrecipe
 pip install -e '.[dev,all]'
 ```


### PR DESCRIPTION
## What changed

**9 files, 14 lines.** Stale `ywatanabe1989/figrecipe` self-references updated to `scitex-ai/figrecipe`.

- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/workflows/cla.yml`
- `CONTRIBUTING.md`
- `README.md`
- `docs/sphinx/conf.py`
- `docs/sphinx/installation.rst`
- `pyproject.toml`
- `scripts/containers/Dockerfile`
- `src/figrecipe/_skills/figrecipe/01_installation.md`

## The rule applied

Only **self-references** were rewritten: a reference inside repo R pointing at `ywatanabe1989/R`, where R's own remote is now `scitex-ai/R`. Nothing broader.

## Deliberately NOT changed

This is the important half of the review — these were left alone on purpose:

- **Cross-repo links to repositories that genuinely still live under `ywatanabe1989`** — gPAC, neurovista, ripple-wm, scitex-linter, scitex-live-paper, scitex-bridge and others. Those links are correct as written; rewriting them would produce 404s.
- **Bare usernames rather than org paths** — e.g. `allowlist: bot*,ywatanabe1989` and `github.actor == 'ywatanabe1989'` in the CLA workflow. These are GitHub *usernames*, not repo paths. Rewriting them would have broken CI.
- **Historical records** — ADRs, frozen release notes, and one-shot migration scripts. Rewriting them would falsify the record of what was true at the time.
- **Generated Sphinx HTML** under `_sphinx_html/` / `_build/html/`. The root cause is `docs/sphinx/conf.py` (`html_context.github_user`), which **is** fixed in this PR. The remaining stale links in committed build output (~91 across the sweep) need a docs rebuild (`make html`), not hand edits to generated files.
