### PR TITLE
fix(ci): pass the named CLA secret instead of `secrets: inherit`

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,4 +23,11 @@ permissions:
 jobs:
   call:
     uses: scitex-ai/.github/.github/workflows/cla.yml@main
-    secrets: inherit
+    # NAMED SECRET, not `inherit`. This caller runs on `issue_comment` and
+    # `pull_request_target` -- both unauthenticated on a public repo -- and
+    # `secrets: inherit` forwards EVERY secret this repo holds into a job an
+    # outsider can start, on the shared self-hosted runner the callee targets.
+    # Neither file shows that on its own: the caller names no runs-on, so the
+    # destination lives in the callee. Pass only the secret the callee declares.
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
`secrets: inherit` in `cla.yml` forwards **every** secret this repo holds into the reusable CLA workflow.

That caller is triggered by `issue_comment` and `pull_request_target` — both fireable by an unauthenticated outsider on a public repo — and the callee runs on a **shared persistent self-hosted runner**.

Neither file shows the exposure on its own: this caller names no `runs-on`, so the destination lives in the callee. That is why it survived review.

**Change:** pass only `GH_PERSONAL_ACCESS_TOKEN`, the one secret the callee declares as required. Every other secret stops being forwarded into an attacker-startable job; the CLA check is unaffected.

Reference implementation: scitex-dev's own `.github/workflows/cla.yml`.

Found while auditing the fleet after scitex-logging hit this on their own repo (their PR #29 is the same change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)