### PR TITLE
fix(bridge): import mobile.css in the Django-bridge entry (release 0.34.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.3] - 2026-07-22
+
+### Fixed
+- **Django-bridge entry now loads `mobile.css` — the hub-embedded editor gets
+  the mobile layout.** `src/styles/mobile.css` (stack `.editor-body` vertically
+  at ≤768px) was imported only by the standalone entry (`main.tsx`), while the
+  bridge entry (`bridge/bridge-init.ts`) — the path scitex-cloud actually mounts
+  the editor through — imported every stylesheet *except* it. On the hub a
+  390px-wide phone therefore rendered the desktop 3-pane layout: text cut
+  mid-word, clipped buttons, the rail overlaying the toolbar. One import line
+  puts the existing stylesheet on the path that executes.
+
 ## [0.34.1] - 2026-07-14
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.34.2"
+version = "0.34.3"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/figrecipe/_django/frontend/src/bridge/bridge-init.ts
+++ b/src/figrecipe/_django/frontend/src/bridge/bridge-init.ts
@@ -19,6 +19,7 @@ import "../styles/export-dialog.css";
 import "../styles/feedback.css";
 import "../styles/ribbon.css";
 import "../styles/panel-resizer.css";
+import "../styles/mobile.css";
 
 import {
   mountFigrecipeEditor,


### PR DESCRIPTION
## Problem

The hub (scitex.ai) mounts the figrecipe editor through the Django-bridge entry (`src/bridge/bridge-init.ts`). That entry imports every figrecipe stylesheet **except** `mobile.css`, which is imported only by the standalone entry (`main.tsx:22`). So on the hub the editor renders the desktop 3-pane layout at phone widths (390px): text cut mid-word, clipped buttons, the rail overlaying the toolbar — while `src/styles/mobile.css` (which stacks `.editor-body` vertically at ≤768px) sits unused. Classic "the artifact exists but not on the path that executes".

## Fix

One line: add `import "../styles/mobile.css";` to `bridge-init.ts`, at the end of the stylesheet block (mirroring `main.tsx`, where `mobile.css` comes last so its media-query overrides win ties).

## Proof (bridge path, not the standalone path)

Built the bridge entry itself in lib mode (temporary local vite config with the hub's `"scitex-ui"` → static-dir alias; 97 modules transformed). The emitted `style.css` now contains the mobile rule:

```
$ rg -o '\.editor-body\{flex-direction:column[^}]*' bridge-proof-dist/style.css
.editor-body{flex-direction:column!important;height:auto!important;flex:1;overflow:hidden
$ rg -c 'max-width: ?768px' bridge-proof-dist/style.css
2
```

Before this change the bridge module graph had no reference to `mobile.css`, so the rule could not appear in bridge output.

## Notes

- `npm run build` (standalone) fails on develop **before** this change with pre-existing `@scitex/ui/src/...` TS2307 resolution errors in the local-dev setup (verified on the pristine develop checkout); not touched here. CI builds against its own pinned setup.
- Release 0.34.3 folded in (pyproject + CHANGELOG), matching the 0.34.1/0.34.2 pattern; tag `v0.34.3` to be pushed after merge to trigger the publish-on-tag pipeline.
- Downstream: scitex-cloud's `Dockerfile.prod` pins `figrecipe==0.27.0` — the hub gets this fix only after the 0.34.3 release **and** a pin bump there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
