### PR TITLE
fix(ci): anchor the audit gate on the checkout under test

### DIFF
--- a/tests/develop/test_audit.py
+++ b/tests/develop/test_audit.py
@@ -5,6 +5,7 @@ after upgrading scitex-dev to refresh any pin in [dev].
 """
 
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -25,10 +26,23 @@ def test_audit_all_for_package_reports_clean():
     # a clean return is the assertion proxy. The §6 MCP<->Python-API
     # parity rule is exempted via `.scitex/dev/config.yaml`
     # (audit.mcp-parity-exempt: true), read by scitex-dev >= 0.12.0.
+    # `path=` anchors the audit on THIS checkout — the tree this test file
+    # lives in. Without it the audit resolves "figrecipe" by import location
+    # or a ~/proj/<name> guess and grades WHATEVER tree sits there, not the
+    # commit under test. That is not hypothetical: through 2026-07-21 the CI
+    # gate graded a stale checkout on the runner host — false-failing PR #312
+    # on a pre-commit hook deleted in #306, and false-passing the 8 violations
+    # later fixed in #321, which had shipped through a green gate. A gate that
+    # grades the wrong tree is worse than no gate (scitex-dev's own docstring
+    # for `path`, which prescribes exactly this anchor).
     # timeout override of the generated 120s default: audit-all runs clean in
     # ~55s standalone but exceeds 120s inside the pytest-matrix SIF (coverage +
     # parallel load), flaking every PR. 300s is a realistic cap for a
     # slow-but-clean audit. (scitex-dev owns the write-audit-test default.)
-    audit_all_for_package("figrecipe", timeout=300)
+    audit_all_for_package(
+        "figrecipe",
+        path=Path(__file__).resolve().parents[2],
+        timeout=300,
+    )
     # Assert
     assert True  # `audit_all_for_package` raises on failure


### PR DESCRIPTION
## One line of substance: `path=` on the audit gate

`tests/develop/test_audit.py` calls `audit_all_for_package("figrecipe")` with no `path=`. scitex-dev's docstring for that argument warns exactly what happens: the audit resolves the repo by import location or a `~/proj/<name>` guess and grades **whatever tree sits there** — not the commit under test.

That is not hypothetical. Through July 21 the guessed tree on the CI runner was a stale checkout: the gate **false-failed** #312 on a `pytest-testmon` pre-commit hook that #306 had deleted (the rule parses real YAML; only a live hook in *some* tree can trigger it), and **false-passed** the 8 violations that #321 later fixed — they shipped through a green gate.

#321 resolved every finding, so the gate is green today — but only because the guessed tree currently coincides with develop. **The guess itself survived #321.** It lies again on the next runner-side drift, and it can never catch a PR's own violations, because it never reads the PR.

The fix is scitex-dev's own prescribed idiom for this exact trap:

```python
audit_all_for_package(
    "figrecipe",
    path=Path(__file__).resolve().parents[2],
    timeout=300,
)
```

## Verification

`scitex-dev ecosystem audit-all figrecipe --path <this tree>` under the **latest rule corpus (0.34.0)**: every rule section reports SUCC, zero errors — the gate stays green while finally looking at the right tree.

Supersedes #325 (same root-cause fix built before I saw that #321 had already landed the violation fixes on develop; closing it in favor of this minimal, conflict-free version). Full forensic history: card `figrecipe-audit-gate-grades-the-wrong-tree-20260717` and the #325 description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)