### PR TITLE
fix(cla): reference the secret that exists, not one that never did

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -58,7 +58,16 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
+          # NAME THE SECRET THAT EXISTS. `CLA_PERSONAL_ACCESS_TOKEN` is not a
+          # secret on this repo and never has been -- measured 2026-08-06:
+          #   repo secrets : CLAUDE_CODE_CREDENTIALS_JSON, PERSONAL_ACCESS_TOKEN
+          #   org  secrets : none (total_count 0)
+          # An absent secret interpolates to EMPTY rather than failing, so the
+          # action received a blank PAT and the step failed for a reason the
+          # workflow never names. Owner PRs survived it for a while because
+          # `allowlist` short-circuits before the PAT is needed; that masked it
+          # until a PR needed the signature store.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/ywatanabe1989/figrecipe/blob/main/CLA.md"


### PR DESCRIPTION
## The bug

`cla.yml` maps the action's `PERSONAL_ACCESS_TOKEN` from `secrets.CLA_PERSONAL_ACCESS_TOKEN`. **That secret does not exist on this repo, and there is no org-level secret to fall back on.**

Measured 2026-08-06:

```
repo secrets  CLAUDE_CODE_CREDENTIALS_JSON, PERSONAL_ACCESS_TOKEN
org  secrets  total_count 0
```

An absent secret **interpolates to empty rather than erroring**, so the action ran with a blank PAT and failed without the workflow ever naming the cause.

## Why nobody noticed

`allowlist: bot*,ywatanabe1989` short-circuits owner PRs to success *before* the PAT is needed. Owner PRs passed while the token was already broken — **the gate looked healthy for exactly the population that couldn't exercise it.**

## This PR

One line: read `secrets.PERSONAL_ACCESS_TOKEN` (which exists). No change to allowlist, phrases, or triggers.

## Related, still outstanding

#328 fixed a real and **separate** problem on `main` (`secrets: inherit` forwarding every repo secret into outsider-triggerable jobs on a shared self-hosted runner). That fix is right on security but names `GH_PERSONAL_ACCESS_TOKEN`, **which also does not exist here** — so `main` needs this same correction.

Targets `develop` because `pull_request_target` runs the *base branch's* workflow. Divergence tracked on `figrecipe-main-develop-ci-divergence-blocks-sync-20260722`.