### PR TITLE
chore(release): v0.34.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.4] - 2026-07-22
+
+### Fixed
+- **Pie styling no longer blanks ticks irreversibly — the fifth and last
+  `set_[xy]ticklabels([])` site.** `apply_pie_axes_visibility` pinned a
+  `NullFormatter` on both axes, so any tick an author set after a styled
+  `ax.pie()` rendered blank, through any handle, with no way to undo it — the
+  same defect class that once shipped a heatmap to review with its frequency
+  numbers gone. `set_[xy]ticks([])` alone clears ticks *and* labels, and is
+  reversible. Four prior hand-searches each declared the class eradicated and
+  each missed a site, so this fix ships with a guard rather than a promise:
+  `tests/develop/test_no_null_formatter_traps.py` walks the AST of every
+  shipped module and fails the build on the empty-list form. Real labels stay
+  legal — categorical axes need them.
+- **The CI audit gate now grades the commit under test.** `test_audit.py`
+  called `audit_all_for_package("figrecipe")` without `path=`, so the audit
+  resolved the package by a `~/proj/<name>` guess and graded whatever tree sat
+  there — on the CI runner, a stale checkout. It failed honest PRs over a
+  pre-commit hook that had already been deleted, and passed the eight
+  violations fixed for 0.34.3 while they were still live. The audit is now
+  anchored on the checkout the test file itself lives in, which is
+  scitex-dev's prescribed idiom for exactly this trap.
+
 ## [0.34.3] - 2026-07-22
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "figrecipe"
-version = "0.34.3"
+version = "0.34.4"
 description = "Reproducible matplotlib wrapper with mm-precision layouts"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump + changelog for the two fixes merged since 0.34.3.

## What ships

**#312 — the pie styler's NullFormatter trap.** `apply_pie_axes_visibility` pinned a `NullFormatter` on both axes, so any tick an author set after a styled `ax.pie()` rendered blank, through any handle, with no way to undo it. Same defect class that once shipped a heatmap to review with its frequency numbers gone. This was the **fifth** site of a class four prior hand-searches each declared eradicated — so it ships with a guard rather than another promise: `tests/develop/test_no_null_formatter_traps.py` walks the AST of every shipped module and fails the build on the empty-list form. Real labels stay legal; categorical axes need them.

**#326 — the CI audit gate grading the wrong tree.** `test_audit.py` called `audit_all_for_package("figrecipe")` without `path=`, so the audit resolved the package by a `~/proj/<name>` guess and graded whatever tree sat there. It failed honest PRs over a pre-commit hook already deleted, and passed the eight violations fixed for 0.34.3 while they were still live. Now anchored on the checkout the test file lives in.

## Verification

- `scitex-dev ecosystem audit-all figrecipe --path <this tree>` under the latest rule corpus: every section SUCC, zero errors.
- Both merged PRs went green on the full matrix (3.11/3.12/3.13) **with the anchored gate** — the first figrecipe PRs ever graded against their own tree.
- `__version__` derives from package metadata, so `pyproject.toml` is the single source; one edit, no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)